### PR TITLE
Replace stringly-typed platform with Platform enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,6 @@ dependencies = [
 name = "fstart-soc-sunxi"
 version = "0.1.0"
 dependencies = [
- "fstart-arch",
  "fstart-services",
  "fstart-types",
 ]

--- a/boards/bananapi-m1/board.ron
+++ b/boards/bananapi-m1/board.ron
@@ -20,7 +20,7 @@
 
 (
     name: "bananapi-m1",
-    platform: "armv7",
+    platform: Armv7,
 
     memory: (
         regions: [

--- a/boards/orangepi-pc2/board.ron
+++ b/boards/orangepi-pc2/board.ron
@@ -20,7 +20,7 @@
 
 (
     name: "orangepi-pc2",
-    platform: "aarch64",
+    platform: Aarch64,
 
     memory: (
         regions: [

--- a/boards/orangepi-r1/board.ron
+++ b/boards/orangepi-r1/board.ron
@@ -21,7 +21,7 @@
 
 (
     name: "orangepi-r1",
-    platform: "armv7",
+    platform: Armv7,
 
     memory: (
         regions: [

--- a/boards/qemu-aarch64-flex/board.ron
+++ b/boards/qemu-aarch64-flex/board.ron
@@ -14,7 +14,7 @@
 
 (
     name: "qemu-aarch64-flex",
-    platform: "aarch64",
+    platform: Aarch64,
 
     // Memory regions: ROM (flash) and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-aarch64-multi/board.ron
+++ b/boards/qemu-aarch64-multi/board.ron
@@ -17,7 +17,7 @@
 
 (
     name: "qemu-aarch64-multi",
-    platform: "aarch64",
+    platform: Aarch64,
 
     // Memory regions: ROM (flash) and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-aarch64/board.ron
+++ b/boards/qemu-aarch64/board.ron
@@ -7,7 +7,7 @@
 
 (
     name: "qemu-aarch64",
-    platform: "aarch64",
+    platform: Aarch64,
 
     // Memory regions: only ROM and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-armv7/board.ron
+++ b/boards/qemu-armv7/board.ron
@@ -15,7 +15,7 @@
 
 (
     name: "qemu-armv7",
-    platform: "armv7",
+    platform: Armv7,
 
     // Memory regions: only ROM and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-riscv64-flex/board.ron
+++ b/boards/qemu-riscv64-flex/board.ron
@@ -13,7 +13,7 @@
 
 (
     name: "qemu-riscv64-flex",
-    platform: "riscv64",
+    platform: Riscv64,
 
     // Memory regions: ROM (flash bank 0) and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-riscv64-multi/board.ron
+++ b/boards/qemu-riscv64-multi/board.ron
@@ -16,7 +16,7 @@
 
 (
     name: "qemu-riscv64-multi",
-    platform: "riscv64",
+    platform: Riscv64,
 
     // Memory regions: ROM (flash bank 0) and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/boards/qemu-riscv64/board.ron
+++ b/boards/qemu-riscv64/board.ron
@@ -12,7 +12,7 @@
 
 (
     name: "qemu-riscv64",
-    platform: "riscv64",
+    platform: Riscv64,
 
     // Memory regions: ROM (flash bank 0) and RAM.
     // Device MMIO addresses are in the driver config, not here.

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -8,12 +8,7 @@ use fstart_types::{BoardConfig, RegionKind, SocImageFormat, StageLayout};
 pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) -> String {
     let mut out = String::new();
 
-    let arch = match config.platform.as_str() {
-        "riscv64" => "riscv",
-        "aarch64" => "aarch64",
-        "armv7" => "arm",
-        other => other,
-    };
+    let arch = config.platform.linker_arch();
 
     // Determine load address, stack size, and optional data address from stage config
     let (load_addr, stack_size, data_addr) = match (&config.stages, stage_name) {

--- a/crates/fstart-codegen/src/ron_loader.rs
+++ b/crates/fstart-codegen/src/ron_loader.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 
 use fstart_device_registry::DriverInstance;
 use fstart_types::{
-    BoardConfig, BuildMode, DeviceConfig, DeviceId, DeviceNode, MemoryMap, PayloadConfig,
+    BoardConfig, BuildMode, DeviceConfig, DeviceId, DeviceNode, MemoryMap, PayloadConfig, Platform,
     SecurityConfig, SocImageFormat, StageLayout,
 };
 
@@ -54,7 +54,7 @@ pub struct ParsedBoard {
 #[derive(Deserialize)]
 struct RonBoardConfig {
     name: HString<64>,
-    platform: HString<32>,
+    platform: Platform,
     memory: MemoryMap,
     devices: Vec<RonDevice>,
     stages: StageLayout,

--- a/crates/fstart-codegen/src/stage_gen/capabilities.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities.rs
@@ -10,6 +10,7 @@ use quote::{format_ident, quote};
 
 use fstart_device_registry::DriverInstance;
 use fstart_types::memory::RegionKind;
+use fstart_types::Platform;
 use fstart_types::{
     AutoBootDevice, BoardConfig, BootMedium, BuildMode, DeviceConfig, FdtSource, FirmwareKind,
     LoadDevice, SocImageFormat,
@@ -159,14 +160,14 @@ pub(super) fn generate_driver_init(
     sorted_indices: &[usize],
     already_inited: &[String],
     boot_media_gated: &[(String, Vec<u8>)],
-    platform: &str,
+    platform: Platform,
     halt: &TokenStream,
     mode: BuildMode,
 ) -> TokenStream {
     let mut stmts = TokenStream::new();
     let mut count = 0usize;
 
-    let has_gated = !boot_media_gated.is_empty() && platform == "armv7";
+    let has_gated = !boot_media_gated.is_empty() && platform == Platform::Armv7;
     if has_gated {
         stmts.extend(quote! {
             let _bm = fstart_soc_sunxi::boot_media();
@@ -249,9 +250,9 @@ pub(super) fn collect_boot_media_gated_devices(
     capabilities: &[fstart_types::Capability],
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
-    platform: &str,
+    platform: Platform,
 ) -> Vec<(String, Vec<u8>)> {
-    if platform != "armv7" {
+    if platform != Platform::Armv7 {
         return Vec::new();
     }
 
@@ -479,7 +480,7 @@ pub(super) fn generate_sig_verify(embed_anchor: bool) -> TokenStream {
 /// board config value (runtime-detected DRAM size from training).
 pub(super) fn generate_fdt_prepare(
     config: &BoardConfig,
-    platform: &str,
+    platform: Platform,
     uses_handoff: bool,
 ) -> TokenStream {
     let Some(ref payload) = config.payload else {
@@ -496,12 +497,11 @@ pub(super) fn generate_fdt_prepare(
                 hex_addr(addr)
             } else {
                 match platform {
-                    "riscv64" => quote! { fstart_platform_riscv64::boot_dtb_addr() },
-                    "aarch64" => quote! { fstart_platform_aarch64::boot_dtb_addr() },
+                    Platform::Riscv64 => quote! { fstart_platform::boot_dtb_addr() },
+                    Platform::Aarch64 => quote! { fstart_platform::boot_dtb_addr() },
                     // ARMv7: no DTB address saved by platform (board-specific).
                     // Use src_dtb_addr in the board RON instead.
-                    "armv7" => quote! { 0u64 },
-                    _ => quote! { 0 },
+                    Platform::Armv7 => quote! { 0u64 },
                 }
             };
             let dtb_dst = hex_addr(payload.dtb_addr.unwrap_or(0));
@@ -609,7 +609,7 @@ fn generate_dram_expressions(
 /// Generate code for the PayloadLoad capability.
 pub(super) fn generate_payload_load(
     config: &BoardConfig,
-    platform: &str,
+    platform: Platform,
     embed_anchor: bool,
 ) -> TokenStream {
     if is_linux_boot(config) {
@@ -628,12 +628,7 @@ pub(super) fn generate_payload_load(
     }
 
     let anchor = anchor_expr(embed_anchor);
-    let jump_fn: TokenStream = match platform {
-        "riscv64" => quote! { fstart_platform_riscv64::jump_to },
-        "aarch64" => quote! { fstart_platform_aarch64::jump_to },
-        "armv7" => quote! { fstart_platform_armv7::jump_to },
-        _ => quote! { fstart_platform_riscv64::jump_to },
-    };
+    let jump_fn: TokenStream = quote! { fstart_platform::jump_to };
     quote! {
         fstart_capabilities::payload_load(#anchor, &boot_media, #jump_fn);
     }
@@ -642,7 +637,7 @@ pub(super) fn generate_payload_load(
 /// Generate the Linux boot payload sequence for a specific platform.
 fn generate_payload_load_linux(
     config: &BoardConfig,
-    platform: &str,
+    platform: Platform,
     embed_anchor: bool,
 ) -> TokenStream {
     let payload = config.payload.as_ref().unwrap(); // caller verified is_linux_boot
@@ -694,32 +689,32 @@ fn generate_payload_load_linux(
     let kernel_addr = hex_addr(payload.kernel_load_addr.unwrap_or(0));
 
     match platform {
-        "riscv64" => {
+        Platform::Riscv64 => {
             let fw_addr = hex_addr(payload.firmware.as_ref().map(|f| f.load_addr).unwrap_or(0));
             stmts.extend(quote! {
-                let _fw_info = fstart_platform_riscv64::FwDynamicInfo::new(
+                let _fw_info = fstart_platform::FwDynamicInfo::new(
                     #kernel_addr,
-                    fstart_platform_riscv64::boot_hart_id(),
+                    fstart_platform::boot_hart_id(),
                 );
                 fstart_log::info!("jumping to SBI firmware...");
-                fstart_platform_riscv64::boot_linux_sbi(
+                fstart_platform::boot_linux_sbi(
                     #fw_addr,
-                    fstart_platform_riscv64::boot_hart_id(),
+                    fstart_platform::boot_hart_id(),
                     #dtb_addr,
                     &_fw_info,
                 );
             });
         }
-        "aarch64" => {
+        Platform::Aarch64 => {
             let fw_addr = hex_addr(payload.firmware.as_ref().map(|f| f.load_addr).unwrap_or(0));
             stmts.extend(quote! {
-                let mut _bl33_ep: fstart_platform_aarch64::EntryPointInfo =
+                let mut _bl33_ep: fstart_platform::EntryPointInfo =
                     unsafe { core::mem::zeroed() };
-                let mut _bl33_node: fstart_platform_aarch64::BlParamsNode =
+                let mut _bl33_node: fstart_platform::BlParamsNode =
                     unsafe { core::mem::zeroed() };
-                let mut _bl_params: fstart_platform_aarch64::BlParams =
+                let mut _bl_params: fstart_platform::BlParams =
                     unsafe { core::mem::zeroed() };
-                fstart_platform_aarch64::prepare_bl_params(
+                fstart_platform::prepare_bl_params(
                     #kernel_addr,
                     #dtb_addr,
                     &mut _bl33_ep,
@@ -727,10 +722,10 @@ fn generate_payload_load_linux(
                     &mut _bl_params,
                 );
                 fstart_log::info!("jumping to ATF BL31...");
-                fstart_platform_aarch64::boot_linux_atf(#fw_addr, &_bl_params);
+                fstart_platform::boot_linux_atf(#fw_addr, &_bl_params);
             });
         }
-        "armv7" => {
+        Platform::Armv7 => {
             // ARMv7 Linux boot protocol: no SBI/ATF, jump directly to kernel.
             // r0=0, r1=0xFFFFFFFF (DT-only), r2=DTB address.
             //
@@ -746,14 +741,10 @@ fn generate_payload_load_linux(
                 fstart_log::info!("  dtb    @ {:#x}", #dtb_addr as u64);
 
                 // Clean up CPU state: disable/invalidate I-cache, flush BP.
-                fstart_platform_armv7::cleanup_before_linux();
+                fstart_platform::cleanup_before_linux();
 
-                fstart_platform_armv7::boot_linux(#kernel_addr, #dtb_addr);
+                fstart_platform::boot_linux(#kernel_addr, #dtb_addr);
             });
-        }
-        _ => {
-            let msg = format!("LinuxBoot not supported on platform '{platform}'");
-            stmts.extend(quote! { compile_error!(#msg); });
         }
     }
 
@@ -768,7 +759,7 @@ fn generate_payload_load_linux(
 /// 3. Resolves the configuration (default or named)
 /// 4. Copies each component (kernel, ramdisk) to its load address
 /// 5. Boots via platform-specific protocol
-fn generate_payload_load_fit_runtime(config: &BoardConfig, platform: &str) -> TokenStream {
+fn generate_payload_load_fit_runtime(config: &BoardConfig, platform: Platform) -> TokenStream {
     let payload = config.payload.as_ref().unwrap();
     let halt = halt_expr(platform);
     let anchor = anchor_as_bytes_expr();
@@ -897,32 +888,32 @@ fn generate_payload_load_fit_runtime(config: &BoardConfig, platform: &str) -> To
     let kernel_addr = quote! { _kernel_load };
 
     match platform {
-        "riscv64" => {
+        Platform::Riscv64 => {
             let fw_addr = hex_addr(payload.firmware.as_ref().map(|f| f.load_addr).unwrap_or(0));
             stmts.extend(quote! {
-                let _fw_info = fstart_platform_riscv64::FwDynamicInfo::new(
+                let _fw_info = fstart_platform::FwDynamicInfo::new(
                     #kernel_addr,
-                    fstart_platform_riscv64::boot_hart_id(),
+                    fstart_platform::boot_hart_id(),
                 );
                 fstart_log::info!("jumping to SBI firmware...");
-                fstart_platform_riscv64::boot_linux_sbi(
+                fstart_platform::boot_linux_sbi(
                     #fw_addr,
-                    fstart_platform_riscv64::boot_hart_id(),
+                    fstart_platform::boot_hart_id(),
                     #dtb_addr,
                     &_fw_info,
                 );
             });
         }
-        "aarch64" => {
+        Platform::Aarch64 => {
             let fw_addr = hex_addr(payload.firmware.as_ref().map(|f| f.load_addr).unwrap_or(0));
             stmts.extend(quote! {
-                let mut _bl33_ep: fstart_platform_aarch64::EntryPointInfo =
+                let mut _bl33_ep: fstart_platform::EntryPointInfo =
                     unsafe { core::mem::zeroed() };
-                let mut _bl33_node: fstart_platform_aarch64::BlParamsNode =
+                let mut _bl33_node: fstart_platform::BlParamsNode =
                     unsafe { core::mem::zeroed() };
-                let mut _bl_params: fstart_platform_aarch64::BlParams =
+                let mut _bl_params: fstart_platform::BlParams =
                     unsafe { core::mem::zeroed() };
-                fstart_platform_aarch64::prepare_bl_params(
+                fstart_platform::prepare_bl_params(
                     #kernel_addr,
                     #dtb_addr,
                     &mut _bl33_ep,
@@ -930,21 +921,17 @@ fn generate_payload_load_fit_runtime(config: &BoardConfig, platform: &str) -> To
                     &mut _bl_params,
                 );
                 fstart_log::info!("jumping to ATF BL31...");
-                fstart_platform_aarch64::boot_linux_atf(#fw_addr, &_bl_params);
+                fstart_platform::boot_linux_atf(#fw_addr, &_bl_params);
             });
         }
-        "armv7" => {
+        Platform::Armv7 => {
             // ARMv7: no ATF/SBI — jump directly to kernel with pre-boot cleanup.
             stmts.extend(quote! {
                 fstart_log::info!("booting Linux (ARMv7)...");
-                fstart_platform_armv7::set_arch_timer_freq(24_000_000);
-                fstart_platform_armv7::cleanup_before_linux();
-                fstart_platform_armv7::boot_linux(#kernel_addr as u64, #dtb_addr);
+                fstart_platform::set_arch_timer_freq(24_000_000);
+                fstart_platform::cleanup_before_linux();
+                fstart_platform::boot_linux(#kernel_addr as u64, #dtb_addr);
             });
-        }
-        _ => {
-            let msg = format!("FIT boot not supported on platform '{platform}'");
-            stmts.extend(quote! { compile_error!(#msg); });
         }
     }
 
@@ -1074,7 +1061,7 @@ pub(super) fn generate_load_next_stage(
     config: &BoardConfig,
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
-    platform: &str,
+    _platform: Platform,
     capabilities: &[fstart_types::Capability],
     halt: &TokenStream,
 ) -> TokenStream {
@@ -1124,11 +1111,8 @@ pub(super) fn generate_load_next_stage(
     };
 
     // Platform-specific jump call.
-    let jump_call = if platform == "aarch64" {
-        quote! { fstart_platform_aarch64::jump_to_with_handoff(#load_addr, #handoff_addr as usize); }
-    } else {
-        quote! { fstart_platform_armv7::jump_to_with_handoff(#load_addr, #handoff_addr as usize); }
-    };
+    let jump_call =
+        quote! { fstart_platform::jump_to_with_handoff(#load_addr, #handoff_addr as usize); };
 
     // Build the handoff + jump sequence (shared by all arms).
     let handoff_and_jump = quote! {
@@ -1246,8 +1230,8 @@ pub(super) fn generate_late_driver_init() -> TokenStream {
 ///
 /// Emits code that restores the saved BROM state and returns to FEL
 /// mode. Only supported on armv7 (Allwinner sunxi).
-pub(super) fn generate_return_to_fel(platform: &str) -> TokenStream {
-    if platform != "armv7" {
+pub(super) fn generate_return_to_fel(platform: Platform) -> TokenStream {
+    if platform != Platform::Armv7 {
         let msg = format!("ReturnToFel is only supported on armv7, not '{platform}'");
         return quote! { compile_error!(#msg); };
     }
@@ -1263,16 +1247,11 @@ pub(super) fn generate_return_to_fel(platform: &str) -> TokenStream {
 /// Generate code for the StageLoad capability.
 pub(super) fn generate_stage_load(
     next_stage: &str,
-    platform: &str,
+    _platform: Platform,
     embed_anchor: bool,
 ) -> TokenStream {
     let anchor = anchor_expr(embed_anchor);
-    let jump_fn: TokenStream = match platform {
-        "riscv64" => quote! { fstart_platform_riscv64::jump_to },
-        "aarch64" => quote! { fstart_platform_aarch64::jump_to },
-        "armv7" => quote! { fstart_platform_armv7::jump_to },
-        _ => quote! { fstart_platform_riscv64::jump_to },
-    };
+    let jump_fn: TokenStream = quote! { fstart_platform::jump_to };
     quote! {
         fstart_capabilities::stage_load(#next_stage, #anchor, &boot_media, #jump_fn);
     }

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -35,7 +35,7 @@ use quote::{format_ident, quote};
 
 use fstart_device_registry::DriverInstance;
 use fstart_types::{
-    BoardConfig, BootMedium, BuildMode, Capability, DeviceConfig, DeviceNode, StageLayout,
+    BoardConfig, BootMedium, BuildMode, Capability, DeviceConfig, DeviceNode, Platform, StageLayout,
 };
 
 use crate::ron_loader::ParsedBoard;
@@ -64,7 +64,7 @@ use validation::{get_boot_medium, needs_embedded_anchor, needs_ffs, validate_cap
 /// `#![no_std] #![no_main]` crate root.
 pub fn generate_stage_source(parsed: &ParsedBoard, stage_name: Option<&str>) -> String {
     let config = &parsed.config;
-    let platform = config.platform.as_str();
+    let platform = config.platform;
 
     // Get capabilities for this stage
     let capabilities = match (&config.stages, stage_name) {
@@ -192,14 +192,20 @@ pub fn generate_stage_source(parsed: &ParsedBoard, stage_name: Option<&str>) -> 
 // =======================================================================
 
 /// Generate `extern crate` items for platform and runtime.
-fn generate_platform_externs(platform: &str) -> TokenStream {
+///
+/// The platform crate is aliased to `fstart_platform` so that all
+/// downstream codegen can reference `fstart_platform::halt()`,
+/// `fstart_platform::jump_to()`, etc. without matching on the platform.
+fn generate_platform_externs(platform: Platform) -> TokenStream {
     let platform_crate = match platform {
-        "riscv64" => quote! { extern crate fstart_platform_riscv64; },
-        "aarch64" => quote! { extern crate fstart_platform_aarch64; },
-        "armv7" => quote! { extern crate fstart_platform_armv7; },
-        p => {
-            let msg = format!("unsupported platform: {p}");
-            return quote! { compile_error!(#msg); };
+        Platform::Riscv64 => {
+            quote! { extern crate fstart_platform_riscv64 as fstart_platform; }
+        }
+        Platform::Aarch64 => {
+            quote! { extern crate fstart_platform_aarch64 as fstart_platform; }
+        }
+        Platform::Armv7 => {
+            quote! { extern crate fstart_platform_armv7 as fstart_platform; }
         }
     };
     quote! {
@@ -349,8 +355,8 @@ fn generate_flash_constants(base: u64, size: u64) -> TokenStream {
 /// header.  The AArch64 assembler cannot emit ARM32 instructions, so
 /// the branch must be encoded manually.  The `_start` entry point in
 /// `entry_sunxi.rs` handles the AArch32→AArch64 RMR switch.
-fn generate_allwinner_egon_header(platform: &str) -> TokenStream {
-    let branch_asm = if platform == "aarch64" {
+fn generate_allwinner_egon_header(platform: Platform) -> TokenStream {
+    let branch_asm = if platform == Platform::Aarch64 {
         // AArch64 target: emit the ARM32 branch as a raw .word.
         // 0xEA000016 = ARM32 "b .+0x60" (branch forward 22 words from
         // PC+8 = 96 bytes = offset 0x60, past the eGON header).
@@ -570,7 +576,7 @@ fn generate_fstart_main(
     instances: &[DriverInstance],
     device_tree: &[DeviceNode],
     capabilities: &[Capability],
-    platform: &str,
+    platform: Platform,
     mode: BuildMode,
     embed_anchor: bool,
     stage_name: Option<&str>,

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -30,7 +30,7 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
 
     let config = BoardConfig {
         name: HString::try_from("test-board").unwrap(),
-        platform: HString::try_from("riscv64").unwrap(),
+        platform: Platform::Riscv64,
         memory: MemoryMap {
             regions: {
                 let mut v = heapless::Vec::new();
@@ -253,7 +253,7 @@ fn test_stage_load_generates_call() {
         "should pass &boot_media: {source}"
     );
     assert!(
-        source.contains("fstart_platform_riscv64::jump_to"),
+        source.contains("fstart_platform::jump_to"),
         "should pass jump_to: {source}"
     );
 }
@@ -291,7 +291,7 @@ fn test_stage_load_with_flash_base_generates_real_call() {
         "should pass &boot_media: {source}"
     );
     assert!(
-        source.contains("fstart_platform_riscv64::jump_to"),
+        source.contains("fstart_platform::jump_to"),
         "should pass jump_to: {source}"
     );
 }
@@ -392,7 +392,7 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
 
     let config = BoardConfig {
         name: HString::try_from("test-i2c-board").unwrap(),
-        platform: HString::try_from("riscv64").unwrap(),
+        platform: Platform::Riscv64,
         memory: MemoryMap {
             regions: {
                 let mut v = heapless::Vec::new();
@@ -818,7 +818,7 @@ fn test_flexible_multi_driver_parsed_board(
 
     let config = BoardConfig {
         name: HString::try_from("test-flex-multi").unwrap(),
-        platform: HString::try_from("riscv64").unwrap(),
+        platform: Platform::Riscv64,
         memory: MemoryMap {
             regions: {
                 let mut v = heapless::Vec::new();
@@ -1177,7 +1177,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
 
     let config = BoardConfig {
         name: HString::try_from("test-multi").unwrap(),
-        platform: HString::try_from("riscv64").unwrap(),
+        platform: Platform::Riscv64,
         memory: MemoryMap {
             regions: {
                 let mut v = heapless::Vec::new();
@@ -1285,7 +1285,7 @@ fn test_multi_stage_bootblock_with_flash_base() {
         "bootblock should pass &boot_media: {source}"
     );
     assert!(
-        source.contains("fstart_platform_riscv64::jump_to"),
+        source.contains("fstart_platform::jump_to"),
         "bootblock should pass jump_to: {source}"
     );
 }

--- a/crates/fstart-codegen/src/stage_gen/tokens.rs
+++ b/crates/fstart-codegen/src/stage_gen/tokens.rs
@@ -7,20 +7,20 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+use fstart_types::Platform;
+
 /// Create a hex-formatted u64 literal token (e.g., `0x80000000`).
 pub(super) fn hex_addr(val: u64) -> TokenStream {
     let s = format!("{val:#x}");
     s.parse().expect("hex literal should parse as TokenStream")
 }
 
-/// Generate the platform halt expression (e.g., `fstart_platform_riscv64::halt()`).
-pub(super) fn halt_expr(platform: &str) -> TokenStream {
-    match platform {
-        "riscv64" => quote! { fstart_platform_riscv64::halt() },
-        "aarch64" => quote! { fstart_platform_aarch64::halt() },
-        "armv7" => quote! { fstart_platform_armv7::halt() },
-        _ => quote! { loop { core::hint::spin_loop() } },
-    }
+/// Generate the platform halt expression.
+///
+/// Uses the `fstart_platform` alias emitted by `generate_platform_externs()`,
+/// so this is platform-agnostic — no match needed.
+pub(super) fn halt_expr(_platform: Platform) -> TokenStream {
+    quote! { fstart_platform::halt() }
 }
 
 /// The `unsafe` expression that casts `&FSTART_ANCHOR` to `&[u8]` for

--- a/crates/fstart-soc-sunxi/Cargo.toml
+++ b/crates/fstart-soc-sunxi/Cargo.toml
@@ -5,6 +5,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-fstart-arch = { workspace = true, features = ["armv7"] }
 fstart-services = { workspace = true }
 fstart-types = { workspace = true }

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -14,10 +14,12 @@ default = []
 # Platform selection (exactly one must be enabled)
 riscv64 = ["dep:fstart-platform-riscv64"]
 aarch64 = ["dep:fstart-platform-aarch64"]
-armv7 = ["dep:fstart-platform-armv7", "dep:fstart-soc-sunxi"]
+armv7 = ["dep:fstart-platform-armv7"]
 # Allwinner sunxi support — adds fstart-soc-sunxi and enables the sunxi
-# entry point on aarch64 (ARMv8 RMR switch for H5/A64).
-sunxi = ["dep:fstart-soc-sunxi", "fstart-platform-aarch64?/sunxi"]
+# entry point on platforms that support it (AArch64 RMR switch for H5/A64,
+# ARMv7 eGON boot for A20/H3).  Driven by `soc_image_format: AllwinnerEgon`
+# in the board RON, not by platform — sunxi boards exist on multiple ISAs.
+sunxi = ["dep:fstart-soc-sunxi", "fstart-platform-aarch64?/sunxi", "fstart-platform-armv7?/sunxi"]
 # Driver selection (enabled based on board.ron devices)
 ns16550 = ["dep:fstart-driver-ns16550"]
 pl011 = ["dep:fstart-driver-pl011"]
@@ -55,7 +57,7 @@ fstart-types = { workspace = true }
 # Platform crates (exactly one enabled via feature)
 fstart-platform-riscv64 = { workspace = true, optional = true }
 fstart-platform-aarch64 = { workspace = true, optional = true }
-fstart-platform-armv7 = { workspace = true, optional = true, features = ["sunxi"] }
+fstart-platform-armv7 = { workspace = true, optional = true }
 fstart-soc-sunxi = { workspace = true, optional = true }
 
 # Individual driver crates (enabled via features matching board.ron driver names)

--- a/crates/fstart-types/src/board.rs
+++ b/crates/fstart-types/src/board.rs
@@ -8,6 +8,57 @@ use crate::memory::MemoryMap;
 use crate::security::SecurityConfig;
 use crate::stage::StageLayout;
 
+/// Target platform / ISA.
+///
+/// This enum is the single source of truth for platform identity.
+/// Adding a new platform variant automatically produces compiler errors
+/// at every `match` site that needs updating — no stringly-typed
+/// matching required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Platform {
+    /// RISC-V 64-bit (riscv64gc-unknown-none-elf)
+    Riscv64,
+    /// AArch64 / ARMv8-A (aarch64-unknown-none)
+    Aarch64,
+    /// ARMv7-A (armv7a-none-eabi)
+    Armv7,
+}
+
+impl Platform {
+    /// Rust target triple for cross-compilation.
+    pub fn target_triple(&self) -> &'static str {
+        match self {
+            Platform::Riscv64 => "riscv64gc-unknown-none-elf",
+            Platform::Aarch64 => "aarch64-unknown-none",
+            Platform::Armv7 => "armv7a-none-eabi",
+        }
+    }
+
+    /// Linker `OUTPUT_ARCH(...)` name.
+    pub fn linker_arch(&self) -> &'static str {
+        match self {
+            Platform::Riscv64 => "riscv",
+            Platform::Aarch64 => "aarch64",
+            Platform::Armv7 => "arm",
+        }
+    }
+
+    /// Short string identifier (used for cargo feature names, log messages).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Platform::Riscv64 => "riscv64",
+            Platform::Aarch64 => "aarch64",
+            Platform::Armv7 => "armv7",
+        }
+    }
+}
+
+impl core::fmt::Display for Platform {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Top-level board configuration, deserialized from a board.ron file.
 ///
 /// This is the single source of truth for a board's hardware description,
@@ -16,8 +67,8 @@ use crate::stage::StageLayout;
 pub struct BoardConfig {
     /// Human-readable board name (e.g., "qemu-riscv64")
     pub name: HString<64>,
-    /// Platform identifier (e.g., "riscv64", "aarch64", "armv7")
-    pub platform: HString<32>,
+    /// Target platform / ISA
+    pub platform: Platform,
     /// Memory map: ROM, RAM, MMIO regions
     pub memory: MemoryMap,
     /// Device declarations with driver and service bindings

--- a/crates/fstart-types/src/lib.rs
+++ b/crates/fstart-types/src/lib.rs
@@ -17,7 +17,7 @@ pub mod stage;
 
 pub use board::{
     BoardConfig, BuildMode, FdtSource, FirmwareConfig, FirmwareKind, FitParseMode, PayloadConfig,
-    PayloadKind, SocImageFormat,
+    PayloadKind, Platform, SocImageFormat,
 };
 pub use device::{DeviceConfig, DeviceId, DeviceNode};
 pub use ffs::{

--- a/docs/continuation-plan.md
+++ b/docs/continuation-plan.md
@@ -643,9 +643,100 @@ FFS image: 9.5 MiB (103 KiB firmware + 49 KiB BL31 + 9.0 MiB kernel).
   `QEMU_USE_GIC_DRIVER=QEMU_GICV3`; without explicit `gic-version=3`,
   QEMU may default to GICv2, causing BL31 to hang during GIC init.
 
+### Phase 12: Platform Scalability Refactor (COMPLETE)
+
+Replaced stringly-typed platform identity with a `Platform` enum, introduced
+a codegen platform crate alias, and decoupled ARMv7 from Allwinner sunxi.
+These changes make adding new platform targets (x86_64, LoongArch, etc.)
+a compile-checked, mechanical process.
+
+#### Platform Enum
+
+`fstart-types/src/board.rs` — new `Platform` enum:
+- Variants: `Riscv64`, `Aarch64`, `Armv7`
+- Methods: `target_triple()`, `linker_arch()`, `as_str()`
+- `Display` impl, serde derives, `Copy + PartialEq + Eq`
+- `BoardConfig.platform` changed from `HString<32>` to `Platform`
+- Exhaustive `match` everywhere — adding a new variant causes compile errors
+  at every site that needs updating
+
+#### Codegen Platform Alias
+
+`generate_platform_externs()` in `stage_gen/mod.rs` now emits:
+```rust
+extern crate fstart_platform_riscv64 as fstart_platform;
+```
+Common calls (`halt()`, `jump_to()`) use `fstart_platform::` instead of
+per-platform crate names. Platform-specific boot protocols (SBI, ATF, direct
+Linux) still use the concrete platform crate where needed.
+
+#### ARMv7 / Sunxi Decoupling
+
+- `fstart-stage/Cargo.toml`: `armv7` feature no longer implies
+  `dep:fstart-soc-sunxi`. A separate `sunxi` feature activates on either
+  `aarch64` or `armv7` via `dep:fstart-soc-sunxi?` syntax.
+- `fstart-soc-sunxi/Cargo.toml`: removed spurious `fstart-arch` dependency.
+- This allows non-Allwinner ARMv7 boards (e.g., QEMU virt) to build without
+  pulling in sunxi SoC code.
+
+#### Scope of Changes
+
+Eliminated string matching in **17 locations** across 6 files:
+- `fstart-codegen/src/stage_gen/mod.rs` — function signatures, platform
+  extern generation, import generation
+- `fstart-codegen/src/stage_gen/capabilities.rs` — all 9 platform match
+  sites for boot protocols, jump functions, memory init
+- `fstart-codegen/src/stage_gen/tokens.rs` — `halt_expr()` now uses alias
+- `fstart-codegen/src/linker.rs` — `linker_arch()` method replaces match
+- `xtask/src/build_board.rs` — target triple, features, flat binary, sunxi
+- `xtask/src/qemu.rs` — QEMU machine/CPU selection
+
+All 10 board RON files updated: `platform: "riscv64"` → `platform: Riscv64`.
+
+#### Verification
+
+| Check | Result |
+|-------|--------|
+| `cargo test` | 71 pass (47 codegen + 14 FFS + 10 FIT) |
+| `cargo clippy` | Clean (`-D warnings`) |
+| qemu-riscv64 | Builds |
+| qemu-aarch64 | Builds |
+| qemu-armv7 | Builds |
+| qemu-riscv64-multi | Builds |
+| qemu-riscv64-flex | Builds |
+| qemu-aarch64-multi | Builds |
+| qemu-aarch64-flex | Builds |
+| orangepi-pc2 | Builds |
+| bananapi-m1 | Pre-existing linker overflow (bootblock too large for SRAM) |
+| orangepi-r1 | Pre-existing linker overflow (bootblock too large for SRAM) |
+
 ---
 
 ## What Remains
+
+### Platform Scalability — Deferred Items
+
+These were identified during Phase 12 but deferred as lower priority:
+
+1. **Uniform `boot_linux()` API** — Each platform crate exports different
+   boot functions (`boot_linux_sbi`, `boot_linux_atf`, `boot_linux`).
+   Unifying to a single `boot_linux(kernel, dtb, fw)` per-platform would
+   reduce codegen duplication in `generate_payload_load_linux` and
+   `generate_payload_load_fit_runtime`. Requires API changes in all 3
+   platform crates.
+
+2. **Abstract SoC boot header** — `LoadNextStage` and block-device
+   `AnchorScan` are eGON-only. A `SocBootHeader` trait would allow
+   other SoCs (e.g., Rockchip, MediaTek) to provide their own boot
+   media detection and header format.
+
+3. **Move BROM mapping out of codegen** — `boot_media_values_for_device()`
+   in capabilities.rs still hardcodes sunxi BROM constants. These should
+   move to the SoC crate or board RON.
+
+4. **Fix ARMv7 sunxi bootblock size** — bananapi-m1 and orangepi-r1
+   debug builds overflow SRAM. Options: LTO, `opt-level = "s"` for
+   bootblock profile, or split crypto into the main stage only.
 
 ### Explore crabtime (Optional)
 
@@ -711,13 +802,24 @@ be at offset 0 (QEMU's `-bios` expects executable code at the start).
 
 ---
 
-## File Summary (Phase 11 Changes — Linux Boot)
+## File Summary (Phase 12 Changes — Platform Scalability)
 
 | File | Change |
 |------|--------|
-| `xtask/src/qemu.rs` | Added `gic-version=3` to AArch64 QEMU machine flags |
-| `crates/fstart-log/src/lib.rs` | SyncCell wrapper, double-init guard, removed dead `Level::tag()` |
-| `docs/continuation-plan.md` | Updated with Phase 10 + 11 completion |
+| `crates/fstart-types/src/board.rs` | Added `Platform` enum, changed `BoardConfig.platform` type |
+| `crates/fstart-types/src/lib.rs` | Added `Platform` to re-exports |
+| `crates/fstart-codegen/src/ron_loader.rs` | `RonBoardConfig.platform` → `Platform` |
+| `crates/fstart-codegen/src/linker.rs` | Uses `Platform::linker_arch()` |
+| `crates/fstart-codegen/src/stage_gen/mod.rs` | Platform alias, all signatures changed |
+| `crates/fstart-codegen/src/stage_gen/tokens.rs` | `halt_expr()` uses alias |
+| `crates/fstart-codegen/src/stage_gen/capabilities.rs` | 9 match sites → `Platform` enum |
+| `crates/fstart-codegen/src/stage_gen/tests.rs` | Updated for `Platform::Riscv64`, `fstart_platform::` |
+| `xtask/src/build_board.rs` | `Platform` methods, sunxi feature decoupled |
+| `xtask/src/qemu.rs` | `Platform` parameter, exhaustive match |
+| `xtask/src/main.rs` | Passes `config.platform` to qemu |
+| `crates/fstart-stage/Cargo.toml` | Decoupled `armv7` from `sunxi` |
+| `crates/fstart-soc-sunxi/Cargo.toml` | Removed `fstart-arch` dependency |
+| `boards/*/board.ron` (10 files) | `platform:` field → enum variant |
 
 ## Git State
 

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -6,7 +6,7 @@
 //! 4. Return the path(s) to the built binary(ies)
 
 use fstart_codegen::ron_loader;
-use fstart_types::{Capability, SecurityConfig, SocImageFormat, StageLayout};
+use fstart_types::{Capability, Platform, SecurityConfig, SocImageFormat, StageLayout};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -53,18 +53,13 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
     eprintln!("[fstart] platform: {}", config.platform);
     eprintln!("[fstart] mode: {:?}", config.mode);
 
-    // Determine target triple
-    let target = match config.platform.as_str() {
-        "riscv64" => "riscv64gc-unknown-none-elf",
-        "aarch64" => "aarch64-unknown-none",
-        "armv7" => "armv7a-none-eabi",
-        other => return Err(format!("unsupported platform: {other}")),
-    };
+    // Determine target triple from the Platform enum.
+    let target = config.platform.target_triple();
 
     // Base features: platform + all driver features (every stage constructs
     // all devices, so driver features are always needed globally).
     let mut base_features = Vec::new();
-    base_features.push(config.platform.to_string());
+    base_features.push(config.platform.as_str().to_string());
     for device in &config.devices {
         base_features.push(device.driver.to_string());
     }
@@ -87,10 +82,9 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
 
     // Allwinner sunxi SoCs use the eGON boot format and need
     // fstart-soc-sunxi for the eGON header, boot media detection,
-    // and FEL support.  For AArch64 sunxi boards (H5, A64) this also
-    // enables the RMR switch entry point in fstart-platform-aarch64.
-    // (ARMv7 sunxi boards always pull in sunxi via the `armv7` feature.)
-    if config.soc_image_format == SocImageFormat::AllwinnerEgon && config.platform != "armv7" {
+    // and FEL support.  This is driven by `soc_image_format`, not by
+    // the platform — sunxi boards exist on both ARMv7 and AArch64.
+    if config.soc_image_format == SocImageFormat::AllwinnerEgon {
         base_features.push("sunxi".to_string());
     }
 
@@ -99,7 +93,10 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
     // All bare-metal platforms need flat binaries: AArch64 uses -bios
     // which expects raw binary, RISC-V uses pflash, and ARMv7 Allwinner
     // boot ROM loads raw binary from SD/SPI/eMMC.
-    let needs_flat_binary = matches!(config.platform.as_str(), "aarch64" | "riscv64" | "armv7");
+    let needs_flat_binary = matches!(
+        config.platform,
+        Platform::Aarch64 | Platform::Riscv64 | Platform::Armv7
+    );
 
     let soc_format = config.soc_image_format;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -110,11 +110,11 @@ fn run_board(
     if is_multi_stage || has_payload_blobs {
         // Assemble the FFS image (includes stage + firmware + kernel)
         let image_path = assemble::assemble_with_opts(board_name, release, kernel, firmware)?;
-        qemu::run(board_name, &image_path)
+        qemu::run(config.platform, &image_path)
     } else {
         // Simple monolithic: build and boot the single binary directly
         let res = build_board::build(board_name, release)?;
-        qemu::run(board_name, &res.primary_binary().run_path)
+        qemu::run(config.platform, &res.primary_binary().run_path)
     }
 }
 

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -1,5 +1,6 @@
 //! QEMU launcher for testing.
 
+use fstart_types::Platform;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -8,9 +9,9 @@ use std::process::Command;
 /// For both monolithic and FFS builds, `binary` is a flat binary (raw
 /// firmware or FFS image). RISC-V uses pflash to load it at flash base
 /// (0x20000000, XIP); AArch64 uses `-bios` to load it at flash (0x0, XIP).
-pub fn run(board_name: &str, binary: &Path) -> Result<(), String> {
-    let (qemu_bin, args) = match board_name {
-        name if name.contains("riscv64") => {
+pub fn run(platform: Platform, binary: &Path) -> Result<(), String> {
+    let (qemu_bin, args) = match platform {
+        Platform::Riscv64 => {
             // RISC-V virt: load firmware into pflash bank 0 at 0x20000000
             // (XIP).  The MROM trampoline at 0x1000 sets a0=mhartid,
             // a1=DTB addr, then jumps to flash base.
@@ -32,7 +33,7 @@ pub fn run(board_name: &str, binary: &Path) -> Result<(), String> {
             ];
             ("qemu-system-riscv64", args)
         }
-        name if name.contains("aarch64") => {
+        Platform::Aarch64 => {
             let mut args = vec![
                 "-machine".to_string(),
                 // secure=on: enable TrustZone so secure SRAM at 0x0E000000 exists
@@ -52,22 +53,21 @@ pub fn run(board_name: &str, binary: &Path) -> Result<(), String> {
             args.extend(["-bios".to_string(), binary.display().to_string()]);
             ("qemu-system-aarch64", args)
         }
-        name if name.contains("armv7") => {
+        Platform::Armv7 => {
             let args = vec![
                 "-machine".to_string(),
                 "virt".to_string(),
                 "-cpu".to_string(),
                 "cortex-a15".to_string(),
                 "-nographic".to_string(),
+                // ARMv7: always use -bios so QEMU enters firmware boot mode,
+                // which places the DTB at RAM base (0x40000000) and starts the
+                // CPU at PC=0x0. Same as AArch64.
+                "-bios".to_string(),
+                binary.display().to_string(),
             ];
-            // ARMv7: always use -bios so QEMU enters firmware boot mode,
-            // which places the DTB at RAM base (0x40000000) and starts the
-            // CPU at PC=0x0. Same as AArch64.
-            let mut args = args;
-            args.extend(["-bios".to_string(), binary.display().to_string()]);
             ("qemu-system-arm", args)
         }
-        _ => return Err(format!("no QEMU configuration for board: {board_name}")),
     };
 
     eprintln!("[fstart] launching: {qemu_bin} {}", args.join(" "));


### PR DESCRIPTION
## Summary

- **Platform enum** replaces `HString<32>` platform identity with a typed `Platform` enum (`Riscv64`, `Aarch64`, `Armv7`) in `fstart-types`, eliminating stringly-typed matching in 17 locations across 6 files. Adding a new platform target now produces compile errors at every site that needs updating.
- **Codegen platform alias** (`extern crate fstart_platform_X as fstart_platform`) lets common calls like `halt()` and `jump_to()` use a uniform `fstart_platform::` prefix instead of per-platform crate names.
- **ARMv7 decoupled from sunxi** — the `armv7` feature in `fstart-stage` no longer implies `fstart-soc-sunxi`, enabling non-Allwinner ARMv7 boards (e.g., QEMU virt) to build without sunxi SoC code. Removed spurious `fstart-arch` dependency from `fstart-soc-sunxi`.

## Verification

- 71 tests pass (47 codegen + 14 FFS + 10 FIT)
- Clippy clean (`-D warnings`)
- 8 of 10 boards cross-compile (bananapi-m1 and orangepi-r1 have pre-existing linker overflow unrelated to this change)

## Changed files (25)

- `crates/fstart-types/src/board.rs` — `Platform` enum definition
- `crates/fstart-codegen/src/stage_gen/` — all codegen updated to `Platform` + alias
- `xtask/src/` — build/qemu use `Platform` methods
- `crates/fstart-stage/Cargo.toml` — armv7/sunxi feature decoupling
- `boards/*/board.ron` (10 files) — `platform:` field → enum variant
- `docs/continuation-plan.md` — Phase 12 documentation