### PR TITLE
Add Allwinner H5 / Orange Pi PC2 board support (AArch64 sunxi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ fit/initramfs-*
 # Board test artifacts (DTBs, kernel images, symlinks)
 *.dtb
 zImage
+Image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,9 @@ dependencies = [
 [[package]]
 name = "fstart-platform-aarch64"
 version = "0.1.0"
+dependencies = [
+ "fstart-soc-sunxi",
+]
 
 [[package]]
 name = "fstart-platform-armv7"

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -192,16 +192,19 @@ fn generate_xip_layout(
 
     // Allwinner eGON header — placed before code, contains a branch
     // instruction at offset 0 that jumps over the header to _start.
+    // KEEP() ensures --gc-sections doesn't strip these; the raw
+    // machine-code branch from .head.text to .text.entry is opaque
+    // to the linker.
     if needs_egon_header {
         writeln!(out, "    .head : {{").unwrap();
-        writeln!(out, "        *(.head.text)").unwrap();
-        writeln!(out, "        *(.head.egon)").unwrap();
+        writeln!(out, "        KEEP(*(.head.text))").unwrap();
+        writeln!(out, "        KEEP(*(.head.egon))").unwrap();
         writeln!(out, "    }} > ROM\n").unwrap();
     }
 
     // Code in ROM
     writeln!(out, "    .text : {{").unwrap();
-    writeln!(out, "        *(.text.entry)").unwrap();
+    writeln!(out, "        KEEP(*(.text.entry))").unwrap();
     writeln!(out, "        *(.text .text.*)").unwrap();
     writeln!(out, "    }} > ROM\n").unwrap();
 
@@ -309,7 +312,7 @@ fn generate_ram_layout(
 
 fn write_text_section(out: &mut String, region: &str) {
     writeln!(out, "    .text : {{").unwrap();
-    writeln!(out, "        *(.text.entry)").unwrap();
+    writeln!(out, "        KEEP(*(.text.entry))").unwrap();
     writeln!(out, "        *(.text .text.*)").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
 }
@@ -347,10 +350,15 @@ fn write_bss_section(out: &mut String, region: &str) {
 }
 
 /// Allwinner eGON .head section: branch instruction + eGON.BT0 struct.
+///
+/// `KEEP()` ensures these sections survive `--gc-sections` even when the
+/// entry point symbol (`_head_jump`) is the only reference — the raw
+/// machine-code branch from `.head.text` to `.text.entry` is opaque to
+/// the linker and wouldn't count as a reference without `KEEP`.
 fn write_allwinner_egon_section(out: &mut String, region: &str) {
     writeln!(out, "    .head : {{").unwrap();
-    writeln!(out, "        *(.head.text)").unwrap();
-    writeln!(out, "        *(.head.egon)").unwrap();
+    writeln!(out, "        KEEP(*(.head.text))").unwrap();
+    writeln!(out, "        KEEP(*(.head.egon))").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
 }
 

--- a/crates/fstart-codegen/src/stage_gen/capabilities.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities.rs
@@ -12,7 +12,7 @@ use fstart_device_registry::DriverInstance;
 use fstart_types::memory::RegionKind;
 use fstart_types::{
     AutoBootDevice, BoardConfig, BootMedium, BuildMode, DeviceConfig, FdtSource, FirmwareKind,
-    LoadDevice,
+    LoadDevice, SocImageFormat,
 };
 
 use super::flexible::{flexible_enum_for_device, generate_flexible_wrapping};
@@ -293,9 +293,9 @@ pub(super) fn collect_boot_media_gated_devices(
 /// Generate code for the BootMedia capability.
 pub(super) fn generate_boot_media(
     medium: &BootMedium,
+    config: &BoardConfig,
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
-    platform: &str,
     halt: &TokenStream,
 ) -> TokenStream {
     match medium {
@@ -316,7 +316,42 @@ pub(super) fn generate_boot_media(
         }
         BootMedium::AutoDevice {
             devices: candidates,
-        } => generate_boot_media_auto_device(candidates, devices, instances, platform, halt),
+        } => generate_boot_media_auto_device(candidates, config, devices, instances, halt),
+    }
+}
+
+/// Return the SRAM base address from the board config.
+///
+/// This is the first stage's `load_addr` — where the BROM loads the eGON
+/// image. Used by sunxi helpers that read fields from the eGON header
+/// at runtime (boot media detection, FFS total size, next-stage offset).
+///
+/// Returns 0 for monolithic or empty stage layouts (matches the H3 default).
+fn egon_sram_base(config: &BoardConfig) -> u64 {
+    match &config.stages {
+        fstart_types::StageLayout::MultiStage(stages) => {
+            stages.first().map(|s| s.load_addr).unwrap_or(0)
+        }
+        _ => 0,
+    }
+}
+
+/// Check that the board uses the Allwinner eGON image format.
+///
+/// Capabilities that read eGON header fields at runtime (BootMedia AutoDevice,
+/// LoadNextStage, anchor scan) must only be generated for eGON boards.
+/// A non-eGON aarch64 board (e.g. qemu-aarch64) would fault trying to read
+/// sunxi-specific SRAM locations.
+fn require_egon_format(config: &BoardConfig, capability: &str) -> Result<(), TokenStream> {
+    if config.soc_image_format != SocImageFormat::AllwinnerEgon {
+        let msg = format!(
+            "{capability} requires soc_image_format: AllwinnerEgon, \
+             but board '{}' uses {:?}",
+            config.name, config.soc_image_format
+        );
+        Err(quote! { compile_error!(#msg); })
+    } else {
+        Ok(())
     }
 }
 
@@ -327,17 +362,17 @@ pub(super) fn generate_boot_media(
 /// `fstart_soc_sunxi::boot_device()` selects the matching candidate.
 fn generate_boot_media_auto_device(
     candidates: &[AutoBootDevice],
+    config: &BoardConfig,
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
-    platform: &str,
     halt: &TokenStream,
 ) -> TokenStream {
-    if platform != "armv7" {
-        let msg = format!(
-            "BootMedia(AutoDevice) currently only supports armv7 (eGON header), not '{platform}'"
-        );
-        return quote! { compile_error!(#msg); };
+    if let Err(err) = require_egon_format(config, "BootMedia(AutoDevice)") {
+        return err;
     }
+
+    // SRAM base for eGON header access (bootblock load_addr).
+    let sram_base = hex_addr(egon_sram_base(config));
 
     // Build the enum variants and BlockDevice match arms.
     let mut enum_variants = TokenStream::new();
@@ -414,7 +449,7 @@ fn generate_boot_media_auto_device(
         }
 
         let (_boot_block_dev, _boot_offset, _boot_size) = {
-            let bm = fstart_soc_sunxi::boot_media();
+            let bm = fstart_soc_sunxi::boot_media_at(#sram_base);
             fstart_log::info!("boot media detect: {:#x}", bm);
             match bm {
                 #match_arms
@@ -931,7 +966,7 @@ fn generate_payload_load_fit_runtime(config: &BoardConfig, platform: &str) -> To
 /// `&scanned_anchor_data[..]`.
 pub(super) fn generate_anchor_scan(
     medium: &BootMedium,
-    platform: &str,
+    config: &BoardConfig,
     halt: &TokenStream,
 ) -> TokenStream {
     match medium {
@@ -973,17 +1008,20 @@ pub(super) fn generate_anchor_scan(
         BootMedium::Device { .. } | BootMedium::AutoDevice { .. } => {
             // Block device: read the anchor at ffs_total_size - ANCHOR_SIZE.
             // The FFS assembler patches ffs_total_size into the eGON header
-            // (ARMv7) so non-first stages can locate the anchor without
-            // scanning the entire device.
-            let ffs_size_expr: TokenStream = match platform {
-                "armv7" => quote! { fstart_soc_sunxi::ffs_total_size() as usize },
-                _ => {
-                    let msg = format!(
-                        "block device anchor scan not yet supported on platform '{platform}'"
-                    );
-                    return quote! { compile_error!(#msg); };
-                }
-            };
+            // so non-first stages can locate the anchor without scanning
+            // the entire device.
+            //
+            // SAFETY invariant: this reads the eGON header from SRAM even
+            // when running from the main stage in DRAM.  This is safe because
+            // the header (offsets 0x00–0x60) is at the very start of SRAM
+            // while the bootblock stack grows downward from the top, so the
+            // header bytes survive across stages.
+            if let Err(err) = require_egon_format(config, "block device anchor scan") {
+                return err;
+            }
+            let sram_base = hex_addr(egon_sram_base(config));
+            let ffs_size_expr: TokenStream =
+                quote! { fstart_soc_sunxi::ffs_total_size_at(#sram_base) as usize };
             quote! {
                 let scanned_anchor_data: [u8; fstart_types::ffs::ANCHOR_SIZE] = {
                     let ffs_size = #ffs_size_expr;
@@ -1056,11 +1094,14 @@ pub(super) fn generate_load_next_stage(
     };
     let load_addr = hex_addr(next_load_addr);
 
-    if platform != "armv7" {
-        let msg =
-            format!("LoadNextStage currently only supports armv7 (eGON header), not '{platform}'");
-        return quote! { compile_error!(#msg); };
+    // LoadNextStage requires an Allwinner eGON-format bootblock to read
+    // next-stage offset/size from the eGON header at the SRAM base.
+    if let Err(err) = require_egon_format(config, "LoadNextStage") {
+        return err;
     }
+
+    // SRAM base for eGON header access (bootblock load_addr: H3=0x0, H5=0x10000).
+    let sram_base = hex_addr(egon_sram_base(config));
 
     // Handoff buffer: placed 4K below the next stage's load address.
     let handoff_addr = hex_addr(next_load_addr - 0x1000);
@@ -1082,6 +1123,13 @@ pub(super) fn generate_load_next_stage(
         None => quote! { 0u64 },
     };
 
+    // Platform-specific jump call.
+    let jump_call = if platform == "aarch64" {
+        quote! { fstart_platform_aarch64::jump_to_with_handoff(#load_addr, #handoff_addr as usize); }
+    } else {
+        quote! { fstart_platform_armv7::jump_to_with_handoff(#load_addr, #handoff_addr as usize); }
+    };
+
     // Build the handoff + jump sequence (shared by all arms).
     let handoff_and_jump = quote! {
         // Serialize handoff for the next stage.
@@ -1101,7 +1149,7 @@ pub(super) fn generate_load_next_stage(
         fstart_log::info!("handoff: {} bytes at {:#x}", handoff_len, #handoff_addr as u64);
 
         fstart_log::info!("jumping to stage '{}' at {:#x}", #next_stage, #load_addr as u64);
-        fstart_platform_armv7::jump_to_with_handoff(#load_addr, #handoff_addr as usize);
+        #jump_call
     };
 
     if load_devices.len() == 1 {
@@ -1112,8 +1160,8 @@ pub(super) fn generate_load_next_stage(
         let base_off = hex_addr(ld.base_offset);
 
         return quote! {
-            let ns_ffs_offset = fstart_soc_sunxi::next_stage_offset() as u64;
-            let ns_size = fstart_soc_sunxi::next_stage_size() as usize;
+            let ns_ffs_offset = fstart_soc_sunxi::next_stage_offset_at(#sram_base) as u64;
+            let ns_size = fstart_soc_sunxi::next_stage_size_at(#sram_base) as usize;
             if ns_ffs_offset == 0 || ns_size == 0 {
                 fstart_log::error!("FATAL: eGON header has zero next_stage_offset/size");
                 #halt;
@@ -1166,13 +1214,13 @@ pub(super) fn generate_load_next_stage(
     }
 
     quote! {
-        let ns_ffs_offset = fstart_soc_sunxi::next_stage_offset() as u64;
-        let ns_size = fstart_soc_sunxi::next_stage_size() as usize;
+        let ns_ffs_offset = fstart_soc_sunxi::next_stage_offset_at(#sram_base) as u64;
+        let ns_size = fstart_soc_sunxi::next_stage_size_at(#sram_base) as usize;
         if ns_ffs_offset == 0 || ns_size == 0 {
             fstart_log::error!("FATAL: eGON header has zero next_stage_offset/size");
             #halt;
         }
-        let bm = fstart_soc_sunxi::boot_media();
+        let bm = fstart_soc_sunxi::boot_media_at(#sram_base);
         fstart_log::info!("boot media detect: {:#x}", bm);
         match bm {
             #match_arms

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -128,7 +128,7 @@ pub fn generate_stage_source(parsed: &ParsedBoard, stage_name: Option<&str>) -> 
     let is_first_stage = needs_embedded_anchor(&config.stages, stage_name);
     if is_first_stage {
         if let fstart_types::SocImageFormat::AllwinnerEgon = config.soc_image_format {
-            tokens.extend(generate_allwinner_egon_header());
+            tokens.extend(generate_allwinner_egon_header(platform));
         }
     }
 
@@ -342,18 +342,41 @@ fn generate_flash_constants(base: u64, size: u64) -> TokenStream {
 /// The linker script orders: `.head.text` → `.head.egon` → `.text.entry`.
 /// Xtask computes the actual binary size (512-byte aligned), pads the
 /// binary, and patches both the length and checksum fields post-build.
-fn generate_allwinner_egon_header() -> TokenStream {
+///
+/// On ARMv7, the branch is `.arm` + `b _start`.
+/// On AArch64 (sun50i H5/A64), the branch is a raw `.word 0xEA000016` —
+/// the ARM32 encoding of `b .+0x60` that jumps over the 96-byte eGON
+/// header.  The AArch64 assembler cannot emit ARM32 instructions, so
+/// the branch must be encoded manually.  The `_start` entry point in
+/// `entry_sunxi.rs` handles the AArch32→AArch64 RMR switch.
+fn generate_allwinner_egon_header(platform: &str) -> TokenStream {
+    let branch_asm = if platform == "aarch64" {
+        // AArch64 target: emit the ARM32 branch as a raw .word.
+        // 0xEA000016 = ARM32 "b .+0x60" (branch forward 22 words from
+        // PC+8 = 96 bytes = offset 0x60, past the eGON header).
+        quote! {
+            core::arch::global_asm!(
+                ".section .head.text, \"ax\", %progbits",
+                ".global _head_jump",
+                "_head_jump:",
+                ".word 0xEA000016",
+            );
+        }
+    } else {
+        // ARMv7 target: assembler natively supports ARM mode.
+        quote! {
+            core::arch::global_asm!(
+                ".section .head.text, \"ax\", %progbits",
+                ".arm",
+                ".global _head_jump",
+                "_head_jump:",
+                "b _start",
+            );
+        }
+    };
+
     quote! {
-        // Branch instruction at offset 0x00 — jumps over the eGON header
-        // to the real _start entry point in .text.entry.
-        // Must be ARM mode: the BROM starts execution in ARM state.
-        core::arch::global_asm!(
-            ".section .head.text, \"ax\", %progbits",
-            ".arm",
-            ".global _head_jump",
-            "_head_jump:",
-            "b _start",
-        );
+        #branch_asm
 
         /// Allwinner eGON.BT0 header — length and checksum are placeholders,
         /// patched by xtask post-build from the actual binary size.
@@ -629,15 +652,15 @@ fn generate_fstart_main(
             Capability::BootMedia(medium) => {
                 body.extend(generate_boot_media(
                     medium,
+                    config,
                     &config.devices,
                     instances,
-                    platform,
                     &halt,
                 ));
                 // Non-first stages scan the boot media for the anchor
                 // instead of using an embedded FSTART_ANCHOR static.
                 if !embed_anchor && needs_ffs(capabilities) {
-                    body.extend(generate_anchor_scan(medium, platform, &halt));
+                    body.extend(generate_anchor_scan(medium, config, &halt));
                 }
             }
             Capability::MemoryInit => {

--- a/crates/fstart-codegen/src/stage_gen/registry.rs
+++ b/crates/fstart-codegen/src/stage_gen/registry.rs
@@ -84,7 +84,11 @@ const KNOWN_DRIVER_META: &[DriverMeta] = &[
         module_path: "fstart_driver_sunxi_mmc",
         config_type: "SunxiMmcConfig",
         services: &["BlockDevice"],
-        compatible: &["allwinner,sun7i-a20-mmc", "allwinner,sun8i-h3-mmc"],
+        compatible: &[
+            "allwinner,sun7i-a20-mmc",
+            "allwinner,sun8i-h3-mmc",
+            "allwinner,sun50i-h5-mmc",
+        ],
     },
     DriverMeta {
         name: "sunxi-spi",
@@ -108,6 +112,6 @@ const KNOWN_DRIVER_META: &[DriverMeta] = &[
         module_path: "fstart_driver_sunxi_h3_dramc",
         config_type: "SunxiH3DramcConfig",
         services: &["MemoryController"],
-        compatible: &["allwinner,sun8i-h3-dramc"],
+        compatible: &["allwinner,sun8i-h3-dramc", "allwinner,sun50i-h5-dramc"],
     },
 ];

--- a/crates/fstart-device-registry/src/lib.rs
+++ b/crates/fstart-device-registry/src/lib.rs
@@ -223,7 +223,7 @@ impl DriverInstance {
                 module_path: "fstart_driver_sunxi_h3_dramc",
                 config_type: "SunxiH3DramcConfig",
                 services: &["MemoryController"],
-                compatible: &["allwinner,sun8i-h3-dramc"],
+                compatible: &["allwinner,sun8i-h3-dramc", "allwinner,sun50i-h5-dramc"],
             },
             #[cfg(feature = "sunxi-mmc")]
             Self::SunxiMmc(_) => &DriverMeta {
@@ -232,7 +232,11 @@ impl DriverInstance {
                 module_path: "fstart_driver_sunxi_mmc",
                 config_type: "SunxiMmcConfig",
                 services: &["BlockDevice"],
-                compatible: &["allwinner,sun7i-a20-mmc", "allwinner,sun8i-h3-mmc"],
+                compatible: &[
+                    "allwinner,sun7i-a20-mmc",
+                    "allwinner,sun8i-h3-mmc",
+                    "allwinner,sun50i-h5-mmc",
+                ],
             },
             #[cfg(feature = "sunxi-spi")]
             Self::SunxiSpi(_) => &DriverMeta {

--- a/crates/fstart-driver-sunxi-h3-dramc/src/lib.rs
+++ b/crates/fstart-driver-sunxi-h3-dramc/src/lib.rs
@@ -138,7 +138,9 @@ register_bitfields! [u32,
         /// Analog PHY phase select (bits [9:8]).
         APHY_PHASE OFFSET(8) NUMBITS(2) [],
         /// Digital PHY phase select (bits [11:10]).
-        DPHY_PHASE OFFSET(10) NUMBITS(2) []
+        DPHY_PHASE OFFSET(10) NUMBITS(2) [],
+        /// DQ hold disable (bit 13) — H5 clears this for VTF.
+        DQ_HOLD OFFSET(13) NUMBITS(1) []
     ],
 
     /// DTCR — Data Training Configuration Register.
@@ -158,7 +160,9 @@ register_bitfields! [u32,
     /// ACIOCR — AC I/O Configuration Register.
     pub ACIOCR_REG [
         /// AC power-down receiver (bit 1).
-        AC_PDR OFFSET(1) NUMBITS(1) []
+        AC_PDR OFFSET(1) NUMBITS(1) [],
+        /// AC ODT (bit 11) — H5 clears this.
+        AC_ODT OFFSET(11) NUMBITS(1) []
     ],
 
     /// UPD2 — Update Register 2.
@@ -494,6 +498,10 @@ mod dx_gcr {
     pub const RTTOAL_MASK: u32 = 0x3 << 14;
     /// Combined mask for all ODT-related fields.
     pub const ODT_FIELDS: u32 = ODT_MASK | DQSRPD | DQSRTT_MASK | RTTOH_MASK | RTTOAL_MASK;
+    /// H5 DQSG mode: clear bit 9 mask.
+    pub const H5_DQSG_CLR: u32 = 0x2 << 8;
+    /// H5 DQSG mode: set bit 10.
+    pub const H5_DQSG_SET: u32 = 0x4 << 8;
 }
 
 /// DX byte-lane General Status Register 0 field masks.
@@ -548,6 +556,31 @@ const H3_DX_WRITE_DELAYS: [[u8; 11]; 4] = [
 const H3_AC_DELAYS: [u8; 31] = [0; 31];
 
 // ===================================================================
+// Per-byte-lane delay constants for H5 (from u-boot)
+// ===================================================================
+
+/// H5 DX read delays — 4 byte lanes × 11 signals.
+const H5_DX_READ_DELAYS: [[u8; 11]; 4] = [
+    [14, 15, 17, 17, 17, 17, 17, 18, 17, 3, 3],
+    [21, 21, 12, 22, 21, 21, 21, 21, 21, 3, 3],
+    [16, 19, 19, 17, 22, 22, 21, 22, 19, 3, 3],
+    [21, 21, 22, 22, 20, 21, 19, 19, 19, 3, 3],
+];
+
+/// H5 DX write delays — 4 byte lanes × 11 signals.
+const H5_DX_WRITE_DELAYS: [[u8; 11]; 4] = [
+    [1, 2, 3, 4, 3, 4, 4, 4, 6, 6, 6],
+    [6, 6, 6, 5, 5, 5, 5, 5, 6, 6, 6],
+    [0, 2, 4, 2, 6, 5, 5, 5, 6, 6, 6],
+    [3, 3, 3, 2, 2, 1, 1, 1, 4, 4, 4],
+];
+
+/// H5 AC (address/command) delays — non-zero tuning.
+const H5_AC_DELAYS: [u8; 31] = [
+    0, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 0, 0,
+];
+
+// ===================================================================
 // Modified Gray code tables for ZQ calibration
 // ===================================================================
 
@@ -572,13 +605,27 @@ fn repeat_byte(b: u8) -> u32 {
 // Configuration
 // ===================================================================
 
-/// Typed configuration for the H3/H2+ DRAM controller driver.
+/// SoC variant selector for the DesignWare DRAM controller.
+///
+/// The H3 and H5 share the same DesignWare IP but differ in PHY
+/// configuration, MBUS priorities, ZQ calibration, bit delays, and
+/// several timing/control register values.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SunxiDramcVariant {
+    /// Allwinner H3/H2+ (sun8i).
+    #[default]
+    H3,
+    /// Allwinner H5 (sun50i).
+    H5,
+}
+
+/// Typed configuration for the H3/H5 DRAM controller driver.
 ///
 /// The DesignWare controller auto-detects most parameters (rank count,
 /// bus width, density). Only the clock frequency and ZQ value need to
 /// be specified per-board.
 ///
-/// For Orange Pi R1 (256 MB DDR3 at 624 MHz):
+/// For Orange Pi R1 (256 MB DDR3 at 624 MHz, H3):
 /// ```ron
 /// SunxiH3Dramc((
 ///     dramc_base: 0x01C62000,
@@ -588,25 +635,40 @@ fn repeat_byte(b: u8) -> u32 {
 ///     odt_en:     true,
 /// ))
 /// ```
+///
+/// For Orange Pi PC2 (1024 MB DDR3 at 672 MHz, H5):
+/// ```ron
+/// SunxiH3Dramc((
+///     dramc_base: 0x01C62000,
+///     ccu_base:   0x01C20000,
+///     clock:      672,
+///     zq:         3881977,
+///     odt_en:     true,
+///     variant:    H5,
+/// ))
+/// ```
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct SunxiH3DramcConfig {
     /// DRAMC COM register base address (`0x01C6_2000`).
     pub dramc_base: u64,
     /// CCU register base address (`0x01C2_0000`).
     pub ccu_base: u64,
-    /// DRAM clock frequency in MHz (e.g., 624).
+    /// DRAM clock frequency in MHz (e.g., 624 for H3, 672 for H5).
     pub clock: u32,
-    /// ZQ calibration value (e.g., 3881979 = 0x3B3BBB for H3).
+    /// ZQ calibration value (e.g., 3881979 for H3, 3881977 for H5).
     pub zq: u32,
     /// On-Die Termination enable.
     pub odt_en: bool,
+    /// SoC variant. Defaults to `H3` for backward compatibility.
+    #[serde(default)]
+    pub variant: SunxiDramcVariant,
 }
 
 // ===================================================================
 // Driver struct
 // ===================================================================
 
-/// Allwinner H3/H2+ DesignWare DRAM controller driver.
+/// Allwinner H3/H5 DesignWare DRAM controller driver.
 pub struct SunxiH3Dramc {
     com: &'static SunxiH3DramComRegs,
     ctl: &'static SunxiH3DramCtlRegs,
@@ -614,6 +676,7 @@ pub struct SunxiH3Dramc {
     clock: u32,
     zq: u32,
     odt_en: bool,
+    variant: SunxiDramcVariant,
     detected_size: Cell<u64>,
     // Run‑state: updated during init
     dual_rank: Cell<bool>,
@@ -634,7 +697,8 @@ unsafe impl Sync for SunxiH3Dramc {}
 
 impl Device for SunxiH3Dramc {
     const NAME: &'static str = "sunxi-h3-dramc";
-    const COMPATIBLE: &'static [&'static str] = &["allwinner,sun8i-h3-dramc"];
+    const COMPATIBLE: &'static [&'static str] =
+        &["allwinner,sun8i-h3-dramc", "allwinner,sun50i-h5-dramc"];
     type Config = SunxiH3DramcConfig;
 
     fn new(config: &SunxiH3DramcConfig) -> Result<Self, DeviceError> {
@@ -647,6 +711,7 @@ impl Device for SunxiH3Dramc {
             clock: config.clock,
             zq: config.zq,
             odt_en: config.odt_en,
+            variant: config.variant,
             detected_size: Cell::new(0),
             dual_rank: Cell::new(true),
             bus_full_width: Cell::new(true),
@@ -657,7 +722,11 @@ impl Device for SunxiH3Dramc {
     }
 
     fn init(&self) -> Result<(), DeviceError> {
-        fstart_log::info!("DRAM: starting H3 DesignWare init");
+        let variant_name = match self.variant {
+            SunxiDramcVariant::H3 => "H3",
+            SunxiDramcVariant::H5 => "H5",
+        };
+        fstart_log::info!("DRAM: starting {} DesignWare init", variant_name);
 
         let size = self.sunxi_dram_init();
         if size == 0 {
@@ -725,8 +794,19 @@ impl SunxiH3Dramc {
         }
         udelay(1);
 
-        // Step 4: H3 ODT delay configuration
-        self.ctl.odtcfg.set(0x0c00_0400);
+        // Step 4: ODT delay configuration (H3 only)
+        if self.variant == SunxiDramcVariant::H3 {
+            self.ctl.odtcfg.set(0x0c00_0400);
+        }
+
+        // Step 4b: VTF enable + DQ hold disable (H5 only)
+        if self.variant == SunxiDramcVariant::H5 {
+            // VTF: set bits [9:8] = 3 in vtfcr
+            let vtfcr = self.ctl.vtfcr.get();
+            self.ctl.vtfcr.set(vtfcr | (3 << 8));
+            // DQ hold disable: clear bit 13 in PGCR2
+            self.ctl.pgcr2.modify(PGCR2::DQ_HOLD::CLEAR);
+        }
 
         // Step 5: Clear credit value
         self.com.cccr.modify(CCCR::CREDIT_CLEAR::SET);
@@ -838,8 +918,12 @@ impl SunxiH3Dramc {
         self.ccu.dram_clk_cfg.modify(H3_DRAM_CLK::RST::SET);
         udelay(10);
 
-        // 15. Write clken magic value for H3
-        self.ctl.clken.set(0xc00e);
+        // 15. Write clken magic value — differs between H3 and H5
+        let clken = match self.variant {
+            SunxiDramcVariant::H3 => 0xc00e,
+            SunxiDramcVariant::H5 => 0x8000,
+        };
+        self.ctl.clken.set(clken);
         udelay(500);
     }
 }
@@ -862,18 +946,32 @@ impl SunxiH3Dramc {
         // 2. Set timing parameters
         self.mctl_set_timing_params();
 
-        // 3. Set MBUS master priority
-        self.mctl_set_master_priority_h3();
+        // 3. Set MBUS master priority (variant-specific)
+        match self.variant {
+            SunxiDramcVariant::H3 => self.mctl_set_master_priority_h3(),
+            SunxiDramcVariant::H5 => self.mctl_set_master_priority_h5(),
+        }
 
         // 4. Disable VTC and clear low-bandwidth clock select in PGCR0
         self.ctl
             .pgcr0
             .modify(PGCR0::VTC::CLEAR + PGCR0::LBCLKSEL.val(0));
 
-        // 5. PGCR1: clear write-leveling step, set PUB mode (H3 path)
-        self.ctl
-            .pgcr1
-            .modify(PGCR1::WLSTEP::CLEAR + PGCR1::PUBMODE::SET);
+        // 5. PGCR1: write-leveling step + PUB mode
+        // H3: clear bit 24 (WLSTEP), set bit 26 (PUBMODE)
+        // H5: set both bit 24 and bit 26
+        match self.variant {
+            SunxiDramcVariant::H3 => {
+                self.ctl
+                    .pgcr1
+                    .modify(PGCR1::WLSTEP::CLEAR + PGCR1::PUBMODE::SET);
+            }
+            SunxiDramcVariant::H5 => {
+                self.ctl
+                    .pgcr1
+                    .modify(PGCR1::WLSTEP::SET + PGCR1::PUBMODE::SET);
+            }
+        }
 
         // 6. Increase DFI_PHY_UPD clock (protect/upd2/unprotect)
         self.com.protect.set(PROTECT_MAGIC);
@@ -883,32 +981,58 @@ impl SunxiH3Dramc {
         udelay(100);
 
         // 7. Set DRAMC ODT per byte lane
+        // H5 additionally modifies DQSG mode bits [10:8].
         for i in 0..4 {
             let odt = if self.odt_en {
                 dx_gcr::ODT_DYNAMIC
             } else {
                 dx_gcr::ODT_OFF
             };
+            let mut clr = dx_gcr::ODT_FIELDS;
+            let mut set = odt;
+            if self.variant == SunxiDramcVariant::H5 {
+                clr |= dx_gcr::H5_DQSG_CLR;
+                set |= dx_gcr::H5_DQSG_SET;
+            }
             let gcr = self.ctl.dx_read(i, dx_off::GCR);
-            self.ctl
-                .dx_write(i, dx_off::GCR, (gcr & !dx_gcr::ODT_FIELDS) | odt);
+            self.ctl.dx_write(i, dx_off::GCR, (gcr & !clr) | set);
         }
 
-        // 8. AC PDR: enable power-down receiver in ACIOCR
-        self.ctl.aciocr.modify(ACIOCR_REG::AC_PDR::SET);
+        // 8. AC PDR + H5 AC ODT disable
+        // H5 additionally clears bit 11 (AC_ODT).
+        match self.variant {
+            SunxiDramcVariant::H3 => {
+                self.ctl.aciocr.modify(ACIOCR_REG::AC_PDR::SET);
+            }
+            SunxiDramcVariant::H5 => {
+                self.ctl
+                    .aciocr
+                    .modify(ACIOCR_REG::AC_PDR::SET + ACIOCR_REG::AC_ODT::CLEAR);
+            }
+        }
 
         // 9. Set DQS auto gating PD mode in PGCR2
         self.ctl.pgcr2.modify(PGCR2::DQS_GATE_PD.val(0x3));
 
-        // 10. H3: dx ddr_clk & hdr_clk dynamic mode
-        self.ctl
-            .pgcr0
-            .modify(PGCR0::DDRCLKSEL.val(0) + PGCR0::HDRCLKSEL.val(0));
-
-        // 11. H3: dphy & aphy phase select 270 degree
-        self.ctl
-            .pgcr2
-            .modify(PGCR2::DPHY_PHASE.val(0x1) + PGCR2::APHY_PHASE.val(0x2));
+        // 10-11. Clock mode and PHY phase select (variant-specific)
+        // H3: clear PGCR0 bits [15:12] (dynamic mode), then dphy=1 aphy=2
+        // H5: leave PGCR0 bits [15:12] at default, then dphy=0 aphy=3
+        match self.variant {
+            SunxiDramcVariant::H3 => {
+                self.ctl
+                    .pgcr0
+                    .modify(PGCR0::DDRCLKSEL.val(0) + PGCR0::HDRCLKSEL.val(0));
+                self.ctl
+                    .pgcr2
+                    .modify(PGCR2::DPHY_PHASE.val(0x1) + PGCR2::APHY_PHASE.val(0x2));
+            }
+            SunxiDramcVariant::H5 => {
+                // H5 does NOT modify PGCR0 clock mode bits.
+                self.ctl
+                    .pgcr2
+                    .modify(PGCR2::DPHY_PHASE.val(0x0) + PGCR2::APHY_PHASE.val(0x3));
+            }
+        }
 
         // 12. Set half DQ: if not full width, disable upper byte lanes
         if !bus_full_width {
@@ -924,18 +1048,36 @@ impl SunxiH3Dramc {
         self.mctl_set_bit_delays();
         udelay(50);
 
-        // 15. H3 ZQ calibration quirk
-        self.mctl_h3_zq_calibration_quirk();
-
-        // 16. PHY init: PLL init + digital cal + PHY reset + DRAM reset + DRAM init + QS gate
-        self.mctl_phy_init(
-            PIR::PLLINIT::SET
-                + PIR::DCAL::SET
-                + PIR::PHYRST::SET
-                + PIR::DRAMRST::SET
-                + PIR::DRAMINIT::SET
-                + PIR::QSGATE::SET,
-        );
+        // 15-16. ZQ calibration + PHY init (variant-specific)
+        // H3: complex multi-step ZQ quirk, then init WITHOUT PIR_ZCAL
+        // H5: simple ZQCR write, then init WITH PIR_ZCAL
+        match self.variant {
+            SunxiDramcVariant::H3 => {
+                self.mctl_h3_zq_calibration_quirk();
+                self.mctl_phy_init(
+                    PIR::PLLINIT::SET
+                        + PIR::DCAL::SET
+                        + PIR::PHYRST::SET
+                        + PIR::DRAMRST::SET
+                        + PIR::DRAMINIT::SET
+                        + PIR::QSGATE::SET,
+                );
+            }
+            SunxiDramcVariant::H5 => {
+                // H5: write full ZQ value directly, let hardware do ZCAL
+                let zqcr_val = self.ctl.zqcr.get();
+                self.ctl.zqcr.set((zqcr_val & !0x00ff_ffff) | self.zq);
+                self.mctl_phy_init(
+                    PIR::ZCAL::SET
+                        + PIR::PLLINIT::SET
+                        + PIR::DCAL::SET
+                        + PIR::PHYRST::SET
+                        + PIR::DRAMRST::SET
+                        + PIR::DRAMINIT::SET
+                        + PIR::QSGATE::SET,
+                );
+            }
+        }
 
         // 17. Detect ranks and bus width
         if self.ctl.pgsr0.read(PGSR0::ERRORS) != 0 {
@@ -980,8 +1122,12 @@ impl SunxiH3Dramc {
         self.ctl.rfshctl0.modify(RFSHCTL0::REFRESH_TRIGGER::CLEAR);
         udelay(10);
 
-        // 20. Set PGCR3, CKE polarity (H3 value)
-        self.ctl.pgcr3.set(0x00aa_0060);
+        // 20. Set PGCR3, CKE polarity (variant-specific)
+        let pgcr3 = match self.variant {
+            SunxiDramcVariant::H3 => 0x00aa_0060,
+            SunxiDramcVariant::H5 => 0xc0aa_0060,
+        };
+        self.ctl.pgcr3.set(pgcr3);
 
         // 21. Power down ZQ calibration module for power save
         self.ctl.zqcr.modify(ZQCR::PWRDOWN::SET);
@@ -1095,8 +1241,14 @@ impl SunxiH3Dramc {
         );
 
         // DRAMTMG8: two-rank timing (read-modify-write)
+        // H5 uses 0x33 for POST_SELFREF_GAP_DLY (faster self-refresh exit).
+        let selfref_gap_dly = match self.variant {
+            SunxiDramcVariant::H3 => 0x66,
+            SunxiDramcVariant::H5 => 0x33,
+        };
         self.ctl.dramtmg8.modify(
-            DRAMTMG8_REG::POST_SELFREF_GAP.val(0x10) + DRAMTMG8_REG::POST_SELFREF_GAP_DLY.val(0x66),
+            DRAMTMG8_REG::POST_SELFREF_GAP.val(0x10)
+                + DRAMTMG8_REG::POST_SELFREF_GAP_DLY.val(selfref_gap_dly),
         );
 
         // PITMG0: PHY interface timing
@@ -1235,15 +1387,23 @@ impl SunxiH3Dramc {
     /// Exact port of U-Boot `mctl_set_bit_delays()`.
     /// Each BDLR register gets: `(write_delay << 8) | read_delay`.
     /// Each ACBDLR register gets: `write_delay << 8`.
+    ///
+    /// H3 and H5 use different per-bit delay tables reflecting
+    /// different PHY characteristics and PCB trace layouts.
     fn mctl_set_bit_delays(&self) {
+        let (dx_read, dx_write, ac) = match self.variant {
+            SunxiDramcVariant::H3 => (&H3_DX_READ_DELAYS, &H3_DX_WRITE_DELAYS, &H3_AC_DELAYS),
+            SunxiDramcVariant::H5 => (&H5_DX_READ_DELAYS, &H5_DX_WRITE_DELAYS, &H5_AC_DELAYS),
+        };
+
         // Disable auto-calibration during delay programming
         self.ctl.pgcr0.modify(PGCR0::AUTOCAL::CLEAR);
 
         // DX byte-lane delays: 4 lanes × 11 signals per lane
         for i in 0..4 {
             for j in 0..11 {
-                let wr = H3_DX_WRITE_DELAYS[i][j] as u32;
-                let rd = H3_DX_READ_DELAYS[i][j] as u32;
+                let wr = dx_write[i][j] as u32;
+                let rd = dx_read[i][j] as u32;
                 self.ctl
                     .dx_write(i, dx_off::BDLR_BASE + j * 4, (wr << 8) | rd);
             }
@@ -1251,7 +1411,7 @@ impl SunxiH3Dramc {
 
         // AC bit delay line registers: 31 entries
         for i in 0..31 {
-            self.ctl.write_acbdlr(i, (H3_AC_DELAYS[i] as u32) << 8);
+            self.ctl.write_acbdlr(i, (ac[i] as u32) << 8);
         }
 
         // Re-enable auto-calibration
@@ -1318,6 +1478,37 @@ impl SunxiH3Dramc {
         self.mbus_configure_port(9, true, false, HIGH, 0, 0, 1024, 256, 64); // DI
         self.mbus_configure_port(10, true, false, HIGHEST, 0, 3, 8192, 6120, 1024); // DE
         self.mbus_configure_port(11, true, false, HIGH, 0, 0, 1024, 288, 64); // DE_CFD
+    }
+
+    /// Set MBUS master priority for H5.
+    ///
+    /// Exact port of U-Boot `mctl_set_master_priority_h5()`.
+    /// H5 uses `tmr` register for window size and different BW limits.
+    fn mctl_set_master_priority_h5(&self) {
+        // H5 uses tmr register for window size, bwcr only has enable bit
+        self.com.tmr.set(399);
+        self.com.bwcr.set(1 << 16);
+
+        // Set CPU high priority
+        self.com.mapr.set(0x0000_0001);
+
+        const HIGHEST: u8 = 3;
+        const HIGH: u8 = 2;
+
+        //            port  bwlimit  priority  qos      wait acs  bwl0   bwl1  bwl2
+        self.mbus_configure_port(0, true, false, HIGHEST, 0, 0, 300, 260, 150); // CPU
+        self.mbus_configure_port(1, true, false, HIGHEST, 0, 0, 600, 400, 200); // GPU
+        self.mbus_configure_port(2, true, false, HIGHEST, 0, 0, 512, 256, 96); // UNUSED
+        self.mbus_configure_port(3, true, false, HIGHEST, 0, 0, 256, 128, 32); // DMA
+        self.mbus_configure_port(4, true, false, HIGHEST, 0, 0, 1900, 1500, 1000); // VE
+        self.mbus_configure_port(5, true, false, HIGHEST, 0, 0, 150, 120, 100); // CSI
+        self.mbus_configure_port(6, true, false, HIGH, 0, 0, 256, 128, 64); // NAND
+        self.mbus_configure_port(7, true, false, HIGHEST, 0, 0, 256, 128, 64); // SS
+        self.mbus_configure_port(8, true, false, HIGHEST, 0, 0, 256, 128, 64); // TS
+        self.mbus_configure_port(9, true, false, HIGH, 0, 0, 1024, 256, 64); // DI
+        self.mbus_configure_port(10, true, false, HIGHEST, 0, 3, 3400, 2400, 1024); // DE
+        self.mbus_configure_port(11, true, false, HIGHEST, 0, 0, 600, 400, 200);
+        // DE_CFD
     }
 }
 

--- a/crates/fstart-driver-sunxi-mmc/src/lib.rs
+++ b/crates/fstart-driver-sunxi-mmc/src/lib.rs
@@ -64,14 +64,29 @@ pub enum SunxiMmcConfig {
         /// MMC controller index (0-2) for clock register selection.
         mmc_index: u8,
     },
+    /// H5 (sun50i) — same hardware as H3, sun6i-generation.
+    ///
+    /// Identical register layout and behaviour to `Sun8iH3`.
+    /// Separate variant for board-level clarity and future-proofing.
+    Sun50iH5 {
+        /// MMC controller base address (e.g., 0x01C0F000 for MMC0).
+        base_addr: u64,
+        /// CCU base address (0x01C20000) for clock gating.
+        ccu_base: u64,
+        /// PIO base address (0x01C20800) for GPIO pin mux.
+        pio_base: u64,
+        /// MMC controller index (0-2) for clock register selection.
+        mmc_index: u8,
+    },
 }
 
 impl SunxiMmcConfig {
     /// Extract the `mmc_index` from any variant.
     pub fn mmc_index(&self) -> u8 {
         match self {
-            Self::Sun7iA20 { mmc_index, .. } => *mmc_index,
-            Self::Sun8iH3 { mmc_index, .. } => *mmc_index,
+            Self::Sun7iA20 { mmc_index, .. }
+            | Self::Sun8iH3 { mmc_index, .. }
+            | Self::Sun50iH5 { mmc_index, .. } => *mmc_index,
         }
     }
 }
@@ -251,8 +266,11 @@ unsafe impl Sync for SunxiMmc {}
 
 impl Device for SunxiMmc {
     const NAME: &'static str = "sunxi-mmc";
-    const COMPATIBLE: &'static [&'static str] =
-        &["allwinner,sun7i-a20-mmc", "allwinner,sun8i-h3-mmc"];
+    const COMPATIBLE: &'static [&'static str] = &[
+        "allwinner,sun7i-a20-mmc",
+        "allwinner,sun8i-h3-mmc",
+        "allwinner,sun50i-h5-mmc",
+    ];
     type Config = SunxiMmcConfig;
 
     fn new(config: &SunxiMmcConfig) -> Result<Self, DeviceError> {
@@ -264,6 +282,12 @@ impl Device for SunxiMmc {
                 mmc_index,
             } => (base_addr, ccu_base, pio_base, mmc_index, SunxiGen::Sun4i),
             SunxiMmcConfig::Sun8iH3 {
+                base_addr,
+                ccu_base,
+                pio_base,
+                mmc_index,
+            }
+            | SunxiMmcConfig::Sun50iH5 {
                 base_addr,
                 ccu_base,
                 pio_base,

--- a/crates/fstart-platform-aarch64/Cargo.toml
+++ b/crates/fstart-platform-aarch64/Cargo.toml
@@ -5,3 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+fstart-soc-sunxi = { workspace = true, optional = true }
+
+[features]
+default = []
+sunxi = ["dep:fstart-soc-sunxi"]

--- a/crates/fstart-platform-aarch64/src/entry_sunxi.rs
+++ b/crates/fstart-platform-aarch64/src/entry_sunxi.rs
@@ -1,0 +1,278 @@
+//! AArch64 entry point for Allwinner sun50i SoCs (H5, A64).
+//!
+//! All 64-bit Allwinner SoCs boot in AArch32 from the Boot ROM (BROM).
+//! This module implements the ARMv8 RMR (Reset Management Register)
+//! warm-reset sequence to switch into AArch64.
+//!
+//! ## Binary layout
+//!
+//! The Allwinner eGON header is placed before `_start` by codegen:
+//!
+//! ```text
+//! [0x00] ARM32 branch to _start (eGON header, .head.text)
+//! [0x04] eGON.BT0 magic + header (.head.egon, 92 bytes)
+//! [0x60] _start (.text.entry):
+//!          dual-mode instruction: ARM32 "b start32" / AArch64 "tst x0,x0"
+//!          b aa64_entry  (AArch64 branch past RMR switch data)
+//!          .space 0x78   (padding, required by dual-mode encoding)
+//!          RMR switch code (ARM32, encoded as .word directives)
+//!          configuration data (RVBAR address, SRAMC base, _start addr)
+//!        aa64_entry:
+//!          normal AArch64 init → fstart_main
+//! ```
+//!
+//! ## Cold boot flow
+//!
+//! 1. BROM (ARM32) loads the eGON image into SRAM, jumps to offset 0x00.
+//! 2. The eGON branch at 0x00 jumps to `_start` at offset 0x60.
+//! 3. In ARM32, the dual-mode instruction at `_start` branches to the
+//!    RMR switch code at `_start + 0x84`.
+//! 4. The RMR switch saves BROM state (for FEL return), writes `_start`
+//!    to the writable RVBAR alias at `0x017000A0`, and triggers a warm
+//!    reset requesting AArch64 mode.
+//! 5. After warm reset, the CPU starts in AArch64 at RVBAR = `_start`.
+//! 6. In AArch64, the dual-mode instruction is a harmless `tst x0, x0`.
+//! 7. The next instruction `b aa64_entry` branches to the real AArch64
+//!    entry point past all the ARM32 data.
+//! 8. `aa64_entry` sets up the stack, clears BSS, and calls `fstart_main`.
+//!
+//! ## Dual-mode instruction
+//!
+//! The encoding `0xEA00001F` is carefully chosen to be valid in both
+//! execution states:
+//! - ARM32: `B #0x84` (branch forward 0x84 bytes to the RMR switch code)
+//! - AArch64: `ANDS XZR, X0, X0` (harmless flag-set, falls through)
+//!
+//! Reference: U-Boot `arch/arm/mach-sunxi/rmr_switch.S` and
+//! `arch/arm/include/asm/arch-sunxi/boot0.h`.
+
+use core::arch::global_asm;
+
+global_asm!(
+    r#"
+    .section .text.entry
+    .global _start
+    .global fel_stash
+    .global return_to_fel
+
+    // ===============================================================
+    // _start — dual-mode entry point (AArch32 / AArch64)
+    //
+    // First entry (from BROM, ARM32):
+    //   0xEA00001F = "b .+0x84" → branches to start32 (RMR switch)
+    //
+    // Second entry (after warm reset, AArch64):
+    //   0xEA00001F = "tst x0, x0" → harmless NOP, falls through
+    //   Next instruction: "b aa64_entry" → jumps to AArch64 init
+    // ===============================================================
+_start:
+    // Dual-mode instruction: ARM32 branch / AArch64 NOP.
+    // Must be assembled as raw .word — the AArch64 assembler cannot
+    // emit ARM32 branch instructions.
+    .word 0xEA00001F
+
+    // AArch64-only: branch past RMR switch data to real entry.
+    // Never executed in ARM32 (already branched at the .word above).
+    b aa64_entry
+
+    // Padding — required by the dual-mode encoding.
+    // The ARM32 branch at _start targets _start + 0x84.
+    // We fill the gap: 4 (dual) + 4 (b) + 0x78 (space) = 0x80,
+    // then 4 bytes for the fel_stash offset = 0x84.
+    .space 0x78
+
+    // ---------------------------------------------------------------
+    // Relative pointer to the fel_stash buffer.
+    // Used by the ARM32 code at start32 to locate fel_stash without
+    // needing an absolute address (position-independent).
+    // ---------------------------------------------------------------
+    .word fel_stash - .
+
+    // ===============================================================
+    // start32 — ARM32 RMR switch code
+    //
+    // All instructions below are pre-assembled ARM32 machine code
+    // embedded as .word directives.  The AArch64 assembler treats
+    // them as data.
+    //
+    // This code:
+    //   1. Saves BROM state (SP, LR, CPSR, SCTLR, VBAR, SP_irq) to
+    //      the fel_stash buffer for potential FEL return.
+    //   2. Reads the SRAM version register to detect die variants
+    //      that may need an alternate RVBAR address.
+    //   3. Writes the address of _start to the writable RVBAR alias
+    //      at 0x017000A0 (Allwinner sun50i specific).
+    //   4. Triggers an RMR warm reset requesting AArch64 mode.
+    //   5. Spins in WFI — the warm reset occurs before waking.
+    //
+    // Ported from U-Boot arch/arm/include/asm/arch-sunxi/boot0.h
+    // (CONFIG_ARM_BOOT_HOOK_RMR path, without A523 ICC code).
+    // ===============================================================
+
+    // --- FEL stash: save BROM state for potential FEL return ---
+    // sub  r0, pc, #12      → r0 = address of the fel_stash offset word
+    .word 0xe24f000c
+    // ldr  r1, [pc, #-16]   → r1 = (fel_stash - .) relative offset
+    .word 0xe51f1010
+    // add  r0, r0, r1       → r0 = real address of fel_stash
+    .word 0xe0800001
+    // str  sp, [r0]         → save BROM SP
+    .word 0xe580d000
+    // str  lr, [r0, #4]     → save BROM LR (return address)
+    .word 0xe580e004
+    // mrs  lr, CPSR         → save CPSR
+    .word 0xe10fe000
+    // str  lr, [r0, #8]
+    .word 0xe580e008
+    // mrs  lr, SP_irq       → save IRQ stack pointer
+    .word 0xe101e300
+    // str  lr, [r0, #20]
+    .word 0xe580e014
+    // mrc  p15, 0, lr, c1, c0, 0  → save SCTLR
+    .word 0xee11ef10
+    // str  lr, [r0, #12]
+    .word 0xe580e00c
+    // mrc  p15, 0, lr, c12, c0, 0 → save VBAR
+    .word 0xee1cef10
+    // str  lr, [r0, #16]
+    .word 0xe580e010
+
+    // --- RVBAR setup: write _start address and trigger warm reset ---
+    // ldr  r1, [pc, #52]    → r1 = CONFIG_SUNXI_RVBAR_ADDRESS (0x017000A0)
+    .word 0xe59f1034
+    // ldr  r0, [pc, #52]    → r0 = SUNXI_SRAMC_BASE (0x01C00000)
+    .word 0xe59f0034
+    // ldr  r0, [r0, #36]    → r0 = SRAM_VER_REG (die variant check)
+    .word 0xe5900024
+    // ands r0, r0, #0xFF    → mask low byte
+    .word 0xe21000ff
+    // ldrne r1, [pc, #44]   → if non-zero: r1 = RVBAR_ALTERNATIVE
+    .word 0x159f102c
+    // ldr  r0, [pc, #44]    → r0 = _start (target address for RVBAR)
+    .word 0xe59f002c
+    // str  r0, [r1]         → write RVBAR
+    .word 0xe5810000
+    // dsb  sy               → ensure RVBAR write completes
+    .word 0xf57ff04f
+    // isb  sy               → synchronise pipeline
+    .word 0xf57ff06f
+    // mrc  p15, 0, r0, cr12, cr0, 2  → read RMR register
+    .word 0xee1c0f50
+    // orr  r0, r0, #3       → bit 0: request AArch64; bit 1: request reset
+    .word 0xe3800003
+    // mcr  p15, 0, r0, cr12, cr0, 2  → write RMR (triggers warm reset)
+    .word 0xee0c0f50
+    // isb  sy
+    .word 0xf57ff06f
+    // wfi                   → wait for warm reset
+    .word 0xe320f003
+    // b    @wfi             → loop (reset occurs before waking)
+    .word 0xeafffffd
+
+    // --- Configuration data (loaded by the ldr instructions above) ---
+    // Writable RVBAR alias register (Allwinner sun50i specific).
+    .word 0x017000A0
+    // SUNXI_SRAMC_BASE — SRAM controller base for die-variant check.
+    .word 0x01C00000
+    // RVBAR alternative address for die variants (same for H5).
+    .word 0x017000A0
+    // Target address for RVBAR — linker resolves _start to the
+    // absolute SRAM address where the image is loaded.
+    .word _start
+
+    // ===============================================================
+    // aa64_entry — AArch64 entry point (after warm reset)
+    //
+    // Reached via the "b aa64_entry" instruction at _start + 0x04.
+    // This is the real AArch64 initialisation sequence.
+    // ===============================================================
+    .balign 8
+aa64_entry:
+    // Disable all interrupts (DAIF: Debug, Abort, IRQ, FIQ).
+    msr daifset, #0xf
+
+    // Set up stack pointer from linker-provided symbol.
+    ldr x0, =_stack_top
+    mov sp, x0
+
+    // Copy .data initializers from LMA (ROM) to VMA (RAM).
+    // For XIP this copies from flash; for RAM-only it's a no-op
+    // (LMA == VMA, zero-length copy).
+    ldr x0, =_data_load
+    ldr x1, =_data_start
+    ldr x2, =_data_end
+1:
+    cmp x1, x2
+    b.ge 2f
+    ldr x3, [x0], #8
+    str x3, [x1], #8
+    b 1b
+2:
+    // Clear BSS.
+    ldr x0, =_bss_start
+    ldr x1, =_bss_end
+3:
+    cmp x0, x1
+    b.ge 4f
+    str xzr, [x0], #8
+    b 3b
+4:
+    // Jump to Rust entry point.
+    // x0 = handoff_ptr = 0 (no inter-stage handoff on first stage).
+    mov x0, #0
+    bl fstart_main
+
+    // Should never return — halt.
+5:
+    wfe
+    b 5b
+
+    // ===============================================================
+    // return_to_fel — switch back to AArch32 and return to BROM FEL
+    //
+    // NOT YET IMPLEMENTED for AArch64 sunxi.
+    //
+    // Returning to FEL from AArch64 requires:
+    //   1. Writing an AArch32 FEL-return stub address to RVBAR
+    //   2. Triggering RMR with AA64 bit cleared (request AArch32)
+    //   3. The AArch32 stub restoring BROM state from fel_stash
+    //
+    // Reference: U-Boot arch/arm/cpu/armv8/fel_utils.S
+    //
+    // For now this halts — FEL return is a future enhancement.
+    // ===============================================================
+return_to_fel:
+    wfe
+    b return_to_fel
+
+    // ===============================================================
+    // fel_stash — saved BROM state for FEL mode return
+    //
+    // Written by the ARM32 RMR switch code BEFORE the mode switch
+    // (and before BSS clear).  Must be in .data, not .bss.
+    //
+    // Layout (matches U-Boot and fstart-soc-sunxi::FelStash):
+    //   +0x00: SP
+    //   +0x04: LR
+    //   +0x08: CPSR
+    //   +0x0C: SCTLR
+    //   +0x10: VBAR
+    //   +0x14: SP_irq
+    //   +0x18: ICC_PMR   (unused on H5, reserved)
+    //   +0x1C: ICC_IGRPEN1 (unused on H5, reserved)
+    // ===============================================================
+    .section .data
+    .balign 4
+fel_stash:
+    .space 32       // 8 words: SP, LR, CPSR, SCTLR, VBAR, SP_irq, +2 reserved
+    "#
+);
+
+extern "Rust" {
+    /// Rust entry point — generated by fstart-stage from board.ron capabilities.
+    ///
+    /// `handoff_ptr` is the address of a serialized `StageHandoff` from a
+    /// previous stage, or 0 if this is the first/only stage.
+    #[allow(dead_code)]
+    fn fstart_main(handoff_ptr: usize) -> !;
+}

--- a/crates/fstart-platform-aarch64/src/lib.rs
+++ b/crates/fstart-platform-aarch64/src/lib.rs
@@ -1,14 +1,28 @@
 //! AArch64 platform support.
 //!
 //! Provides the reset vector entry point, stack setup, BSS clearing,
-//! and architecture-specific helpers. Captures the DTB address passed
-//! by QEMU at reset.
+//! and architecture-specific helpers.
+//!
+//! Two entry paths are supported:
+//!
+//! - **Default** (`entry.rs`): Standard AArch64 entry for platforms that
+//!   start directly in AArch64 mode (e.g., QEMU virt). Captures the DTB
+//!   address from `x0` at reset.
+//!
+//! - **Sunxi** (`entry_sunxi.rs`, behind `sunxi` feature): Entry for
+//!   Allwinner sun50i SoCs (H5, A64) that boot in AArch32 from the BROM.
+//!   Implements the ARMv8 RMR warm-reset sequence to switch into AArch64,
+//!   with FEL state saving for USB debug mode return.
 
 #![no_std]
 
 use core::sync::atomic::{AtomicU64, Ordering};
 
+#[cfg(not(feature = "sunxi"))]
 pub mod entry;
+
+#[cfg(feature = "sunxi")]
+pub mod entry_sunxi;
 
 // ---------------------------------------------------------------------------
 // Boot parameters — written by _start assembly, read by Rust code
@@ -248,6 +262,26 @@ pub fn jump_to(addr: u64) -> ! {
         core::arch::asm!(
             "br {0}",
             in(reg) addr,
+            options(noreturn),
+        );
+    }
+}
+
+/// Jump to the next stage, passing the handoff address in x0.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `addr` points to valid AArch64 executable code
+/// - `handoff_addr` points to a valid serialized `StageHandoff` (or 0)
+/// - This function never returns
+#[inline(always)]
+pub fn jump_to_with_handoff(addr: u64, handoff_addr: usize) -> ! {
+    unsafe {
+        core::arch::asm!(
+            "br {addr}",
+            addr = in(reg) addr,
+            in("x0") handoff_addr,
             options(noreturn),
         );
     }

--- a/crates/fstart-soc-sunxi/src/lib.rs
+++ b/crates/fstart-soc-sunxi/src/lib.rs
@@ -165,38 +165,41 @@ pub enum BootDevice {
     Unknown(u8),
 }
 
-/// Read the raw boot medium byte from the eGON header in SRAM.
+/// Read the raw boot medium byte from the eGON header at `sram_base`.
 ///
 /// The BROM writes the boot device type at image offset 0x28 after
 /// loading the bootblock into SRAM. Since the BROM patches the
 /// in-SRAM copy, this must be read via volatile.
 ///
+/// `sram_base` is the SRAM address where the eGON image is loaded:
+/// - `0x0000_0000` for A20 (sun7i) and H3 (sun8i)
+/// - `0x0001_0000` for H5 (sun50i) and A64 (sun50i)
+///
 /// Returns one of the `BOOT_MEDIA_*` constants.
 #[inline]
-pub fn boot_media() -> u8 {
-    // SAFETY: The eGON header starts at SRAM address 0x00 (for A20).
-    // Offset 0x28 is the boot_media field, written by the BROM.
-    unsafe { core::ptr::read_volatile(0x28 as *const u8) }
+pub fn boot_media_at(sram_base: usize) -> u8 {
+    // SAFETY: The eGON header starts at the SRAM base address provided
+    // by the board config. Offset 0x28 is the boot_media field.
+    unsafe { core::ptr::read_volatile((sram_base + 0x28) as *const u8) }
 }
 
-/// Read and decode the boot device from the eGON header in SRAM.
+/// Read and decode the boot device from the eGON header at `sram_base`.
 ///
 /// Returns a typed [`BootDevice`] enum value. If the eGON magic is
 /// not present (indicating FEL boot or corrupted header), returns
 /// [`BootDevice::Fel`].
-pub fn boot_device() -> BootDevice {
-    // Validate eGON magic before trusting the boot_media field.
-    // SAFETY: The eGON header is at SRAM address 0x00 (for A20).
-    // Offset 0x04 is the 8-byte magic field.
+///
+/// See [`boot_media_at`] for `sram_base` values.
+pub fn boot_device_at(sram_base: usize) -> BootDevice {
     let magic_valid = unsafe {
-        let magic_ptr = 0x04 as *const [u8; 8];
+        let magic_ptr = (sram_base + 0x04) as *const [u8; 8];
         core::ptr::read_volatile(magic_ptr) == EGON_MAGIC
     };
     if !magic_valid {
         return BootDevice::Fel;
     }
 
-    match boot_media() {
+    match boot_media_at(sram_base) {
         BOOT_MEDIA_MMC0 => BootDevice::Mmc0,
         BOOT_MEDIA_NAND => BootDevice::Nand,
         BOOT_MEDIA_MMC2 => BootDevice::Mmc2,
@@ -207,32 +210,67 @@ pub fn boot_device() -> BootDevice {
     }
 }
 
-/// Read the next-stage offset from the eGON header in SRAM.
+/// Read the next-stage offset from the eGON header at `sram_base`.
 ///
 /// This field is patched by the FFS assembler. Must be read via volatile
 /// because the compiler sees the source-level value as 0.
 #[inline]
-pub fn next_stage_offset() -> u32 {
-    unsafe { core::ptr::read_volatile(0x2C as *const u32) }
+pub fn next_stage_offset_at(sram_base: usize) -> u32 {
+    unsafe { core::ptr::read_volatile((sram_base + 0x2C) as *const u32) }
 }
 
-/// Read the next-stage size from the eGON header in SRAM.
+/// Read the next-stage size from the eGON header at `sram_base`.
 ///
 /// This field is patched by the FFS assembler. Must be read via volatile
 /// because the compiler sees the source-level value as 0.
 #[inline]
-pub fn next_stage_size() -> u32 {
-    unsafe { core::ptr::read_volatile(0x30 as *const u32) }
+pub fn next_stage_size_at(sram_base: usize) -> u32 {
+    unsafe { core::ptr::read_volatile((sram_base + 0x30) as *const u32) }
 }
 
-/// Read the total FFS image size from the eGON header in SRAM.
+/// Read the total FFS image size from the eGON header at `sram_base`.
 ///
 /// This field is patched by the FFS assembler. Subsequent stages use
 /// this to locate the FFS anchor at `ffs_total_size - ANCHOR_SIZE`
 /// on the boot medium.
 #[inline]
+pub fn ffs_total_size_at(sram_base: usize) -> u32 {
+    unsafe { core::ptr::read_volatile((sram_base + 0x34) as *const u32) }
+}
+
+// --- Backward-compatible wrappers (SRAM base = 0, for A20/H3) ---
+
+/// Read boot medium byte from SRAM base 0 (A20/H3).
+///
+/// For H5/A64, use [`boot_media_at`] with `sram_base = 0x10000`.
+#[inline]
+pub fn boot_media() -> u8 {
+    boot_media_at(0)
+}
+
+/// Read and decode boot device from SRAM base 0 (A20/H3).
+///
+/// For H5/A64, use [`boot_device_at`] with `sram_base = 0x10000`.
+pub fn boot_device() -> BootDevice {
+    boot_device_at(0)
+}
+
+/// Read next-stage offset from SRAM base 0 (A20/H3).
+#[inline]
+pub fn next_stage_offset() -> u32 {
+    next_stage_offset_at(0)
+}
+
+/// Read next-stage size from SRAM base 0 (A20/H3).
+#[inline]
+pub fn next_stage_size() -> u32 {
+    next_stage_size_at(0)
+}
+
+/// Read total FFS image size from SRAM base 0 (A20/H3).
+#[inline]
 pub fn ffs_total_size() -> u32 {
-    unsafe { core::ptr::read_volatile(0x34 as *const u32) }
+    ffs_total_size_at(0)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -15,6 +15,9 @@ default = []
 riscv64 = ["dep:fstart-platform-riscv64"]
 aarch64 = ["dep:fstart-platform-aarch64"]
 armv7 = ["dep:fstart-platform-armv7", "dep:fstart-soc-sunxi"]
+# Allwinner sunxi support — adds fstart-soc-sunxi and enables the sunxi
+# entry point on aarch64 (ARMv8 RMR switch for H5/A64).
+sunxi = ["dep:fstart-soc-sunxi", "fstart-platform-aarch64?/sunxi"]
 # Driver selection (enabled based on board.ron devices)
 ns16550 = ["dep:fstart-driver-ns16550"]
 pl011 = ["dep:fstart-driver-pl011"]

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -85,6 +85,15 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
         base_features.push("fit".to_string());
     }
 
+    // Allwinner sunxi SoCs use the eGON boot format and need
+    // fstart-soc-sunxi for the eGON header, boot media detection,
+    // and FEL support.  For AArch64 sunxi boards (H5, A64) this also
+    // enables the RMR switch entry point in fstart-platform-aarch64.
+    // (ARMv7 sunxi boards always pull in sunxi via the `armv7` feature.)
+    if config.soc_image_format == SocImageFormat::AllwinnerEgon && config.platform != "armv7" {
+        base_features.push("sunxi".to_string());
+    }
+
     eprintln!("[fstart] target: {target}");
 
     // All bare-metal platforms need flat binaries: AArch64 uses -bios


### PR DESCRIPTION
Port the H5 SoC (Cortex-A53, AArch64) to fstart with ARM32-to-ARM64
RMR warm-reset entry, H5 DRAM variant (20 differences from H3),
Sun50iH5 MMC variant, ATF BL31 handoff for EL3→EL2 Linux boot,
and KEEP() linker directives to prevent --gc-sections from stripping
eGON entry sections. Verified booting Linux on hardware.