### PR TITLE
Add x86_64 (QEMU Q35) platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,11 @@ fit/Image-*
 fit/zImage-*
 fit/initramfs-*
 
-# Board test artifacts (DTBs, kernel images, symlinks)
+# Board test artifacts (DTBs, kernel images, symlinks, disk images)
 *.dtb
+*.img
+*.iso
+*.qcow2
 zImage
 Image
 bl31.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ version = "0.1.0"
 dependencies = [
  "fstart-log",
  "fstart-mmio",
+ "fstart-pio",
  "fstart-services",
  "serde",
  "ufmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "fstart-driver-ns16550",
  "fstart-driver-pci-ecam",
  "fstart-driver-pl011",
+ "fstart-driver-q35-hostbridge",
  "fstart-driver-qemu-fw-cfg",
  "fstart-driver-sifive-uart",
  "fstart-driver-sunxi-a20-dramc",
@@ -613,7 +614,6 @@ version = "0.1.0"
 dependencies = [
  "fstart-log",
  "fstart-mmio",
- "fstart-pio",
  "fstart-services",
  "serde",
  "ufmt",
@@ -630,6 +630,18 @@ dependencies = [
  "heapless",
  "serde",
  "tock-registers",
+]
+
+[[package]]
+name = "fstart-driver-q35-hostbridge"
+version = "0.1.0"
+dependencies = [
+ "fstart-driver-pci-ecam",
+ "fstart-log",
+ "fstart-pio",
+ "fstart-services",
+ "serde",
+ "ufmt",
 ]
 
 [[package]]
@@ -877,6 +889,7 @@ dependencies = [
  "fstart-driver-ns16550",
  "fstart-driver-pci-ecam",
  "fstart-driver-pl011",
+ "fstart-driver-q35-hostbridge",
  "fstart-driver-qemu-fw-cfg",
  "fstart-driver-sifive-uart",
  "fstart-driver-sunxi-a20-dramc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "fstart-driver-ns16550",
  "fstart-driver-pci-ecam",
  "fstart-driver-pl011",
+ "fstart-driver-qemu-fw-cfg",
  "fstart-driver-sifive-uart",
  "fstart-driver-sunxi-a20-dramc",
  "fstart-driver-sunxi-ccu",
@@ -600,6 +601,7 @@ name = "fstart-driver-ns16550"
 version = "0.1.0"
 dependencies = [
  "fstart-mmio",
+ "fstart-pio",
  "fstart-services",
  "serde",
  "tock-registers",
@@ -627,6 +629,17 @@ dependencies = [
  "heapless",
  "serde",
  "tock-registers",
+]
+
+[[package]]
+name = "fstart-driver-qemu-fw-cfg"
+version = "0.1.0"
+dependencies = [
+ "fstart-log",
+ "fstart-pio",
+ "fstart-services",
+ "serde",
+ "ufmt",
 ]
 
 [[package]]
@@ -785,6 +798,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "fstart-pio"
+version = "0.1.0"
+
+[[package]]
 name = "fstart-platform-aarch64"
 version = "0.1.0"
 dependencies = [
@@ -804,6 +821,16 @@ name = "fstart-platform-riscv64"
 version = "0.1.0"
 dependencies = [
  "fstart-soc-sunxi",
+]
+
+[[package]]
+name = "fstart-platform-x86_64"
+version = "0.1.0"
+dependencies = [
+ "fstart-log",
+ "fstart-pio",
+ "fstart-services",
+ "ufmt",
 ]
 
 [[package]]
@@ -849,6 +876,7 @@ dependencies = [
  "fstart-driver-ns16550",
  "fstart-driver-pci-ecam",
  "fstart-driver-pl011",
+ "fstart-driver-qemu-fw-cfg",
  "fstart-driver-sifive-uart",
  "fstart-driver-sunxi-a20-dramc",
  "fstart-driver-sunxi-ccu",
@@ -864,6 +892,7 @@ dependencies = [
  "fstart-platform-aarch64",
  "fstart-platform-armv7",
  "fstart-platform-riscv64",
+ "fstart-platform-x86_64",
  "fstart-runtime",
  "fstart-services",
  "fstart-soc-sunxi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,6 +514,7 @@ name = "fstart-crabefi"
 version = "0.1.0"
 dependencies = [
  "crabefi",
+ "fstart-pio",
  "fstart-services",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "crates/fstart-pio",
     "crates/fstart-platform-x86_64",
     "crates/fstart-driver-qemu-fw-cfg",
+    "crates/fstart-driver-q35-hostbridge",
 ]
 
 [workspace.package]
@@ -126,6 +127,7 @@ fstart-smbios = { path = "crates/fstart-smbios" }
 fstart-pio = { path = "crates/fstart-pio" }
 fstart-platform-x86_64 = { path = "crates/fstart-platform-x86_64" }
 fstart-driver-qemu-fw-cfg = { path = "crates/fstart-driver-qemu-fw-cfg" }
+fstart-driver-q35-hostbridge = { path = "crates/fstart-driver-q35-hostbridge" }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ members = [
     "crates/fstart-acpi",
     "crates/fstart-acpi-macros",
     "crates/fstart-smbios",
+    "crates/fstart-pio",
+    "crates/fstart-platform-x86_64",
+    "crates/fstart-driver-qemu-fw-cfg",
 ]
 
 [workspace.package]
@@ -120,6 +123,9 @@ fstart-stage = { path = "crates/fstart-stage" }
 fstart-fit = { path = "crates/fstart-fit" }
 fstart-acpi = { path = "crates/fstart-acpi" }
 fstart-smbios = { path = "crates/fstart-smbios" }
+fstart-pio = { path = "crates/fstart-pio" }
+fstart-platform-x86_64 = { path = "crates/fstart-platform-x86_64" }
+fstart-driver-qemu-fw-cfg = { path = "crates/fstart-driver-qemu-fw-cfg" }
 
 [profile.dev]
 panic = "abort"

--- a/boards/bananapi-m1/board.ron
+++ b/boards/bananapi-m1/board.ron
@@ -51,10 +51,9 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x01C28000,
+                regs: Mmio(0x01C28000, 2, 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
-                reg_shift: 2,
             )),
             services: ["Console"],
         ),

--- a/boards/bananapi-m1/board.ron
+++ b/boards/bananapi-m1/board.ron
@@ -51,7 +51,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x01C28000, 2, 0),
+                regs: Mmio(base: 0x01C28000, reg_shift: 2, reg_width: 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
             )),

--- a/boards/licheerv-dock/board.ron
+++ b/boards/licheerv-dock/board.ron
@@ -49,7 +49,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x02500000, 2, 4),
+                regs: Mmio(base: 0x02500000, reg_shift: 2, reg_width: 4),
                 clock_freq: 24000000,
                 baud_rate: 115200,
             )),

--- a/boards/licheerv-dock/board.ron
+++ b/boards/licheerv-dock/board.ron
@@ -49,11 +49,9 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x02500000,
+                regs: Mmio(0x02500000, 2, 4),
                 clock_freq: 24000000,
                 baud_rate: 115200,
-                reg_shift: 2,
-                reg_width: 4,
             )),
             services: ["Console"],
         ),

--- a/boards/orangepi-pc2/board.ron
+++ b/boards/orangepi-pc2/board.ron
@@ -51,10 +51,9 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x01C28000,
+                regs: Mmio(0x01C28000, 2, 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
-                reg_shift: 2,
             )),
             services: ["Console"],
         ),

--- a/boards/orangepi-pc2/board.ron
+++ b/boards/orangepi-pc2/board.ron
@@ -51,7 +51,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x01C28000, 2, 0),
+                regs: Mmio(base: 0x01C28000, reg_shift: 2, reg_width: 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
             )),

--- a/boards/orangepi-r1/board.ron
+++ b/boards/orangepi-r1/board.ron
@@ -53,10 +53,9 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x01C28000,
+                regs: Mmio(0x01C28000, 2, 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
-                reg_shift: 2,
             )),
             services: ["Console"],
         ),

--- a/boards/orangepi-r1/board.ron
+++ b/boards/orangepi-r1/board.ron
@@ -53,7 +53,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x01C28000, 2, 0),
+                regs: Mmio(base: 0x01C28000, reg_shift: 2, reg_width: 0),
                 clock_freq: 24000000,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-q35-uefi/board.ron
+++ b/boards/qemu-q35-uefi/board.ron
@@ -1,0 +1,151 @@
+// QEMU Q35 (x86_64) — CrabEFI UEFI firmware.
+//
+// Two-stage boot: XIP bootblock + RAM main stage.
+//
+// Stage 1 "bootblock": runs XIP from flash, minimal hw init (UART, page
+//   tables), reads FFS from flash, loads main stage to RAM, jumps.
+//
+// Stage 2 "main": runs from RAM at 2 MiB, full CrabEFI with PCI enum,
+//   AHCI discovery, bochs-display, ACPI tables, e820 memory map.
+//   CrabEFI boots Fedora/Ubuntu from AHCI disk via EFI boot manager.
+//
+// Flash: 8 MiB pflash at top of 4 GiB address space (0xFF800000-0xFFFFFFFF).
+// RAM: 4 GiB (detected at runtime via fw_cfg e820).
+// UART: legacy ISA NS16550 at I/O port 0x3F8 (COM1).
+// ACPI: loaded from QEMU via fw_cfg table-loader protocol.
+// PCI: Q35 host bridge — ECAM at 0xB0000000, 256 buses.
+//      MMIO windows computed at runtime from e820 memory map.
+(
+    name: "qemu-q35-uefi",
+    platform: X86_64,
+    memory: (
+        regions: [
+            ( name: "flash", base: 0xFF800000, size: 0x00800000, kind: Rom ),
+            // 4 GiB RAM for CrabEFI + shim + GRUB + Fedora.
+            // Actual size detected via fw_cfg e820.
+            // Bootblock uses workram (1 MiB at 0x100000) for BSS/stack.
+            // Main stage uses full RAM for CrabEFI + OS.
+            // Main stage runs at 16 MiB to keep 0-16 MiB free for
+            // Linux trampolines and AP startup code.
+            ( name: "workram", base: 0x00100000, size: 0x03F00000, kind: Ram ),
+        ],
+    ),
+    devices: [
+        (
+            name: "uart0",
+            driver: Ns16550((
+                regs: Pio(0x3F8),
+                clock_freq: 1843200,
+                baud_rate: 115200,
+            )),
+            services: ["Console"],
+        ),
+        (
+            name: "fw_cfg0",
+            driver: QemuFwCfg((
+                ctl_port: 0x510,
+                data_port: 0x511,
+            )),
+            services: ["AcpiTableProvider", "MemoryDetector"],
+        ),
+        (
+            name: "pci0",
+            driver: Q35HostBridge((
+                ecam_base:  0xB0000000,
+                ecam_size:  0x10000000,
+                bus_start: 0,
+                bus_end: 255,
+            )),
+            services: ["PciRootBus"],
+            children: [
+                (
+                    name: "bochs0",
+                    driver: BochsDisplay((
+                        device: 2,
+                        function: 0,
+                        width: 1024,
+                        height: 768,
+                    )),
+                    services: ["Framebuffer"],
+                ),
+            ],
+        ),
+    ],
+    stages: MultiStage([
+        // Stage 1: Bootblock (XIP from flash)
+        //
+        // Minimal init: UART for logging, then load main stage from FFS.
+        // Page tables at 0x1000-0x7000, IDT at 0x7000-0x8000.
+        // BSS/stack at 0x100000 (workram). Stack 256 KiB for bootblock.
+        (
+            name: "bootblock",
+            capabilities: [
+                ConsoleInit( device: "uart0" ),
+                // FFS at flash offset 0x100000 (1 MiB) — after stage code.
+                // base = flash_base + 0x100000 = 0xFF900000.
+                // size = 8 MiB - 1 MiB (stage) - 4 KiB (boot block) ≈ 7 MiB.
+                BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000 )),
+                StageLoad( next_stage: "main" ),
+            ],
+            load_addr: 0xFF800000,
+            stack_size: 0x40000,
+            // Minimal heap required because PCI driver features
+            // transitively depend on alloc (via fstart-alloc).
+            // The bootblock doesn't use it, but it must be linked.
+            heap_size: Some(0x1000),
+            runs_from: Rom,
+            data_addr: Some(0x100000),
+            // 2 pages for PML4+PDPT (1 GiB pages) + 1 page for IDT.
+            page_table_addr: Some((0x1000, 0x4000)),
+        ),
+        // Stage 2: Main stage (RAM)
+        //
+        // Runs from DRAM at 16 MiB. Full hw init + CrabEFI.
+        // Stack 4 MiB for CrabEFI + systemd-boot + kernel loading.
+        // Heap 1 MiB for PCI enumeration + CrabEFI internal allocs.
+        // FFS is re-read from flash (copied to RAM at 32 MiB for speed).
+        (
+            name: "main",
+            capabilities: [
+                ConsoleInit( device: "uart0" ),
+                MemoryDetect( device: "fw_cfg0" ),
+                MemoryInit,
+                AcpiLoad( device: "fw_cfg0" ),
+                PciInit( device: "pci0" ),
+                // FFS at flash offset 0x100000 — same as bootblock.
+                // Copied to RAM at 32 MiB for fast LZ4/SHA operations.
+                BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000, ram_copy_addr: Some(0x2000000) )),
+                SigVerify,
+                DriverInit,
+                PayloadLoad,
+            ],
+            // data_addr at 16 MiB: Linux needs 0-16 MiB for trampolines,
+            // AP startup, and real-mode emulation.  STRICT_KERNEL_RWX
+            // marks RuntimeServicesData pages NX, so firmware data must
+            // not overlap the kernel's low-memory executable regions.
+            load_addr: 0x1000000,
+            stack_size: 0x400000,
+            heap_size: Some(0x100000),
+            runs_from: Ram,
+            data_addr: Some(0x1000000),
+            page_table_addr: None,
+        ),
+    ]),
+    security: (
+        signing_algorithm: Ed25519,
+        pubkey_file: "keys/dev-signing.pub",
+        required_digests: [Sha256],
+    ),
+    mode: Rigid,
+    // CrabEFI UEFI payload — linked as a library.
+    // No kernel file — CrabEFI boots from AHCI disk via EFI boot manager.
+    payload: Some((
+        kind: UefiPayload,
+        kernel_file: None,
+        kernel_load_addr: None,
+        fdt: Platform,
+        dtb_addr: None,
+        bootargs: None,
+        firmware: None,
+    )),
+)

--- a/boards/qemu-q35-uefi/board.ron
+++ b/boards/qemu-q35-uefi/board.ron
@@ -34,7 +34,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Pio(0x3F8),
+                regs: Pio(base: 0x3F8),
                 clock_freq: 1843200,
                 baud_rate: 115200,
             )),
@@ -95,8 +95,8 @@
             heap_size: Some(0x1000),
             runs_from: Rom,
             data_addr: Some(0x100000),
-            // 2 pages for PML4+PDPT (1 GiB pages) + 1 page for IDT.
             page_table_addr: Some((0x1000, 0x4000)),
+            page_size: Size1GiB,
         ),
         // Stage 2: Main stage (RAM)
         //

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -23,7 +23,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Pio(0x3F8),
+                regs: Pio(base: 0x3F8),
                 clock_freq: 1843200,
                 baud_rate: 115200,
             )),
@@ -86,12 +86,14 @@
         // Q35's modest bus topology (~20 devices).
         heap_size: Some(0x40000),
         data_addr: Some(0x100000),
-        // Page tables (6 pages) + IDT (1 page) at conventional memory
-        // 0x1000-0x8000. On QEMU x86_64, RAM below 1 MiB is available
-        // but not usable for BSS/stack (too small for debug builds).
+        // Page tables + IDT at conventional memory 0x1000-0x8000.
+        // On QEMU x86_64, RAM below 1 MiB is available but not usable
+        // for BSS/stack (too small for debug builds).
         // Real Intel/AMD platforms may put page tables in ROM or CAR.
-        // 2 pages for PML4+PDPT (1 GiB pages) + 1 page for IDT.
         page_table_addr: Some((0x1000, 0x4000)),
+        // QEMU always supports 1 GiB pages; real hardware should use
+        // Size2MiB unless the target CPU is known to have PDPE1GB.
+        page_size: Size1GiB,
     )),
     security: (
         signing_algorithm: Ed25519,

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -4,8 +4,8 @@
 // RAM: detected at runtime via fw_cfg e820.
 // UART: legacy ISA NS16550 at I/O port 0x3F8 (COM1).
 // ACPI: loaded from QEMU via fw_cfg table-loader protocol.
-// PCI: ECAM at 0xB0000000, 256 buses. MMIO32 window below ECAM,
-//      PIO window 0xC000-0xFFFF (above legacy ISA ports).
+// PCI: Q35 host bridge — ECAM at 0xB0000000, 256 buses.
+//      MMIO windows computed at runtime from e820 memory map.
 (
     name: "qemu-q35",
     platform: X86_64,
@@ -39,15 +39,11 @@
         ),
         (
             name: "pci0",
-            driver: PciEcam((
+            // Q35 host bridge: ECAM bootstrap via CF8/CFC, MMIO windows
+            // computed at runtime from e820 (TOLUD depends on DRAM size).
+            driver: Q35HostBridge((
                 ecam_base:  0xB0000000,
                 ecam_size:  0x10000000,   // 256 MiB (256 buses)
-                mmio32_base: 0x80000000,
-                mmio32_size: 0x30000000,  // 768 MiB (0x80000000-0xAFFFFFFF)
-                mmio64_base: 0x380000000,
-                mmio64_size: 0x040000000, // 1 GiB above 4 GiB
-                pio_base:   0xC000,
-                pio_size:   0x4000,       // 0xC000-0xFFFF
                 bus_start: 0,
                 bus_end: 255,
             )),

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -47,7 +47,7 @@
             // Stage code (.text + .rodata + .ltext) occupies ~640 KiB at the
             // start of flash; 1 MiB gives headroom for growth.
             // On x86, codegen copies FFS to RAM before use (fast LZ4/SHA).
-            BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000 )),
+            BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000, ram_copy_addr: Some(0x2000000) )),
             SigVerify,
             DriverInit,
             PayloadLoad,
@@ -56,6 +56,11 @@
         stack_size: 0x80000,
         heap_size: None,
         data_addr: Some(0x100000),
+        // Page tables (6 pages) + IDT (1 page) at conventional memory
+        // 0x1000-0x8000. On QEMU x86_64, RAM below 1 MiB is available
+        // but not usable for BSS/stack (too small for debug builds).
+        // Real Intel/AMD platforms may put page tables in ROM or CAR.
+        page_table_addr: Some((0x1000, 0x7000)),
     )),
     security: (
         signing_algorithm: Ed25519,

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -1,0 +1,78 @@
+// QEMU Q35 (x86_64) — ICH9 chipset emulation.
+//
+// Flash: 8 MiB pflash at top of 4 GiB address space (0xFF800000-0xFFFFFFFF).
+// RAM: detected at runtime via fw_cfg e820.
+// UART: legacy ISA NS16550 at I/O port 0x3F8 (COM1).
+// ACPI: loaded from QEMU via fw_cfg table-loader protocol.
+// PCI: ECAM at 0xB0000000 (256 buses).
+(
+    name: "qemu-q35",
+    platform: X86_64,
+    memory: (
+        regions: [
+            ( name: "flash", base: 0xFF800000, size: 0x00800000, kind: Rom ),
+            // Firmware working RAM above 1 MiB — well clear of the IVT, BDA,
+            // VGA hole, and BIOS shadow areas in conventional memory.
+            // QEMU provides 1 GiB of RAM; actual size detected via fw_cfg e820.
+            // Debug builds with code-model=large need ~512 KiB stack.
+            ( name: "workram", base: 0x00100000, size: 0x00F00000, kind: Ram ),
+        ],
+        flash_base: Some(0xFF800000),
+        flash_size: Some(0x00800000),
+    ),
+    devices: [
+        (
+            name: "uart0",
+            driver: Ns16550((
+                base_addr: 0x3F8,
+                clock_freq: 1843200,
+                baud_rate: 115200,
+                access_mode: Pio,
+            )),
+            services: ["Console"],
+        ),
+        (
+            name: "fw_cfg0",
+            driver: QemuFwCfg((
+                ctl_port: 0x510,
+                data_port: 0x511,
+            )),
+            services: ["AcpiTableProvider", "MemoryDetector"],
+        ),
+    ],
+    stages: Monolithic((
+        capabilities: [
+            ConsoleInit( device: "uart0" ),
+            MemoryDetect( device: "fw_cfg0" ),
+            MemoryInit,
+            AcpiLoad( device: "fw_cfg0" ),
+            // FFS at flash offset 0x100000 (1 MiB) — after stage code, before boot block.
+            // Stage code (.text + .rodata + .ltext) occupies ~640 KiB at the
+            // start of flash; 1 MiB gives headroom for growth.
+            // On x86, codegen copies FFS to RAM before use (fast LZ4/SHA).
+            BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000 )),
+            SigVerify,
+            DriverInit,
+            PayloadLoad,
+        ],
+        load_addr: 0xFF800000,
+        stack_size: 0x80000,
+        heap_size: None,
+        data_addr: Some(0x100000),
+    )),
+    security: (
+        signing_algorithm: Ed25519,
+        pubkey_file: "keys/dev-signing.pub",
+        required_digests: [Sha256],
+    ),
+    mode: Rigid,
+    payload: Some((
+        kind: LinuxBoot,
+        kernel_file: Some("bzImage"),
+        kernel_load_addr: Some(0x1000000),
+        fdt: Platform,
+        dtb_addr: None,
+        bootargs: Some("console=ttyS0 earlycon=uart8250,io,0x3f8,115200n8"),
+        firmware: None,
+    )),
+)

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -90,7 +90,8 @@
         // 0x1000-0x8000. On QEMU x86_64, RAM below 1 MiB is available
         // but not usable for BSS/stack (too small for debug builds).
         // Real Intel/AMD platforms may put page tables in ROM or CAR.
-        page_table_addr: Some((0x1000, 0x7000)),
+        // 2 pages for PML4+PDPT (1 GiB pages) + 1 page for IDT.
+        page_table_addr: Some((0x1000, 0x4000)),
     )),
     security: (
         signing_algorithm: Ed25519,

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -17,17 +17,14 @@
             // Debug builds with code-model=large need ~512 KiB stack.
             ( name: "workram", base: 0x00100000, size: 0x00F00000, kind: Ram ),
         ],
-        flash_base: Some(0xFF800000),
-        flash_size: Some(0x00800000),
     ),
     devices: [
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x3F8,
+                regs: Pio(0x3F8),
                 clock_freq: 1843200,
                 baud_rate: 115200,
-                access_mode: Pio,
             )),
             services: ["Console"],
         ),

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -4,12 +4,8 @@
 // RAM: detected at runtime via fw_cfg e820.
 // UART: legacy ISA NS16550 at I/O port 0x3F8 (COM1).
 // ACPI: loaded from QEMU via fw_cfg table-loader protocol.
-// PCI: ECAM at 0xB0000000 (256 buses).
-//
-// TODO: add PCI root bridge (PciEcam) and VGA device once the heap
-// allocator is integrated. Linux does its own PCI enumeration so
-// this isn't blocking for LinuxBoot, but is needed for firmware-level
-// PCI resource allocation (e.g., for a framebuffer console).
+// PCI: ECAM at 0xB0000000, 256 buses. MMIO32 window below ECAM,
+//      PIO window 0xC000-0xFFFF (above legacy ISA ports).
 (
     name: "qemu-q35",
     platform: X86_64,
@@ -41,6 +37,34 @@
             )),
             services: ["AcpiTableProvider", "MemoryDetector"],
         ),
+        (
+            name: "pci0",
+            driver: PciEcam((
+                ecam_base:  0xB0000000,
+                ecam_size:  0x10000000,   // 256 MiB (256 buses)
+                mmio32_base: 0x80000000,
+                mmio32_size: 0x30000000,  // 768 MiB (0x80000000-0xAFFFFFFF)
+                mmio64_base: 0x380000000,
+                mmio64_size: 0x040000000, // 1 GiB above 4 GiB
+                pio_base:   0xC000,
+                pio_size:   0x4000,       // 0xC000-0xFFFF
+                bus_start: 0,
+                bus_end: 255,
+            )),
+            services: ["PciRootBus"],
+            children: [
+                (
+                    name: "bochs0",
+                    driver: BochsDisplay((
+                        device: 2,
+                        function: 0,
+                        width: 1024,
+                        height: 768,
+                    )),
+                    services: ["Framebuffer"],
+                ),
+            ],
+        ),
     ],
     stages: Monolithic((
         capabilities: [
@@ -48,6 +72,9 @@
             MemoryDetect( device: "fw_cfg0" ),
             MemoryInit,
             AcpiLoad( device: "fw_cfg0" ),
+            // PCI enumeration — sizes BARs, allocates MMIO/IO resources,
+            // enables devices. Must appear after MemoryInit (heap required).
+            PciInit( device: "pci0" ),
             // FFS at flash offset 0x100000 (1 MiB) — after stage code, before boot block.
             // Stage code (.text + .rodata + .ltext) occupies ~640 KiB at the
             // start of flash; 1 MiB gives headroom for growth.
@@ -59,7 +86,9 @@
         ],
         load_addr: 0xFF800000,
         stack_size: 0x80000,
-        heap_size: None,
+        // Heap for PCI device list (alloc::Vec). 256 KiB is plenty for
+        // Q35's modest bus topology (~20 devices).
+        heap_size: Some(0x40000),
         data_addr: Some(0x100000),
         // Page tables (6 pages) + IDT (1 page) at conventional memory
         // 0x1000-0x8000. On QEMU x86_64, RAM below 1 MiB is available

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -5,6 +5,11 @@
 // UART: legacy ISA NS16550 at I/O port 0x3F8 (COM1).
 // ACPI: loaded from QEMU via fw_cfg table-loader protocol.
 // PCI: ECAM at 0xB0000000 (256 buses).
+//
+// TODO: add PCI root bridge (PciEcam) and VGA device once the heap
+// allocator is integrated. Linux does its own PCI enumeration so
+// this isn't blocking for LinuxBoot, but is needed for firmware-level
+// PCI resource allocation (e.g., for a framebuffer console).
 (
     name: "qemu-q35",
     platform: X86_64,

--- a/boards/qemu-riscv64-flex/board.ron
+++ b/boards/qemu-riscv64-flex/board.ron
@@ -30,7 +30,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x10000000,
+                regs: Mmio(0x10000000, 0, 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-riscv64-flex/board.ron
+++ b/boards/qemu-riscv64-flex/board.ron
@@ -30,7 +30,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x10000000, 0, 0),
+                regs: Mmio(base: 0x10000000, reg_shift: 0, reg_width: 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-riscv64-multi/board.ron
+++ b/boards/qemu-riscv64-multi/board.ron
@@ -33,7 +33,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x10000000,
+                regs: Mmio(0x10000000, 0, 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-riscv64-multi/board.ron
+++ b/boards/qemu-riscv64-multi/board.ron
@@ -33,7 +33,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x10000000, 0, 0),
+                regs: Mmio(base: 0x10000000, reg_shift: 0, reg_width: 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-riscv64/board.ron
+++ b/boards/qemu-riscv64/board.ron
@@ -31,7 +31,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                base_addr: 0x10000000,
+                regs: Mmio(0x10000000, 0, 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/boards/qemu-riscv64/board.ron
+++ b/boards/qemu-riscv64/board.ron
@@ -31,7 +31,7 @@
         (
             name: "uart0",
             driver: Ns16550((
-                regs: Mmio(0x10000000, 0, 0),
+                regs: Mmio(base: 0x10000000, reg_shift: 0, reg_width: 0),
                 clock_freq: 3686400,
                 baud_rate: 115200,
             )),

--- a/crates/fstart-arch/Cargo.toml
+++ b/crates/fstart-arch/Cargo.toml
@@ -9,5 +9,6 @@ default = []
 armv7 = []
 aarch64 = []
 riscv64 = []
+x86_64 = []
 
 [dependencies]

--- a/crates/fstart-arch/src/lib.rs
+++ b/crates/fstart-arch/src/lib.rs
@@ -1,7 +1,7 @@
 //! Architecture-specific utilities.
 //!
 //! Provides delay functions, processor halt, and other low-level operations
-//! that vary between CPU architectures (ARMv7-A, AArch64, RISC-V).
+//! that vary between CPU architectures (ARMv7-A, AArch64, RISC-V, x86_64).
 
 #![no_std]
 
@@ -9,7 +9,12 @@
 // udelay — microsecond delay (generic spin loop)
 // ---------------------------------------------------------------------------
 
-#[cfg(any(feature = "armv7", feature = "aarch64", feature = "riscv64"))]
+#[cfg(any(
+    feature = "armv7",
+    feature = "aarch64",
+    feature = "riscv64",
+    feature = "x86_64"
+))]
 pub fn udelay(us: u32) {
     for _ in 0..us.saturating_mul(100) {
         core::hint::spin_loop();
@@ -20,7 +25,12 @@ pub fn udelay(us: u32) {
 // mdelay — millisecond delay
 // ---------------------------------------------------------------------------
 
-#[cfg(any(feature = "armv7", feature = "aarch64", feature = "riscv64"))]
+#[cfg(any(
+    feature = "armv7",
+    feature = "aarch64",
+    feature = "riscv64",
+    feature = "x86_64"
+))]
 pub fn mdelay(ms: u32) {
     for _ in 0..ms {
         udelay(1000);
@@ -116,10 +126,21 @@ pub fn halt() -> ! {
     }
 }
 
+#[cfg(all(feature = "x86_64", target_arch = "x86_64"))]
+pub fn halt() -> ! {
+    loop {
+        // SAFETY: `hlt` puts the CPU in a low-power wait state until the
+        // next interrupt. In firmware context interrupts are typically
+        // disabled, so this is effectively a permanent halt.
+        unsafe { core::arch::asm!("hlt", options(nostack, nomem, preserves_flags)) };
+    }
+}
+
 #[cfg(not(any(
     all(feature = "armv7", target_arch = "arm"),
     all(feature = "aarch64", target_arch = "aarch64"),
-    all(feature = "riscv64", target_arch = "riscv64")
+    all(feature = "riscv64", target_arch = "riscv64"),
+    all(feature = "x86_64", target_arch = "x86_64"),
 )))]
 pub fn halt() -> ! {
     loop {

--- a/crates/fstart-capabilities/src/lib.rs
+++ b/crates/fstart-capabilities/src/lib.rs
@@ -194,6 +194,15 @@ pub fn memory_detect(
     let count = detector.detect_memory(entries)?;
     let total = detector.total_ram_bytes()?;
     fstart_log::info!("Detected {} MiB RAM, {} e820 entries", total >> 20, count);
+
+    // Store in global state so PCI host bridges (and other consumers)
+    // can access e820 data without codegen passing it explicitly.
+    // SAFETY: single-threaded firmware init, called once during the
+    // MemoryDetect capability phase.
+    unsafe {
+        fstart_services::memory_detect::e820_state_mut().store(entries, count, total);
+    }
+
     Ok((count, total))
 }
 

--- a/crates/fstart-capabilities/src/lib.rs
+++ b/crates/fstart-capabilities/src/lib.rs
@@ -152,6 +152,52 @@ pub fn late_driver_init_complete(device_count: usize) {
 }
 
 // ---------------------------------------------------------------------------
+// AcpiLoad
+// ---------------------------------------------------------------------------
+
+/// Load ACPI tables from an external provider (e.g., QEMU fw_cfg).
+///
+/// Calls `load_acpi_tables()` on the given device, writing tables into
+/// `buffer`. Returns the RSDP physical address on success.
+///
+/// This function lives in firmware library code — codegen just calls it
+/// with the appropriate device reference and buffer.
+pub fn acpi_load(
+    provider: &impl fstart_services::acpi_provider::AcpiTableProvider,
+    buffer: &mut [u8],
+    device_name: &str,
+) -> Result<u64, fstart_services::ServiceError> {
+    use fstart_services::acpi_provider::AcpiTableProvider;
+    let rsdp = provider.load_acpi_tables(buffer)?;
+    fstart_log::info!("ACPI tables loaded, RSDP at {:#x}", rsdp);
+    Ok(rsdp)
+}
+
+// ---------------------------------------------------------------------------
+// MemoryDetect
+// ---------------------------------------------------------------------------
+
+/// Detect system memory layout at runtime (e.g., e820 from QEMU fw_cfg).
+///
+/// Calls `detect_memory()` and `total_ram_bytes()` on the given device.
+/// Populates `entries` with memory map entries and returns
+/// `(entry_count, total_ram_bytes)`.
+///
+/// This function lives in firmware library code — codegen just calls it
+/// with the appropriate device reference and entry buffer.
+pub fn memory_detect(
+    detector: &impl fstart_services::memory_detect::MemoryDetector,
+    entries: &mut [fstart_services::memory_detect::E820Entry],
+    device_name: &str,
+) -> Result<(usize, u64), fstart_services::ServiceError> {
+    use fstart_services::memory_detect::MemoryDetector;
+    let count = detector.detect_memory(entries)?;
+    let total = detector.total_ram_bytes()?;
+    fstart_log::info!("Detected {} MiB RAM, {} e820 entries", total >> 20, count);
+    Ok((count, total))
+}
+
+// ---------------------------------------------------------------------------
 // SigVerify
 // ---------------------------------------------------------------------------
 

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -10,19 +10,27 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
 
     let arch = config.platform.linker_arch();
 
-    // Determine load address, stack size, and optional data address from stage config
-    let (load_addr, stack_size, data_addr) = match (&config.stages, stage_name) {
-        (StageLayout::Monolithic(mono), _) => {
-            (mono.load_addr, mono.stack_size as u64, mono.data_addr)
-        }
+    // Determine load address, stack size, and optional data/page-table addresses from stage config
+    let (load_addr, stack_size, data_addr, page_table_addr) = match (&config.stages, stage_name) {
+        (StageLayout::Monolithic(mono), _) => (
+            mono.load_addr,
+            mono.stack_size as u64,
+            mono.data_addr,
+            mono.page_table_addr,
+        ),
         (StageLayout::MultiStage(stages), Some(name)) => {
             if let Some(stage) = stages.iter().find(|s| s.name.as_str() == name) {
-                (stage.load_addr, stage.stack_size as u64, stage.data_addr)
+                (
+                    stage.load_addr,
+                    stage.stack_size as u64,
+                    stage.data_addr,
+                    stage.page_table_addr,
+                )
             } else {
-                (0x8000_0000, 0x10000, None) // fallback
+                (0x8000_0000, 0x10000, None, None) // fallback
             }
         }
-        _ => (0x8000_0000, 0x10000, None),
+        _ => (0x8000_0000, 0x10000, None, None),
     };
 
     // Check if load_addr falls within a ROM region (XIP) or RAM region
@@ -110,6 +118,7 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
             ram_length,
             stack_size,
             data_addr,
+            page_table_addr,
             needs_egon_header,
             config.platform,
         );
@@ -170,6 +179,7 @@ fn generate_xip_layout(
     ram_length: u64,
     stack_size: u64,
     data_addr: Option<u64>,
+    page_table_addr: Option<(u64, u64)>,
     needs_egon_header: bool,
     platform: Platform,
 ) {
@@ -185,12 +195,20 @@ fn generate_xip_layout(
         "    ROM (rx)  : ORIGIN = {rom_origin:#x}, LENGTH = {rom_length:#x}"
     )
     .unwrap();
-    if platform == Platform::X86_64 {
-        // x86_64: page tables (0x1000) and IDT (0x7000) live below the
-        // main RAM region. A separate LOW region prevents the linker
-        // from merging them into the BSS PT_LOAD segment (which would
-        // produce a wrapped MemSiz spanning 0x10000→0x1000).
-        writeln!(out, "    LOW (rwx) : ORIGIN = 0x1000, LENGTH = 0x7000").unwrap();
+    if let Some((pt_origin, pt_length)) = page_table_addr {
+        // Page tables and IDT live in a separate LOW region below the
+        // main RAM. This prevents the linker from merging them into
+        // the BSS PT_LOAD segment (which would produce a wrapped MemSiz).
+        //
+        // On QEMU x86_64 this is conventional memory at 0x1000-0x8000.
+        // On real Intel/AMD platforms with proper flash mapping, page
+        // tables can live in ROM — set page_table_addr to None and the
+        // .pagetables section goes in the normal RAM region.
+        writeln!(
+            out,
+            "    LOW (rwx) : ORIGIN = {pt_origin:#x}, LENGTH = {pt_length:#x}"
+        )
+        .unwrap();
     }
     writeln!(
         out,
@@ -253,7 +271,7 @@ fn generate_xip_layout(
     writeln!(out, "    }} > RAM\n").unwrap();
 
     // Page tables: isolated from BSS to prevent corruption.
-    write_page_tables_section(out, "RAM", platform);
+    write_page_tables_section(out, "RAM", platform, page_table_addr.is_some());
 
     // Stack: grows downward from top of RAM region.
     write_stack(out, stack_size, "RAM");
@@ -333,7 +351,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "CODE");
         write_data_section(out, "CODE");
         write_bss_section(out, "RWDATA");
-        write_page_tables_section(out, "RWDATA", platform);
+        write_page_tables_section(out, "RWDATA", platform, false);
         write_stack(out, stack_size, "RWDATA");
         writeln!(out, "}}").unwrap();
     } else {
@@ -354,7 +372,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "RAM");
         write_data_section(out, "RAM");
         write_bss_section(out, "RAM");
-        write_page_tables_section(out, "RAM", platform);
+        write_page_tables_section(out, "RAM", platform, false);
         write_stack(out, stack_size, "RAM");
         writeln!(out, "}}").unwrap();
     }
@@ -428,18 +446,20 @@ fn write_allwinner_egon_section(out: &mut String, region: &str) {
 /// that must be 4 KiB aligned. Placing them in BSS risks corruption if
 /// any adjacent static (e.g., CrabEFI's firmware state) overflows.
 /// This section is NOLOAD and cleared by the entry stub before use.
-fn write_page_tables_section(out: &mut String, region: &str, platform: Platform) {
-    if platform == Platform::X86_64 {
-        // x86_64: page tables and IDT are placed at fixed low addresses
-        // (0x1000) to keep them separate from BSS/stack. Placing them
-        // below BSS prevents stack overflow from corrupting the page
-        // tables (which causes hard-to-debug triple faults).
+fn write_page_tables_section(
+    out: &mut String,
+    region: &str,
+    platform: Platform,
+    has_low_region: bool,
+) {
+    if has_low_region {
+        // Page tables and IDT placed in the LOW region (separate from
+        // BSS/stack). Used on platforms where page tables must live at
+        // specific addresses (e.g., QEMU x86_64 conventional memory).
         //
-        // Layout:
-        //   0x1000..0x7000  page tables (6 pages, PML4+PDPT+4×PDT)
-        //   0x7000..0x8000  IDT (1 page, 256 entries × 16 bytes)
-        // Place in LOW region so the linker creates a separate PT_LOAD
-        // segment, preventing merge with BSS (which would wrap MemSiz).
+        // Layout (for x86_64):
+        //   page tables: 6 pages (PML4 + PDPT + 4×PDT)
+        //   IDT: 1 page (256 entries × 16 bytes)
         writeln!(out, "    .page_tables (NOLOAD) : {{").unwrap();
         writeln!(out, "        _page_tables_start = .;").unwrap();
         writeln!(

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Write;
 
+use fstart_types::stage::PageSize;
 use fstart_types::{BoardConfig, Platform, RegionKind, SocImageFormat, StageLayout};
 
 /// Generate a linker script for the given board and (optional) stage.
@@ -11,27 +12,30 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
     let arch = config.platform.linker_arch();
 
     // Determine load address, stack size, and optional data/page-table addresses from stage config
-    let (load_addr, stack_size, data_addr, page_table_addr) = match (&config.stages, stage_name) {
-        (StageLayout::Monolithic(mono), _) => (
-            mono.load_addr,
-            mono.stack_size as u64,
-            mono.data_addr,
-            mono.page_table_addr,
-        ),
-        (StageLayout::MultiStage(stages), Some(name)) => {
-            if let Some(stage) = stages.iter().find(|s| s.name.as_str() == name) {
-                (
-                    stage.load_addr,
-                    stage.stack_size as u64,
-                    stage.data_addr,
-                    stage.page_table_addr,
-                )
-            } else {
-                (0x8000_0000, 0x10000, None, None) // fallback
+    let (load_addr, stack_size, data_addr, page_table_addr, page_size) =
+        match (&config.stages, stage_name) {
+            (StageLayout::Monolithic(mono), _) => (
+                mono.load_addr,
+                mono.stack_size as u64,
+                mono.data_addr,
+                mono.page_table_addr,
+                mono.page_size,
+            ),
+            (StageLayout::MultiStage(stages), Some(name)) => {
+                if let Some(stage) = stages.iter().find(|s| s.name.as_str() == name) {
+                    (
+                        stage.load_addr,
+                        stage.stack_size as u64,
+                        stage.data_addr,
+                        stage.page_table_addr,
+                        stage.page_size,
+                    )
+                } else {
+                    (0x8000_0000, 0x10000, None, None, PageSize::default()) // fallback
+                }
             }
-        }
-        _ => (0x8000_0000, 0x10000, None, None),
-    };
+            _ => (0x8000_0000, 0x10000, None, None, PageSize::default()),
+        };
 
     // Check if load_addr falls within a ROM region (XIP) or RAM region
     let rom_region =
@@ -127,6 +131,7 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
             needs_egon_header,
             is_first_stage,
             config.platform,
+            page_size,
         );
     } else {
         // RAM-only layout: everything in RAM at load_addr.
@@ -189,6 +194,7 @@ fn generate_xip_layout(
     needs_egon_header: bool,
     is_first_stage: bool,
     platform: Platform,
+    page_size: PageSize,
 ) {
     // When data_addr is set, split RAM into two memory regions:
     // RAMRO for read-only data (unused currently, but reserved),
@@ -278,7 +284,7 @@ fn generate_xip_layout(
     writeln!(out, "    }} > RAM\n").unwrap();
 
     // Page tables: isolated from BSS to prevent corruption.
-    write_page_tables_section(out, "RAM", platform, page_table_addr.is_some());
+    write_page_tables_section(out, "RAM", platform, page_table_addr.is_some(), page_size);
 
     // Stack: grows downward from top of RAM region.
     write_stack(out, stack_size, "RAM");
@@ -358,7 +364,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "CODE");
         write_data_section(out, "CODE");
         write_bss_section(out, "RWDATA");
-        write_page_tables_section(out, "RWDATA", platform, false);
+        write_page_tables_section(out, "RWDATA", platform, false, PageSize::default());
         write_stack(out, stack_size, "RWDATA");
         writeln!(out, "}}").unwrap();
     } else {
@@ -379,7 +385,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "RAM");
         write_data_section(out, "RAM");
         write_bss_section(out, "RAM");
-        write_page_tables_section(out, "RAM", platform, false);
+        write_page_tables_section(out, "RAM", platform, false, PageSize::default());
         write_stack(out, stack_size, "RAM");
         writeln!(out, "}}").unwrap();
     }
@@ -464,22 +470,24 @@ fn write_page_tables_section(
     region: &str,
     _platform: Platform,
     has_low_region: bool,
+    page_size: PageSize,
 ) {
     if has_low_region {
         // Page tables and IDT placed in the LOW region (separate from
         // BSS/stack). Used on platforms where page tables must live at
         // specific addresses (e.g., QEMU x86_64 conventional memory).
         //
-        // Layout (for x86_64):
-        //   page tables: 6 pages (PML4 + PDPT + 4×PDT)
-        //   IDT: 1 page (256 entries × 16 bytes)
+        // Size depends on page size:
+        //   1 GiB pages: 2 pages (PML4 + PDPT), 512 GiB coverage
+        //   2 MiB pages: 6 pages (PML4 + PDPT + 4xPD), 4 GiB coverage
+        //   IDT: 1 page (256 entries x 16 bytes)
+        let (pt_size, pt_comment) = match page_size {
+            PageSize::Size1GiB => (0x2000, "2 pages: PML4 + PDPT (1 GiB pages, 512 GiB)"),
+            PageSize::Size2MiB => (0x6000, "6 pages: PML4 + PDPT + 4xPD (2 MiB pages, 4 GiB)"),
+        };
         writeln!(out, "    .page_tables (NOLOAD) : {{").unwrap();
         writeln!(out, "        _page_tables_start = .;").unwrap();
-        writeln!(
-            out,
-            "        . += 0x2000;  /* 2 pages: PML4 + PDPT (1 GiB pages) */"
-        )
-        .unwrap();
+        writeln!(out, "        . += {pt_size:#x};  /* {pt_comment} */").unwrap();
         writeln!(out, "        _page_tables_end = .;").unwrap();
         writeln!(out, "    }} > LOW\n").unwrap();
         writeln!(out, "    .idt_table (NOLOAD) : {{").unwrap();

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -120,6 +120,7 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
             data_addr,
             page_table_addr,
             needs_egon_header,
+            is_first_stage,
             config.platform,
         );
     } else {
@@ -181,6 +182,7 @@ fn generate_xip_layout(
     data_addr: Option<u64>,
     page_table_addr: Option<(u64, u64)>,
     needs_egon_header: bool,
+    is_first_stage: bool,
     platform: Platform,
 ) {
     // When data_addr is set, split RAM into two memory regions:
@@ -449,7 +451,7 @@ fn write_allwinner_egon_section(out: &mut String, region: &str) {
 fn write_page_tables_section(
     out: &mut String,
     region: &str,
-    platform: Platform,
+    _platform: Platform,
     has_low_region: bool,
 ) {
     if has_low_region {

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -96,6 +96,11 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
     // Only for the first stage (which has the eGON header).
     if needs_egon_header {
         writeln!(out, "ENTRY(_head_jump)\n").unwrap();
+    } else if config.platform == Platform::X86_64 && !is_first_stage {
+        // Non-first x86_64 stages use a 64-bit-only entry point.
+        // The bootblock already transitioned to long mode; the RAM stage
+        // just needs to set up stack, zero BSS, and call fstart_main.
+        writeln!(out, "ENTRY(_start_ram)\n").unwrap();
     } else {
         writeln!(out, "ENTRY(_start)\n").unwrap();
     }
@@ -384,9 +389,14 @@ fn generate_ram_layout(
 // definitions between the split-RAM and single-RAM layout branches.
 
 fn write_text_section(out: &mut String, region: &str) {
+    // .ltext: large code model (x86_64) puts function bodies in .ltext
+    // sections — capture them alongside normal .text so all executable
+    // code is contiguous and _text_start/_text_end span everything.
     writeln!(out, "    .text : {{").unwrap();
+    writeln!(out, "        _text_start = .;").unwrap();
     writeln!(out, "        KEEP(*(.text.entry))").unwrap();
-    writeln!(out, "        *(.text .text.*)").unwrap();
+    writeln!(out, "        *(.text .text.* .ltext .ltext.*)").unwrap();
+    writeln!(out, "        _text_end = .;").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
 }
 
@@ -400,6 +410,7 @@ fn write_rodata_section(out: &mut String, region: &str) {
     // .lrodata: large code model (x86_64) puts read-only data in separate
     // .lrodata sections — capture them here alongside normal .rodata.
     writeln!(out, "    .rodata : ALIGN(8) {{").unwrap();
+    writeln!(out, "        _rodata_start = .;").unwrap();
     writeln!(out, "        *(.rodata .rodata.* .lrodata .lrodata.*)").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
 }
@@ -466,7 +477,7 @@ fn write_page_tables_section(
         writeln!(out, "        _page_tables_start = .;").unwrap();
         writeln!(
             out,
-            "        . += 0x6000;  /* 6 pages for x86_64 identity map */"
+            "        . += 0x2000;  /* 2 pages: PML4 + PDPT (1 GiB pages) */"
         )
         .unwrap();
         writeln!(out, "        _page_tables_end = .;").unwrap();
@@ -480,6 +491,15 @@ fn write_page_tables_section(
         writeln!(out, "        *(.page_tables .page_tables.*)").unwrap();
         writeln!(out, "        _page_tables_end = .;").unwrap();
         writeln!(out, "    }} > {region}\n").unwrap();
+
+        // x86_64 RAM stages inherit page tables from the bootblock but
+        // still define their own IDT. Place it in the main RAM region
+        // alongside BSS (no LOW region for RAM stages).
+        if _platform == Platform::X86_64 {
+            writeln!(out, "    .idt_table (NOLOAD) : ALIGN(4096) {{").unwrap();
+            writeln!(out, "        *(.idt_table)").unwrap();
+            writeln!(out, "    }} > {region}\n").unwrap();
+        }
     }
 }
 

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -276,15 +276,15 @@ fn generate_xip_layout(
     // Stack: grows downward from top of RAM region.
     write_stack(out, stack_size, "RAM");
 
-    // x86 entry code layout: the CPU starts at 0xFFFFFFF0 (reset vector).
-    // The .text.entry section (16-bit GDT load, mode transitions) must be
-    // within 64KB of the reset vector (CS base = 0xFFFF0000 at reset).
-    // We place it at (ROM_END - 64K) and the reset vector at (ROM_END - 16).
-    // x86: the reset vector at 0xFFFFFFF0 contains a near 16-bit jmp to
-    // _start16bit. Both .reset and .text.entry must be in the last 64K
-    // of the ROM (the initial CS segment at 0xFFFF0000). We merge them
-    // into a single output section pinned to (ROM_END - 64K).
-    if platform == Platform::X86_64 {
+    // x86 bootblock entry code: only the first stage (bootblock) has the
+    // 16-bit reset vector and mode transition code. Later stages in a
+    // multi-stage build start in 64-bit long mode (jumped to by the
+    // bootblock or previous stage) and don't need .x86boot or .reset.
+    //
+    // The CPU starts at 0xFFFFFFF0 (reset vector). The .x86boot section
+    // (16-bit GDT load, mode transitions) must be within 64KB of the
+    // reset vector (CS base = 0xFFFF0000 at reset).
+    if platform == Platform::X86_64 && is_first_stage {
         let boot_block_addr = rom_origin + rom_length - 0x1000; // last 4K
         let reset_addr = rom_origin + rom_length - 16;
         writeln!(out).unwrap();

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -214,7 +214,6 @@ fn generate_xip_layout(
     }
 
     // Code in ROM.
-    // Code in ROM
     writeln!(out, "    .text : {{").unwrap();
     writeln!(out, "        KEEP(*(.text.entry))").unwrap();
     writeln!(out, "        *(.text .text.*)").unwrap();

--- a/crates/fstart-codegen/src/linker.rs
+++ b/crates/fstart-codegen/src/linker.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use fstart_types::{BoardConfig, RegionKind, SocImageFormat, StageLayout};
+use fstart_types::{BoardConfig, Platform, RegionKind, SocImageFormat, StageLayout};
 
 /// Generate a linker script for the given board and (optional) stage.
 pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) -> String {
@@ -111,6 +111,7 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
             stack_size,
             data_addr,
             needs_egon_header,
+            config.platform,
         );
     } else {
         // RAM-only layout: everything in RAM at load_addr.
@@ -147,6 +148,7 @@ pub fn generate_linker_script(config: &BoardConfig, stage_name: Option<&str>) ->
             stack_size,
             bss_origin,
             needs_egon_header,
+            config.platform,
         );
     }
 
@@ -169,6 +171,7 @@ fn generate_xip_layout(
     stack_size: u64,
     data_addr: Option<u64>,
     needs_egon_header: bool,
+    platform: Platform,
 ) {
     // When data_addr is set, split RAM into two memory regions:
     // RAMRO for read-only data (unused currently, but reserved),
@@ -182,6 +185,13 @@ fn generate_xip_layout(
         "    ROM (rx)  : ORIGIN = {rom_origin:#x}, LENGTH = {rom_length:#x}"
     )
     .unwrap();
+    if platform == Platform::X86_64 {
+        // x86_64: page tables (0x1000) and IDT (0x7000) live below the
+        // main RAM region. A separate LOW region prevents the linker
+        // from merging them into the BSS PT_LOAD segment (which would
+        // produce a wrapped MemSiz spanning 0x10000→0x1000).
+        writeln!(out, "    LOW (rwx) : ORIGIN = 0x1000, LENGTH = 0x7000").unwrap();
+    }
     writeln!(
         out,
         "    RAM (rwx) : ORIGIN = {rw_origin:#x}, LENGTH = {rw_length:#x}"
@@ -203,6 +213,7 @@ fn generate_xip_layout(
         writeln!(out, "    }} > ROM\n").unwrap();
     }
 
+    // Code in ROM.
     // Code in ROM
     writeln!(out, "    .text : {{").unwrap();
     writeln!(out, "        KEEP(*(.text.entry))").unwrap();
@@ -214,9 +225,10 @@ fn generate_xip_layout(
     writeln!(out, "        *(.fstart.anchor)").unwrap();
     writeln!(out, "    }} > ROM\n").unwrap();
 
-    // Read-only data in ROM
+    // Read-only data in ROM.
+    // .lrodata: large code model (x86_64) puts read-only data in .lrodata.
     writeln!(out, "    .rodata : ALIGN(16) {{").unwrap();
-    writeln!(out, "        *(.rodata .rodata.*)").unwrap();
+    writeln!(out, "        *(.rodata .rodata.* .lrodata .lrodata.*)").unwrap();
     writeln!(out, "    }} > ROM\n").unwrap();
 
     // Initialized data: stored in ROM (AT > ROM), copied to RAM at startup.
@@ -224,26 +236,61 @@ fn generate_xip_layout(
     // _data_start / _data_end are the RAM addresses (virtual-memory addresses).
     // The _start assembly copies [_data_load .. _data_load + size) to
     // [_data_start .. _data_end) before entering Rust code.
+    // .ldata: large code model (x86_64) puts initialized data in .ldata.
     writeln!(out, "    .data : ALIGN(16) {{").unwrap();
     writeln!(out, "        _data_start = .;").unwrap();
-    writeln!(out, "        *(.data .data.*)").unwrap();
+    writeln!(out, "        *(.data .data.* .ldata .ldata.*)").unwrap();
     writeln!(out, "        _data_end = .;").unwrap();
     writeln!(out, "    }} > RAM AT > ROM").unwrap();
     writeln!(out, "    _data_load = LOADADDR(.data);\n").unwrap();
 
-    // BSS in RAM
+    // BSS in RAM.
+    // .lbss: large code model (x86_64) puts uninitialized data in .lbss.
     writeln!(out, "    .bss (NOLOAD) : ALIGN(16) {{").unwrap();
     writeln!(out, "        _bss_start = .;").unwrap();
-    writeln!(out, "        *(.bss .bss.*)").unwrap();
+    writeln!(out, "        *(.bss .bss.* .lbss .lbss.*)").unwrap();
     writeln!(out, "        *(COMMON)").unwrap();
     writeln!(out, "        _bss_end = .;").unwrap();
     writeln!(out, "    }} > RAM\n").unwrap();
 
     // Page tables: isolated from BSS to prevent corruption.
-    write_page_tables_section(out, "RAM");
+    write_page_tables_section(out, "RAM", platform);
 
     // Stack: grows downward from top of RAM region.
     write_stack(out, stack_size, "RAM");
+
+    // x86 entry code layout: the CPU starts at 0xFFFFFFF0 (reset vector).
+    // The .text.entry section (16-bit GDT load, mode transitions) must be
+    // within 64KB of the reset vector (CS base = 0xFFFF0000 at reset).
+    // We place it at (ROM_END - 64K) and the reset vector at (ROM_END - 16).
+    // x86: the reset vector at 0xFFFFFFF0 contains a near 16-bit jmp to
+    // _start16bit. Both .reset and .text.entry must be in the last 64K
+    // of the ROM (the initial CS segment at 0xFFFF0000). We merge them
+    // into a single output section pinned to (ROM_END - 64K).
+    if platform == Platform::X86_64 {
+        let boot_block_addr = rom_origin + rom_length - 0x1000; // last 4K
+        let reset_addr = rom_origin + rom_length - 16;
+        writeln!(out).unwrap();
+        writeln!(
+            out,
+            "    /* x86: 16-bit/32-bit/64-bit entry code + reset vector */"
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "    .x86boot {boot_block_addr:#x} : AT({boot_block_addr:#x}) {{"
+        )
+        .unwrap();
+        writeln!(out, "        KEEP(*(.x86boot))").unwrap();
+        writeln!(out, "    }} > ROM").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "    .reset {reset_addr:#x} : AT({reset_addr:#x}) {{").unwrap();
+        writeln!(out, "        KEEP(*(.reset))").unwrap();
+        writeln!(out, "    }} > ROM").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "    _binary_end = .;").unwrap();
+    }
+
     writeln!(out, "}}").unwrap();
 }
 
@@ -259,6 +306,7 @@ fn generate_ram_layout(
     stack_size: u64,
     bss_origin: Option<u64>,
     needs_egon_header: bool,
+    platform: Platform,
 ) {
     if let Some(bss_addr) = bss_origin {
         let code_length = bss_addr - ram_origin;
@@ -286,7 +334,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "CODE");
         write_data_section(out, "CODE");
         write_bss_section(out, "RWDATA");
-        write_page_tables_section(out, "RWDATA");
+        write_page_tables_section(out, "RWDATA", platform);
         write_stack(out, stack_size, "RWDATA");
         writeln!(out, "}}").unwrap();
     } else {
@@ -307,7 +355,7 @@ fn generate_ram_layout(
         write_rodata_section(out, "RAM");
         write_data_section(out, "RAM");
         write_bss_section(out, "RAM");
-        write_page_tables_section(out, "RAM");
+        write_page_tables_section(out, "RAM", platform);
         write_stack(out, stack_size, "RAM");
         writeln!(out, "}}").unwrap();
     }
@@ -330,15 +378,20 @@ fn write_anchor_section(out: &mut String, region: &str) {
 }
 
 fn write_rodata_section(out: &mut String, region: &str) {
+    // .lrodata: large code model (x86_64) puts read-only data in separate
+    // .lrodata sections — capture them here alongside normal .rodata.
     writeln!(out, "    .rodata : ALIGN(8) {{").unwrap();
-    writeln!(out, "        *(.rodata .rodata.*)").unwrap();
+    writeln!(out, "        *(.rodata .rodata.* .lrodata .lrodata.*)").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
 }
 
 fn write_data_section(out: &mut String, region: &str) {
+    // .ldata: large code model (x86_64) puts initialized data in .ldata
+    // sections — capture them with .data so LMA is set correctly via
+    // AT > ROM on XIP layouts.
     writeln!(out, "    .data : ALIGN(8) {{").unwrap();
     writeln!(out, "        _data_start = .;").unwrap();
-    writeln!(out, "        *(.data .data.*)").unwrap();
+    writeln!(out, "        *(.data .data.* .ldata .ldata.*)").unwrap();
     writeln!(out, "        _data_end = .;").unwrap();
     writeln!(out, "    }} > {region}").unwrap();
     // For RAM-only layouts, _data_load == _data_start (no ROM-to-RAM copy
@@ -347,9 +400,11 @@ fn write_data_section(out: &mut String, region: &str) {
 }
 
 fn write_bss_section(out: &mut String, region: &str) {
+    // .lbss: large code model (x86_64) puts uninitialized data in .lbss
+    // sections — capture them with .bss so they are NOLOAD.
     writeln!(out, "    .bss (NOLOAD) : ALIGN(8) {{").unwrap();
     writeln!(out, "        _bss_start = .;").unwrap();
-    writeln!(out, "        *(.bss .bss.*)").unwrap();
+    writeln!(out, "        *(.bss .bss.* .lbss .lbss.*)").unwrap();
     writeln!(out, "        *(COMMON)").unwrap();
     writeln!(out, "        _bss_end = .;").unwrap();
     writeln!(out, "    }} > {region}\n").unwrap();
@@ -374,12 +429,37 @@ fn write_allwinner_egon_section(out: &mut String, region: &str) {
 /// that must be 4 KiB aligned. Placing them in BSS risks corruption if
 /// any adjacent static (e.g., CrabEFI's firmware state) overflows.
 /// This section is NOLOAD and cleared by the entry stub before use.
-fn write_page_tables_section(out: &mut String, region: &str) {
-    writeln!(out, "    .page_tables (NOLOAD) : ALIGN(4096) {{").unwrap();
-    writeln!(out, "        _page_tables_start = .;").unwrap();
-    writeln!(out, "        *(.page_tables .page_tables.*)").unwrap();
-    writeln!(out, "        _page_tables_end = .;").unwrap();
-    writeln!(out, "    }} > {region}\n").unwrap();
+fn write_page_tables_section(out: &mut String, region: &str, platform: Platform) {
+    if platform == Platform::X86_64 {
+        // x86_64: page tables and IDT are placed at fixed low addresses
+        // (0x1000) to keep them separate from BSS/stack. Placing them
+        // below BSS prevents stack overflow from corrupting the page
+        // tables (which causes hard-to-debug triple faults).
+        //
+        // Layout:
+        //   0x1000..0x7000  page tables (6 pages, PML4+PDPT+4×PDT)
+        //   0x7000..0x8000  IDT (1 page, 256 entries × 16 bytes)
+        // Place in LOW region so the linker creates a separate PT_LOAD
+        // segment, preventing merge with BSS (which would wrap MemSiz).
+        writeln!(out, "    .page_tables (NOLOAD) : {{").unwrap();
+        writeln!(out, "        _page_tables_start = .;").unwrap();
+        writeln!(
+            out,
+            "        . += 0x6000;  /* 6 pages for x86_64 identity map */"
+        )
+        .unwrap();
+        writeln!(out, "        _page_tables_end = .;").unwrap();
+        writeln!(out, "    }} > LOW\n").unwrap();
+        writeln!(out, "    .idt_table (NOLOAD) : {{").unwrap();
+        writeln!(out, "        *(.idt_table)").unwrap();
+        writeln!(out, "    }} > LOW\n").unwrap();
+    } else {
+        writeln!(out, "    .page_tables (NOLOAD) : ALIGN(4096) {{").unwrap();
+        writeln!(out, "        _page_tables_start = .;").unwrap();
+        writeln!(out, "        *(.page_tables .page_tables.*)").unwrap();
+        writeln!(out, "        _page_tables_end = .;").unwrap();
+        writeln!(out, "    }} > {region}\n").unwrap();
+    }
 }
 
 fn write_stack(out: &mut String, stack_size: u64, region: &str) {

--- a/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
@@ -418,42 +418,40 @@ pub(super) fn generate_boot_media(
     halt: &TokenStream,
 ) -> TokenStream {
     match medium {
+        BootMedium::MemoryMapped {
+            ram_copy_addr: Some(ram_addr),
+            ..
+        } => {
+            // Copy FFS from flash to RAM before operating on it.
+            //
+            // This is used on platforms where flash-mapped MMIO is slow
+            // (e.g., x86_64 with code-model=large) or where the flash
+            // doesn't support true XIP. The board RON specifies the RAM
+            // destination via `ram_copy_addr`.
+            let ram_addr_lit = hex_addr(*ram_addr);
+            quote! {
+                // Copy FFS from flash to RAM for fast access
+                fstart_log::info!("copying FFS from flash {:#x} to RAM {:#x} ({} bytes)...",
+                    FLASH_BASE, #ram_addr_lit, FLASH_SIZE);
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        FLASH_BASE as *const u8,
+                        #ram_addr_lit as *mut u8,
+                        FLASH_SIZE as usize,
+                    );
+                }
+                fstart_log::info!("FFS copied to RAM");
+                let boot_media = unsafe {
+                    MemoryMapped::from_raw_addr(#ram_addr_lit, FLASH_SIZE as usize)
+                };
+            }
+        }
         BootMedium::MemoryMapped { .. } => {
-            if config.platform == Platform::X86_64 {
-                // x86_64 with code-model=large: copy FFS from flash to RAM
-                // before operating on it. The large code model makes every
-                // function call indirect (movabsq+callq), which is very slow
-                // for the tight loops in postcard deserialization and LZ4
-                // decompression. By copying the FFS to RAM first, the data
-                // pointers are in low memory and core::ptr::copy / memcpy
-                // operate on fast RAM instead of flash-mapped MMIO.
-                //
-                // The copy destination is above the kernel load address to
-                // avoid overlap. The kernel gets loaded later and overwrites
-                // only its own region.
-                quote! {
-                    // Copy FFS from flash to RAM for fast access
-                    let _ffs_ram_addr: u64 = 0x2000000; // 32 MiB — above typical kernel
-                    fstart_log::info!("copying FFS from flash {:#x} to RAM {:#x} ({} bytes)...",
-                        FLASH_BASE, _ffs_ram_addr, FLASH_SIZE);
-                    unsafe {
-                        core::ptr::copy_nonoverlapping(
-                            FLASH_BASE as *const u8,
-                            _ffs_ram_addr as *mut u8,
-                            FLASH_SIZE as usize,
-                        );
-                    }
-                    fstart_log::info!("FFS copied to RAM");
-                    let boot_media = unsafe {
-                        MemoryMapped::from_raw_addr(_ffs_ram_addr, FLASH_SIZE as usize)
-                    };
-                }
-            } else {
-                quote! {
-                    let boot_media = unsafe {
-                        MemoryMapped::from_raw_addr(FLASH_BASE, FLASH_SIZE as usize)
-                    };
-                }
+            // Direct XIP from flash-mapped memory (ARM, RISC-V, etc.)
+            quote! {
+                let boot_media = unsafe {
+                    MemoryMapped::from_raw_addr(FLASH_BASE, FLASH_SIZE as usize)
+                };
             }
         }
         BootMedium::Device { name, offset, size } => {
@@ -782,19 +780,18 @@ pub(super) fn generate_acpi_load(device_name: &str, halt: &TokenStream) -> Token
     quote! {
         // AcpiLoad: load ACPI tables from external provider
         {
-            use fstart_services::acpi_provider::AcpiTableProvider;
-            // Allocate 256 KiB buffer for ACPI tables.
+            // 256 KiB buffer for ACPI tables — persists for the OS lifetime.
             // QEMU Q35 produces ~128 KiB of tables plus RSDP/alignment.
             static mut _ACPI_LOAD_BUF: [u8; 256 * 1024] = [0u8; 256 * 1024];
-            let acpi_buf = unsafe { &mut _ACPI_LOAD_BUF };
-            let rsdp = #dev_var.load_acpi_tables(acpi_buf)
-                .unwrap_or_else(|_| {
-                    fstart_log::error!("AcpiLoad: failed to load ACPI tables from '{}'", stringify!(#dev_var));
-                    #halt
-                });
-            // Store RSDP address for PayloadLoad
-            _acpi_rsdp_addr = rsdp;
-            fstart_log::info!("ACPI tables loaded, RSDP at {:#x}", rsdp);
+            let acpi_buf = unsafe { &raw mut _ACPI_LOAD_BUF };
+            _acpi_rsdp_addr = fstart_capabilities::acpi_load(
+                &#dev_var,
+                unsafe { &mut *acpi_buf },
+                stringify!(#dev_var),
+            ).unwrap_or_else(|_| {
+                fstart_log::error!("AcpiLoad: failed");
+                #halt
+            });
         }
     }
 }
@@ -810,19 +807,16 @@ pub(super) fn generate_memory_detect(device_name: &str, halt: &TokenStream) -> T
     quote! {
         // MemoryDetect: discover system memory layout at runtime
         {
-            use fstart_services::memory_detect::MemoryDetector;
-            _e820_count = #dev_var.detect_memory(&mut _e820_entries)
-                .unwrap_or_else(|_| {
-                    fstart_log::error!("MemoryDetect: failed to detect memory from '{}'", stringify!(#dev_var));
-                    #halt
-                });
-            _total_ram = #dev_var.total_ram_bytes()
-                .unwrap_or_else(|_| {
-                    fstart_log::error!("MemoryDetect: failed to get total RAM from '{}'", stringify!(#dev_var));
-                    #halt
-                });
-            fstart_log::info!("Detected {} MiB RAM, {} e820 entries",
-                _total_ram >> 20, _e820_count);
+            let (count, total) = fstart_capabilities::memory_detect(
+                &#dev_var,
+                &mut _e820_entries,
+                stringify!(#dev_var),
+            ).unwrap_or_else(|_| {
+                fstart_log::error!("MemoryDetect: failed");
+                #halt
+            });
+            _e820_count = count;
+            _total_ram = total;
         }
     }
 }

--- a/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
@@ -164,6 +164,10 @@ pub(super) fn generate_memory_init() -> TokenStream {
 /// Finds the referenced PCI root bus device, calls its `init()` method
 /// (which enumerates the bus, sizes BARs, allocates resources, and
 /// programs hardware), and logs the result.
+///
+/// For the Q35 host bridge, `init_with_e820()` is called instead of
+/// `init()`, passing the e820 entries from MemoryDetect so the driver
+/// can compute the PCI MMIO hole at runtime.
 pub(super) fn generate_pci_init(
     device_name: &str,
     devices: &[DeviceConfig],
@@ -191,12 +195,25 @@ pub(super) fn generate_pci_init(
 
     let device = format_ident!("{}", device_name);
 
-    quote! {
-        #device.init().unwrap_or_else(|_| {
-            fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
-            #halt
-        });
-        fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
+    // Q35 host bridge needs e820 data to compute MMIO windows.
+    let is_q35 = dev.driver.as_str() == "q35-hostbridge";
+
+    if is_q35 {
+        quote! {
+            #device.init_with_e820(&_e820_entries[.._e820_count]).unwrap_or_else(|_| {
+                fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
+                #halt
+            });
+            fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
+        }
+    } else {
+        quote! {
+            #device.init().unwrap_or_else(|_| {
+                fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
+                #halt
+            });
+            fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
+        }
     }
 }
 

--- a/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
@@ -195,25 +195,15 @@ pub(super) fn generate_pci_init(
 
     let device = format_ident!("{}", device_name);
 
-    // Q35 host bridge needs e820 data to compute MMIO windows.
-    let is_q35 = dev.driver.as_str() == "q35-hostbridge";
-
-    if is_q35 {
-        quote! {
-            #device.init_with_e820(&_e820_entries[.._e820_count]).unwrap_or_else(|_| {
-                fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
-                #halt
-            });
-            fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
-        }
-    } else {
-        quote! {
-            #device.init().unwrap_or_else(|_| {
-                fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
-                #halt
-            });
-            fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
-        }
+    // All PCI host bridges use Device::init(). Drivers that need e820
+    // data (e.g., Q35) read it from the global E820State populated by
+    // the MemoryDetect capability — no codegen special-casing needed.
+    quote! {
+        #device.init().unwrap_or_else(|_| {
+            fstart_log::error!("FATAL: PCI init failed ({})", #drv_name);
+            #halt
+        });
+        fstart_log::info!("PCI init complete: {} ({})", #device_name, #drv_name);
     }
 }
 
@@ -799,11 +789,14 @@ pub(super) fn generate_acpi_load(device_name: &str, halt: &TokenStream) -> Token
         {
             // 256 KiB buffer for ACPI tables — persists for the OS lifetime.
             // QEMU Q35 produces ~128 KiB of tables plus RSDP/alignment.
-            static mut _ACPI_LOAD_BUF: [u8; 256 * 1024] = [0u8; 256 * 1024];
-            let acpi_buf = unsafe { &raw mut _ACPI_LOAD_BUF };
+            // Uses UnsafeCell to avoid `static mut` deprecation.
+            static _ACPI_LOAD_BUF: core::cell::UnsafeCell<[u8; 256 * 1024]> =
+                core::cell::UnsafeCell::new([0u8; 256 * 1024]);
+            // SAFETY: single-threaded firmware init, buffer used exactly once.
+            let acpi_buf = unsafe { &mut *_ACPI_LOAD_BUF.get() };
             _acpi_rsdp_addr = fstart_capabilities::acpi_load(
                 &#dev_var,
-                unsafe { &mut *acpi_buf },
+                acpi_buf,
                 stringify!(#dev_var),
             ).unwrap_or_else(|_| {
                 fstart_log::error!("AcpiLoad: failed");
@@ -817,14 +810,16 @@ pub(super) fn generate_acpi_load(device_name: &str, halt: &TokenStream) -> Token
 ///
 /// Calls the device's `MemoryDetector::detect_memory()` method to read
 /// the system memory map at runtime (e.g., e820 from QEMU fw_cfg).
-/// Results are stored in `_e820_entries` / `_e820_count` / `_total_ram`
-/// for later use by the boot protocol (x86 zero page, FDT updates, etc.).
+/// Results are stored in the global `E820State` (accessible via
+/// `fstart_services::memory_detect::e820_state()`) for later use by
+/// PCI host bridges, boot protocol, and CrabEFI.
 pub(super) fn generate_memory_detect(device_name: &str, halt: &TokenStream) -> TokenStream {
     let dev_var = format_ident!("{}", device_name);
     quote! {
-        // MemoryDetect: discover system memory layout at runtime
+        // MemoryDetect: discover system memory layout at runtime.
+        // Results are stored in the global E820State for consumers.
         {
-            let (count, total) = fstart_capabilities::memory_detect(
+            let _ = fstart_capabilities::memory_detect(
                 &#dev_var,
                 &mut _e820_entries,
                 stringify!(#dev_var),
@@ -832,8 +827,6 @@ pub(super) fn generate_memory_detect(device_name: &str, halt: &TokenStream) -> T
                 fstart_log::error!("MemoryDetect: failed");
                 #halt
             });
-            _e820_count = count;
-            _total_ram = total;
         }
     }
 }

--- a/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/mod.rs
@@ -31,6 +31,8 @@ pub(super) use smbios::generate_smbios_prepare;
 #[allow(unused_imports)]
 pub(super) use stage_load::generate_anchor_scan;
 pub(super) use stage_load::generate_load_next_stage;
+// Note: generate_acpi_load and generate_memory_detect are defined in this module
+// (not in sub-modules) and are automatically visible to super.
 
 /// Generate code for the ConsoleInit capability.
 pub(super) fn generate_console_init(
@@ -417,10 +419,41 @@ pub(super) fn generate_boot_media(
 ) -> TokenStream {
     match medium {
         BootMedium::MemoryMapped { .. } => {
-            quote! {
-                let boot_media = unsafe {
-                    MemoryMapped::from_raw_addr(FLASH_BASE, FLASH_SIZE as usize)
-                };
+            if config.platform == Platform::X86_64 {
+                // x86_64 with code-model=large: copy FFS from flash to RAM
+                // before operating on it. The large code model makes every
+                // function call indirect (movabsq+callq), which is very slow
+                // for the tight loops in postcard deserialization and LZ4
+                // decompression. By copying the FFS to RAM first, the data
+                // pointers are in low memory and core::ptr::copy / memcpy
+                // operate on fast RAM instead of flash-mapped MMIO.
+                //
+                // The copy destination is above the kernel load address to
+                // avoid overlap. The kernel gets loaded later and overwrites
+                // only its own region.
+                quote! {
+                    // Copy FFS from flash to RAM for fast access
+                    let _ffs_ram_addr: u64 = 0x2000000; // 32 MiB — above typical kernel
+                    fstart_log::info!("copying FFS from flash {:#x} to RAM {:#x} ({} bytes)...",
+                        FLASH_BASE, _ffs_ram_addr, FLASH_SIZE);
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(
+                            FLASH_BASE as *const u8,
+                            _ffs_ram_addr as *mut u8,
+                            FLASH_SIZE as usize,
+                        );
+                    }
+                    fstart_log::info!("FFS copied to RAM");
+                    let boot_media = unsafe {
+                        MemoryMapped::from_raw_addr(_ffs_ram_addr, FLASH_SIZE as usize)
+                    };
+                }
+            } else {
+                quote! {
+                    let boot_media = unsafe {
+                        MemoryMapped::from_raw_addr(FLASH_BASE, FLASH_SIZE as usize)
+                    };
+                }
             }
         }
         BootMedium::Device { name, offset, size } => {
@@ -622,6 +655,8 @@ pub(super) fn generate_fdt_prepare(
                     // ARMv7: no DTB address saved by platform (board-specific).
                     // Use src_dtb_addr in the board RON instead.
                     Platform::Armv7 => quote! { 0u64 },
+                    // x86_64: no DTB from platform — use src_dtb_addr or 0.
+                    Platform::X86_64 => quote! { 0u64 },
                 }
             };
             let dtb_dst = hex_addr(payload.dtb_addr.unwrap_or(0));
@@ -733,6 +768,62 @@ fn generate_dram_expressions(
 pub(super) fn generate_late_driver_init() -> TokenStream {
     quote! {
         fstart_capabilities::late_driver_init_complete(0);
+    }
+}
+
+/// Generate code for the AcpiLoad capability.
+///
+/// Calls the device's `AcpiTableProvider::load_acpi_tables()` method to
+/// load pre-built ACPI tables (e.g., from QEMU fw_cfg) into a heap buffer.
+/// The buffer is leaked so tables persist for the OS. The RSDP physical
+/// address is stored in `_acpi_rsdp_addr` for later use by PayloadLoad.
+pub(super) fn generate_acpi_load(device_name: &str, halt: &TokenStream) -> TokenStream {
+    let dev_var = format_ident!("{}", device_name);
+    quote! {
+        // AcpiLoad: load ACPI tables from external provider
+        {
+            use fstart_services::acpi_provider::AcpiTableProvider;
+            // Allocate 256 KiB buffer for ACPI tables.
+            // QEMU Q35 produces ~128 KiB of tables plus RSDP/alignment.
+            static mut _ACPI_LOAD_BUF: [u8; 256 * 1024] = [0u8; 256 * 1024];
+            let acpi_buf = unsafe { &mut _ACPI_LOAD_BUF };
+            let rsdp = #dev_var.load_acpi_tables(acpi_buf)
+                .unwrap_or_else(|_| {
+                    fstart_log::error!("AcpiLoad: failed to load ACPI tables from '{}'", stringify!(#dev_var));
+                    #halt
+                });
+            // Store RSDP address for PayloadLoad
+            _acpi_rsdp_addr = rsdp;
+            fstart_log::info!("ACPI tables loaded, RSDP at {:#x}", rsdp);
+        }
+    }
+}
+
+/// Generate code for the MemoryDetect capability.
+///
+/// Calls the device's `MemoryDetector::detect_memory()` method to read
+/// the system memory map at runtime (e.g., e820 from QEMU fw_cfg).
+/// Results are stored in `_e820_entries` / `_e820_count` / `_total_ram`
+/// for later use by the boot protocol (x86 zero page, FDT updates, etc.).
+pub(super) fn generate_memory_detect(device_name: &str, halt: &TokenStream) -> TokenStream {
+    let dev_var = format_ident!("{}", device_name);
+    quote! {
+        // MemoryDetect: discover system memory layout at runtime
+        {
+            use fstart_services::memory_detect::MemoryDetector;
+            _e820_count = #dev_var.detect_memory(&mut _e820_entries)
+                .unwrap_or_else(|_| {
+                    fstart_log::error!("MemoryDetect: failed to detect memory from '{}'", stringify!(#dev_var));
+                    #halt
+                });
+            _total_ram = #dev_var.total_ram_bytes()
+                .unwrap_or_else(|_| {
+                    fstart_log::error!("MemoryDetect: failed to get total RAM from '{}'", stringify!(#dev_var));
+                    #halt
+                });
+            fstart_log::info!("Detected {} MiB RAM, {} e820 entries",
+                _total_ram >> 20, _e820_count);
+        }
     }
 }
 

--- a/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
@@ -131,11 +131,15 @@ fn generate_platform_boot_protocol(
                 fstart_log::info!("booting Linux (x86_64)...");
                 fstart_log::info!("  kernel @ {:#x}", #kernel_addr as u64);
                 // x86 Linux boot protocol: fill zero page and jump.
+                // e820 data comes from the global E820State (populated by
+                // MemoryDetect); passed as a slice for the boot protocol.
+                let _e820_state = unsafe { fstart_services::memory_detect::e820_state() };
                 fstart_platform::boot_linux(
                     #kernel_addr as u64,
                     _acpi_rsdp_addr,
-                    &_e820_entries[.._e820_count],
+                    _e820_state.entries(),
                     #bootargs_str,
+                    0x90000u64,  // zero_page_addr: conventional memory
                 );
             }
         }
@@ -503,14 +507,10 @@ fn generate_payload_load_uefi(
     // - x86_64: build from e820 entries (from MemoryDetect), carve firmware
     // - AArch64/RISC-V: build from static board config RAM region
     let memory_map_setup = if platform == Platform::X86_64 {
-        // x86_64: e820 entries are in _e820_entries[.._e820_count] from MemoryDetect.
-        // ROM entries come from the board config.
-        // Firmware data/stack addresses from stage config.
-        //
-        // fw_stack_addr = top of highest RAM below 4G minus stack_size.
-        // Since we don't know the exact RAM top at codegen time,
-        // the generated code computes it from the stage config.
+        // x86_64: e820 entries come from the global E820State populated by
+        // MemoryDetect.  ROM entries come from the board config.
         quote! {
+            let _e820_state = unsafe { fstart_services::memory_detect::e820_state() };
             let _rom_entries: &[fstart_crabefi::MemoryRegion] = &[
                 #static_mem_entries
             ];
@@ -529,7 +529,7 @@ fn generate_payload_load_uefi(
             // Instead, pass the entire RAM as ConventionalMemory and let
             // CrabEFI's allocator split it via runtime_region (below).
             let _mem_idx = fstart_crabefi::build_efi_memory_map_from_e820(
-                &_e820_entries[.._e820_count],
+                _e820_state.entries(),
                 0, 0,  // no firmware data hole
                 0, 0,  // no firmware stack hole
                 _rom_entries,

--- a/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
@@ -126,16 +126,16 @@ fn generate_platform_boot_protocol(
             }
         }
         Platform::X86_64 => {
+            let bootargs_str = payload.bootargs.as_deref().unwrap_or("console=ttyS0");
             quote! {
                 fstart_log::info!("booting Linux (x86_64)...");
                 fstart_log::info!("  kernel @ {:#x}", #kernel_addr as u64);
                 // x86 Linux boot protocol: fill zero page and jump.
-                // The boot_linux function drops to 32-bit protected mode,
-                // sets %esi = zero_page, and jumps to code32_start.
                 fstart_platform::boot_linux(
                     #kernel_addr as u64,
                     _acpi_rsdp_addr,
                     &_e820_entries[.._e820_count],
+                    #bootargs_str,
                 );
             }
         }

--- a/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
@@ -457,77 +457,177 @@ fn generate_payload_load_uefi(
         quote! {}
     };
 
+    // Platform-specific timer, reset, and RNG construction.
+    let (timer_setup, timer_field, reset_setup, reset_field, rng_setup, rng_field) = match platform
+    {
+        Platform::X86_64 => (
+            quote! {
+                let _crabefi_timer = fstart_crabefi::TscTimer::new();
+                fstart_log::info!("TSC timer initialized");
+            },
+            quote! { timer: &_crabefi_timer, },
+            quote! { let _crabefi_reset = fstart_crabefi::X86Reset; },
+            quote! { reset: &_crabefi_reset, },
+            quote! { let _crabefi_rng = fstart_crabefi::X86Rng::new(); },
+            quote! { rng: Some(&_crabefi_rng), },
+        ),
+        _ => (
+            quote! { let _crabefi_timer = fstart_crabefi::ArmGenericTimer::new(); },
+            quote! { timer: &_crabefi_timer, },
+            quote! { let _crabefi_reset = fstart_crabefi::PsciReset; },
+            quote! { reset: &_crabefi_reset, },
+            quote! {},
+            quote! { rng: None, },
+        ),
+    };
+
+    // ACPI RSDP: on x86_64, AcpiLoad provides _acpi_rsdp_addr.
+    let acpi_rsdp_field = if platform == Platform::X86_64 {
+        quote! { acpi_rsdp: Some(_acpi_rsdp_addr), }
+    } else {
+        quote! { acpi_rsdp: None, }
+    };
+
+    // Runtime region: on x86_64, tell CrabEFI's allocator to carve
+    // fstart's code (.text) as RuntimeServicesCode and everything else
+    // (rodata + data + BSS + page tables + IDT + stack) as
+    // RuntimeServicesData. These survive ExitBootServices so the kernel
+    // can access the EFI system table and runtime services.
+    let runtime_region_field = if platform == Platform::X86_64 {
+        quote! { Some(fstart_crabefi::compute_runtime_region()), }
+    } else {
+        quote! { None, }
+    };
+
+    // Memory map construction is platform-specific:
+    // - x86_64: build from e820 entries (from MemoryDetect), carve firmware
+    // - AArch64/RISC-V: build from static board config RAM region
+    let memory_map_setup = if platform == Platform::X86_64 {
+        // x86_64: e820 entries are in _e820_entries[.._e820_count] from MemoryDetect.
+        // ROM entries come from the board config.
+        // Firmware data/stack addresses from stage config.
+        //
+        // fw_stack_addr = top of highest RAM below 4G minus stack_size.
+        // Since we don't know the exact RAM top at codegen time,
+        // the generated code computes it from the stage config.
+        quote! {
+            let _rom_entries: &[fstart_crabefi::MemoryRegion] = &[
+                #static_mem_entries
+            ];
+
+            // 64 entries: up to 128 e820 entries can be split by firmware
+            // regions, plus ROM entries. 64 should be more than enough.
+            let mut _crabefi_mem_buf: [fstart_crabefi::MemoryRegion; 64] = [
+                fstart_crabefi::MemoryRegion {
+                    base: 0, size: 0,
+                    region_type: fstart_crabefi::MemoryType::Reserved,
+                };
+                64
+            ];
+
+            // Do NOT carve firmware holes in the initial e820 map.
+            // Instead, pass the entire RAM as ConventionalMemory and let
+            // CrabEFI's allocator split it via runtime_region (below).
+            let _mem_idx = fstart_crabefi::build_efi_memory_map_from_e820(
+                &_e820_entries[.._e820_count],
+                0, 0,  // no firmware data hole
+                0, 0,  // no firmware stack hole
+                _rom_entries,
+                &mut _crabefi_mem_buf,
+            );
+
+            let _crabefi_memory_map: &[fstart_crabefi::MemoryRegion] =
+                &_crabefi_mem_buf[.._mem_idx];
+            fstart_log::info!("EFI memory map: {} entries", _mem_idx as u32);
+        }
+    } else {
+        // AArch64/RISC-V: static RAM region from board config.
+        quote! {
+            let _static_entries: &[fstart_crabefi::MemoryRegion] = &[
+                #static_mem_entries
+            ];
+
+            let mut _crabefi_mem_buf: [fstart_crabefi::MemoryRegion; 12] = [
+                fstart_crabefi::MemoryRegion {
+                    base: 0, size: 0,
+                    region_type: fstart_crabefi::MemoryType::Reserved,
+                };
+                12
+            ];
+
+            let _mem_idx = fstart_crabefi::build_efi_memory_map(
+                _static_entries,
+                #ram_base_lit,
+                #ram_size_lit,
+                #fw_data_addr_lit,
+                #fw_stack_size_lit,
+                #fw_stack_size_lit,
+                _fdt_reservation,
+                &mut _crabefi_mem_buf,
+            );
+
+            let _crabefi_memory_map: &[fstart_crabefi::MemoryRegion] =
+                &_crabefi_mem_buf[.._mem_idx];
+            fstart_log::info!("EFI memory map: {} entries", _mem_idx as u32);
+        }
+    };
+
+    // FDT reservation is only needed on non-x86 platforms.
+    let fdt_reservation_setup = if platform != Platform::X86_64 {
+        quote! {
+            let _fdt_reservation = if _fdt_addr != 0 {
+                let fdt_size = unsafe {
+                    fstart_crabefi::fdt_page_aligned_size(_fdt_addr)
+                };
+                Some((_fdt_addr, fdt_size))
+            } else {
+                None
+            };
+        }
+    } else {
+        quote! {}
+    };
+
     quote! {
         fstart_log::info!("Launching CrabEFI UEFI payload...");
 
         #bl31_boot
 
-        let _crabefi_timer = fstart_crabefi::ArmGenericTimer::new();
-        let _crabefi_reset = fstart_crabefi::PsciReset;
+        #timer_setup
+        #reset_setup
+        #rng_setup
         #console_setup
 
         // Determine FDT address and prepare the blob.
         #fdt_setup
 
-        // FDT reservation: if an FDT is present, read its page-aligned
-        // size so build_efi_memory_map() can carve it out.
-        let _fdt_reservation = if _fdt_addr != 0 {
-            let fdt_size = unsafe {
-                fstart_crabefi::fdt_page_aligned_size(_fdt_addr)
-            };
-            Some((_fdt_addr, fdt_size))
-        } else {
-            None
-        };
+        #fdt_reservation_setup
 
         // Build the EFI memory map.
-        let _static_entries: &[fstart_crabefi::MemoryRegion] = &[
-            #static_mem_entries
-        ];
-
-        let mut _crabefi_mem_buf: [fstart_crabefi::MemoryRegion; 12] = [
-            fstart_crabefi::MemoryRegion {
-                base: 0, size: 0,
-                region_type: fstart_crabefi::MemoryType::Reserved,
-            };
-            12
-        ];
-
-        let _mem_idx = fstart_crabefi::build_efi_memory_map(
-            _static_entries,
-            #ram_base_lit,
-            #ram_size_lit,
-            #fw_data_addr_lit,
-            #fw_stack_size_lit,
-            #fw_stack_size_lit,
-            _fdt_reservation,
-            &mut _crabefi_mem_buf,
-        );
-
-        let _crabefi_memory_map: &[fstart_crabefi::MemoryRegion] =
-            &_crabefi_mem_buf[.._mem_idx];
-        fstart_log::info!("EFI memory map: {} entries", _mem_idx as u32);
+        #memory_map_setup
 
         #fb_setup
 
         let _crabefi_config = fstart_crabefi::PlatformConfig {
             memory_map: _crabefi_memory_map,
-            timer: &_crabefi_timer,
-            reset: &_crabefi_reset,
+            #timer_field
+            #reset_field
             block_devices: &mut [],
             variable_backend: None,
             #debug_output_field
             console_input: None,
             #framebuffer_field
-            acpi_rsdp: None,
+            #acpi_rsdp_field
             smbios: None,
             #fdt_field
-            rng: None,
+            #rng_field
             #ecam_base_field
             deferred_buffer: None,
-            runtime_region: None,
+            runtime_region: #runtime_region_field
             heap_pre_initialized: false,
         };
+
+        fstart_log::info!("EFI memory map: {} entries, calling init_platform...", _mem_idx as u32);
 
         // init_platform() is -> ! (never returns).
         fstart_crabefi::init_platform(_crabefi_config);

--- a/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
+++ b/crates/fstart-codegen/src/stage_gen/capabilities/payload.rs
@@ -125,6 +125,20 @@ fn generate_platform_boot_protocol(
                 fstart_platform::boot_linux(#kernel_addr as u64, #dtb_addr);
             }
         }
+        Platform::X86_64 => {
+            quote! {
+                fstart_log::info!("booting Linux (x86_64)...");
+                fstart_log::info!("  kernel @ {:#x}", #kernel_addr as u64);
+                // x86 Linux boot protocol: fill zero page and jump.
+                // The boot_linux function drops to 32-bit protected mode,
+                // sets %esi = zero_page, and jumps to code32_start.
+                fstart_platform::boot_linux(
+                    #kernel_addr as u64,
+                    _acpi_rsdp_addr,
+                    &_e820_entries[.._e820_count],
+                );
+            }
+        }
     }
 }
 
@@ -388,7 +402,7 @@ fn generate_payload_load_uefi(
             Platform::Aarch64 | Platform::Riscv64 => {
                 quote! { fstart_platform::boot_dtb_addr() }
             }
-            Platform::Armv7 => quote! { 0u64 },
+            Platform::Armv7 | Platform::X86_64 => quote! { 0u64 },
         }
     };
 
@@ -402,7 +416,7 @@ fn generate_payload_load_uefi(
                     unsafe { fstart_capabilities::fdt_blob_from_addr(_fdt_addr) };
             }
         }
-        Platform::Armv7 => quote! {
+        Platform::Armv7 | Platform::X86_64 => quote! {
             let _fdt_addr: u64 = 0;
             let _fdt_blob: Option<&[u8]> = None;
         },

--- a/crates/fstart-codegen/src/stage_gen/config_ser.rs
+++ b/crates/fstart-codegen/src/stage_gen/config_ser.rs
@@ -35,7 +35,7 @@ pub(super) fn serialize_to_tokens<T: Serialize>(value: &T) -> TokenStream {
 ///
 /// Returns tokens like:
 /// ```text
-/// Ns16550Config { base_addr: 0x10000000, clock_freq: 3686400u32, baud_rate: 115200u32 }
+/// Ns16550Config { regs: Mmio(0x10000000, 0, 0), clock_freq: 3686400u32, baud_rate: 115200u32 }
 /// ```
 ///
 /// This delegates to [`DriverInstance::serialize_config`] with a custom

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -688,9 +688,10 @@ fn generate_fstart_main(
     }
     if has_memory_detect {
         body.extend(quote! {
+            // Buffer for memory_detect() output. The detected entries are
+            // also stored in the global E820State for consumers (PCI host
+            // bridge, boot protocol, CrabEFI).
             let mut _e820_entries = [fstart_services::memory_detect::E820Entry::zeroed(); 128];
-            let mut _e820_count: usize = 0;
-            let mut _total_ram: u64 = 0;
         });
     }
 

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -155,15 +155,35 @@ pub fn generate_stage_source(parsed: &ParsedBoard, stage_name: Option<&str>) -> 
         ));
     }
 
+    // Bus children (e.g., PCI child devices) are only constructed in
+    // stages with DriverInit. For bootblock stages without DriverInit,
+    // exclude these from the Devices struct and StageContext.
+    let has_driver_init = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::DriverInit));
+    let excluded_indices: Vec<usize> = if !has_driver_init {
+        parsed
+            .device_tree
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| node.parent.is_some())
+            .map(|(idx, _)| idx)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     tokens.extend(generate_devices_struct(
         &config.devices,
         &parsed.driver_instances,
         mode,
+        &excluded_indices,
     ));
     tokens.extend(generate_stage_context(
         &config.devices,
         &parsed.driver_instances,
         mode,
+        &excluded_indices,
     ));
     tokens.extend(generate_device_tree_table(&parsed.device_tree));
     tokens.extend(generate_fstart_main(
@@ -531,16 +551,20 @@ fn generate_device_tree_table(tree: &[DeviceNode]) -> TokenStream {
 /// Emit the `Devices` struct — one concrete typed field per device.
 ///
 /// ACPI-only devices (no runtime driver) are excluded.
+/// `excluded_indices` are device indices that this stage won't construct
+/// (e.g., bus children in stages without DriverInit).
 fn generate_devices_struct(
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
     mode: BuildMode,
+    excluded_indices: &[usize],
 ) -> TokenStream {
     let fields = devices
         .iter()
         .zip(instances.iter())
-        .filter(|(_, inst)| !inst.is_acpi_only())
-        .map(|(dev, inst)| {
+        .enumerate()
+        .filter(|(idx, (_, inst))| !inst.is_acpi_only() && !excluded_indices.contains(idx))
+        .map(|(_, (dev, inst))| {
             let field_name = format_ident!("{}", dev.name.as_str());
             let meta = inst.meta();
 
@@ -571,12 +595,12 @@ fn generate_stage_context(
     devices: &[DeviceConfig],
     instances: &[DriverInstance],
     mode: BuildMode,
+    excluded_indices: &[usize],
 ) -> TokenStream {
     let accessors = SERVICE_TRAITS.iter().filter_map(|svc| {
-        let (idx, dev) = devices
-            .iter()
-            .enumerate()
-            .find(|(_, d)| d.services.iter().any(|s| s.as_str() == svc.name))?;
+        let (idx, dev) = devices.iter().enumerate().find(|(idx, d)| {
+            !excluded_indices.contains(idx) && d.services.iter().any(|s| s.as_str() == svc.name)
+        })?;
         let _inst = &instances[idx];
         let accessor_name = format_ident!("{}", svc.accessor);
         let field = format_ident!("{}", dev.name.as_str());
@@ -915,12 +939,27 @@ fn generate_fstart_main(
         )
     });
 
+    // Determine which devices are excluded (bus children in stages without
+    // DriverInit — they're never constructed).
+    let has_driver_init_cap = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::DriverInit));
     let device_fields = config
         .devices
         .iter()
         .zip(instances.iter())
-        .filter(|(_, inst)| !inst.is_acpi_only())
-        .map(|(dev, _)| {
+        .enumerate()
+        .filter(|(idx, (_, inst))| {
+            if inst.is_acpi_only() {
+                return false;
+            }
+            // Exclude bus children when this stage doesn't have DriverInit
+            if !has_driver_init_cap && device_tree[*idx].parent.is_some() {
+                return false;
+            }
+            true
+        })
+        .map(|(_, (dev, _))| {
             let name = format_ident!("{}", dev.name.as_str());
             quote! { #name: #name, }
         });

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -134,7 +134,7 @@ pub fn generate_stage_source(parsed: &ParsedBoard, stage_name: Option<&str>) -> 
         }
     }
 
-    if let Some(BootMedium::MemoryMapped { base, size }) = get_boot_medium(capabilities) {
+    if let Some(BootMedium::MemoryMapped { base, size, .. }) = get_boot_medium(capabilities) {
         tokens.extend(generate_flash_constants(*base, *size));
     }
 

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -256,6 +256,13 @@ fn generate_imports(
         tokens.extend(quote! { use fstart_services::MemoryController; });
     }
 
+    // BusDevice trait is needed when any device has a parent bus (e.g., PCI
+    // child devices use BusDevice::new_on_bus).
+    let has_bus_children = devices.iter().any(|d| d.parent.is_some());
+    if has_bus_children {
+        tokens.extend(quote! { use fstart_services::device::BusDevice; });
+    }
+
     let has_i2c = devices
         .iter()
         .any(|d| d.services.iter().any(|s| s.as_str() == "I2cBus"));
@@ -350,15 +357,9 @@ fn generate_imports(
         tokens.extend(quote! { use fstart_services::acpi_provider::AcpiTableProvider; });
     }
 
-    // MemoryDetect needs the MemoryDetector trait and E820Entry type
-    let uses_memory_detect = capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::MemoryDetect { .. }));
-    if uses_memory_detect {
-        tokens.extend(quote! {
-            use fstart_services::memory_detect::MemoryDetector;
-        });
-    }
+    // MemoryDetect: E820Entry type is used in the generated variable
+    // declarations. The MemoryDetector trait itself is imported by the
+    // fstart_capabilities::memory_detect() function, not the generated code.
 
     // FDT patching no longer requires alloc — the raw FDT patcher
     // operates directly on the blob without heap allocation.
@@ -691,22 +692,29 @@ fn generate_fstart_main(
         });
     }
 
-    // --- Phase 1: Construct all devices in topological order ---
+    // --- Phase 1: Construct root devices (no parent bus) ---
+    //
+    // Bus children (e.g., PCI devices) are deferred to Phase 2 because
+    // their construction reads BARs from the parent bus, which must be
+    // initialized first (via PciInit or similar capability).
+    //
     // Devices are already in pre-order DFS order from RON flattening.
     // ACPI-only devices are skipped — they have no runtime driver.
+    let mut deferred_children: Vec<usize> = Vec::new();
     for (idx, node) in device_tree.iter().enumerate() {
-        let dev = &config.devices[idx];
         let inst = &instances[idx];
         if inst.is_acpi_only() {
             continue;
         }
-        let parent_name = node
-            .parent
-            .map(|pid| config.devices[pid as usize].name.as_str());
+        if node.parent.is_some() {
+            // Bus child — defer to after parent is initialized.
+            deferred_children.push(idx);
+            continue;
+        }
         body.extend(generate_device_construction(
-            dev,
+            &config.devices[idx],
             inst,
-            parent_name,
+            None,
             &halt,
             mode,
         ));
@@ -769,6 +777,25 @@ fn generate_fstart_main(
                 inited_devices.push(dev_name.to_string());
             }
             Capability::DriverInit => {
+                // Construct any remaining deferred bus children before
+                // DriverInit runs. By this point all parent devices
+                // are constructed and initialized (via PciInit or
+                // similar capability), so bus children can read BARs.
+                for &idx in &deferred_children {
+                    let dev = &config.devices[idx];
+                    let inst = &instances[idx];
+                    let parent_name = device_tree[idx]
+                        .parent
+                        .map(|pid| config.devices[pid as usize].name.as_str());
+                    body.extend(generate_device_construction(
+                        dev,
+                        inst,
+                        parent_name,
+                        &halt,
+                        mode,
+                    ));
+                }
+                deferred_children.clear();
                 // Devices are in pre-order DFS — sequential indices are
                 // already topological order.
                 let sequential: Vec<usize> = (0..config.devices.len()).collect();

--- a/crates/fstart-codegen/src/stage_gen/mod.rs
+++ b/crates/fstart-codegen/src/stage_gen/mod.rs
@@ -41,11 +41,12 @@ use fstart_types::{
 use crate::ron_loader::ParsedBoard;
 
 use capabilities::{
-    collect_boot_media_gated_devices, generate_acpi_prepare, generate_boot_media,
-    generate_clock_init, generate_console_init, generate_dram_init, generate_driver_init,
-    generate_fdt_prepare, generate_late_driver_init, generate_load_next_stage,
-    generate_memory_init, generate_payload_load, generate_pci_init, generate_return_to_fel,
-    generate_sig_verify, generate_smbios_prepare, generate_stage_load,
+    collect_boot_media_gated_devices, generate_acpi_load, generate_acpi_prepare,
+    generate_boot_media, generate_clock_init, generate_console_init, generate_dram_init,
+    generate_driver_init, generate_fdt_prepare, generate_late_driver_init,
+    generate_load_next_stage, generate_memory_detect, generate_memory_init, generate_payload_load,
+    generate_pci_init, generate_return_to_fel, generate_sig_verify, generate_smbios_prepare,
+    generate_stage_load,
 };
 use config_ser::{config_tokens, driver_type_tokens};
 use flexible::{flexible_enum_for_device, generate_flexible_enums, SERVICE_TRAITS};
@@ -208,6 +209,9 @@ fn generate_platform_externs(platform: Platform) -> TokenStream {
         Platform::Armv7 => {
             quote! { extern crate fstart_platform_armv7 as fstart_platform; }
         }
+        Platform::X86_64 => {
+            quote! { extern crate fstart_platform_x86_64 as fstart_platform; }
+        }
     };
     quote! {
         #platform_crate
@@ -336,6 +340,24 @@ fn generate_imports(
             }
         }
         None => {}
+    }
+
+    // AcpiLoad needs the AcpiTableProvider trait
+    let uses_acpi_load = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::AcpiLoad { .. }));
+    if uses_acpi_load {
+        tokens.extend(quote! { use fstart_services::acpi_provider::AcpiTableProvider; });
+    }
+
+    // MemoryDetect needs the MemoryDetector trait and E820Entry type
+    let uses_memory_detect = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::MemoryDetect { .. }));
+    if uses_memory_detect {
+        tokens.extend(quote! {
+            use fstart_services::memory_detect::MemoryDetector;
+        });
     }
 
     // FDT patching no longer requires alloc — the raw FDT patcher
@@ -624,6 +646,29 @@ fn generate_fstart_main(
     let halt = halt_expr(platform);
     let mut body = TokenStream::new();
 
+    // --- Pre-phase: Declare mutable state for cross-capability communication ---
+    // These variables are written by one capability and read by another (e.g.,
+    // MemoryDetect writes e820 entries, PayloadLoad reads them for the zero page).
+    let has_acpi_load = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::AcpiLoad { .. }));
+    let has_memory_detect = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::MemoryDetect { .. }));
+
+    if has_acpi_load {
+        body.extend(quote! {
+            let mut _acpi_rsdp_addr: u64 = 0;
+        });
+    }
+    if has_memory_detect {
+        body.extend(quote! {
+            let mut _e820_entries = [fstart_services::memory_detect::E820Entry::zeroed(); 128];
+            let mut _e820_count: usize = 0;
+            let mut _total_ram: u64 = 0;
+        });
+    }
+
     // --- Phase 0: Handoff deserialization (non-first stages only) ---
     // For multi-stage boards, non-first stages receive a serialized
     // StageHandoff in r0 (ARMv7) from the previous stage.
@@ -796,6 +841,14 @@ fn generate_fstart_main(
             }
             Capability::SmBiosPrepare => {
                 body.extend(generate_smbios_prepare(config));
+            }
+            Capability::AcpiLoad { device } => {
+                let dev_name = device.as_str();
+                body.extend(generate_acpi_load(dev_name, &halt));
+            }
+            Capability::MemoryDetect { device } => {
+                let dev_name = device.as_str();
+                body.extend(generate_memory_detect(dev_name, &halt));
             }
             Capability::ReturnToFel => {
                 body.extend(generate_return_to_fel(platform));

--- a/crates/fstart-codegen/src/stage_gen/registry.rs
+++ b/crates/fstart-codegen/src/stage_gen/registry.rs
@@ -168,4 +168,13 @@ const KNOWN_DRIVER_META: &[DriverMeta] = &[
         compatible: &["bochs-display", "qemu-stdvga"],
         has_acpi: false,
     },
+    DriverMeta {
+        name: "q35-hostbridge",
+        type_name: "Q35HostBridge",
+        module_path: "fstart_driver_q35_hostbridge",
+        config_type: "Q35HostBridgeConfig",
+        services: &["PciRootBus"],
+        compatible: &["q35-hostbridge"],
+        has_acpi: false,
+    },
 ];

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -26,6 +26,7 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     )];
 
@@ -387,6 +388,7 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         }),
         DriverInstance::DesignwareI2c(fstart_driver_designware_i2c::DesignwareI2cConfig {
             base_addr: 0x1004_0000,
@@ -690,6 +692,7 @@ fn test_driver_init_with_bus_hierarchy_inits_parent_first() {
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     // i2c0 is at index 1
@@ -748,6 +751,7 @@ fn test_non_bus_parent_is_compile_error() {
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     // uart0 is at index 0
@@ -819,6 +823,7 @@ fn test_flexible_multi_driver_parsed_board(
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         }),
         DriverInstance::Pl011(fstart_driver_pl011::Pl011Config {
             base_addr: 0x0900_0000,
@@ -1148,6 +1153,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     )];
 
@@ -1462,6 +1468,7 @@ fn test_device_tree_table_with_bus_children() {
             baud_rate: 115_200,
             reg_shift: 0,
             reg_width: 0,
+            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     parsed.device_tree.push(DeviceNode {

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -21,7 +21,11 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
 
     let driver_instances = vec![DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x1000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         },
@@ -52,6 +56,7 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
             heap_size: None,
             data_addr: None,
             page_table_addr: None,
+            page_size: fstart_types::stage::PageSize::default(),
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -385,7 +390,11 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
 
     let driver_instances = vec![
         DriverInstance::Ns16550(fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x1000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         }),
@@ -421,6 +430,7 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
             heap_size: None,
             data_addr: None,
             page_table_addr: None,
+            page_size: fstart_types::stage::PageSize::default(),
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -687,7 +697,11 @@ fn test_driver_init_with_bus_hierarchy_inits_parent_first() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x2000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         },
@@ -743,7 +757,11 @@ fn test_non_bus_parent_is_compile_error() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x2000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         },
@@ -812,7 +830,11 @@ fn test_flexible_multi_driver_parsed_board(
 
     let driver_instances = vec![
         DriverInstance::Ns16550(fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x1000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         }),
@@ -851,6 +873,7 @@ fn test_flexible_multi_driver_parsed_board(
             heap_size: None,
             data_addr: None,
             page_table_addr: None,
+            page_size: fstart_types::stage::PageSize::default(),
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -1140,7 +1163,11 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
 
     let driver_instances = vec![DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x1000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         },
@@ -1171,6 +1198,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
         runs_from: RunsFrom::Ram,
         data_addr: None,
         page_table_addr: None,
+        page_size: fstart_types::stage::PageSize::default(),
     });
     let _ = stages.push(StageConfig {
         name: HString::try_from("main").unwrap(),
@@ -1189,6 +1217,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
         runs_from: RunsFrom::Ram,
         data_addr: None,
         page_table_addr: None,
+        page_size: fstart_types::stage::PageSize::default(),
     });
 
     let config = BoardConfig {
@@ -1456,7 +1485,11 @@ fn test_device_tree_table_with_bus_children() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
+            regs: fstart_driver_ns16550::AccessMode::Mmio {
+                base: 0x2000_0000,
+                reg_shift: 0,
+                reg_width: 0,
+            },
             clock_freq: 3_686_400,
             baud_rate: 115_200,
         },

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -51,6 +51,7 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
             stack_size: 0x10000,
             heap_size: None,
             data_addr: None,
+            page_table_addr: None,
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -166,6 +167,7 @@ fn test_sig_verify_generates_call() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x8000_0000,
         size: 0x40_0000,
+        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::SigVerify);
     let parsed = test_parsed_board(caps);
@@ -207,6 +209,7 @@ fn test_sig_verify_with_flash_base_generates_constants() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x0,
         size: 0x800_0000,
+        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::SigVerify);
     let parsed = test_parsed_board(caps);
@@ -235,6 +238,7 @@ fn test_stage_load_generates_call() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x2000_0000,
         size: 0x200_0000,
+        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::StageLoad {
         next_stage: heapless::String::try_from("main").unwrap(),
@@ -269,6 +273,7 @@ fn test_stage_load_with_flash_base_generates_real_call() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x8000_0000,
         size: 0x40_0000,
+        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::StageLoad {
         next_stage: heapless::String::try_from("main").unwrap(),
@@ -415,6 +420,7 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
             stack_size: 0x10000,
             heap_size: None,
             data_addr: None,
+            page_table_addr: None,
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -844,6 +850,7 @@ fn test_flexible_multi_driver_parsed_board(
             stack_size: 0x10000,
             heap_size: None,
             data_addr: None,
+            page_table_addr: None,
         }),
         security: SecurityConfig {
             signing_algorithm: SignatureAlgorithm::Ed25519,
@@ -1150,6 +1157,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
             let _ = v.push(Capability::BootMedia(BootMedium::MemoryMapped {
                 base: 0x2000_0000,
                 size: 0x200_0000,
+                ram_copy_addr: None,
             }));
             let _ = v.push(Capability::SigVerify);
             let _ = v.push(Capability::StageLoad {
@@ -1162,6 +1170,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
         heap_size: None,
         runs_from: RunsFrom::Ram,
         data_addr: None,
+        page_table_addr: None,
     });
     let _ = stages.push(StageConfig {
         name: HString::try_from("main").unwrap(),
@@ -1179,6 +1188,7 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
         heap_size: None,
         runs_from: RunsFrom::Ram,
         data_addr: None,
+        page_table_addr: None,
     });
 
     let config = BoardConfig {
@@ -1361,6 +1371,7 @@ fn test_stage_ending_with_payload_load_no_completion() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x2000_0000,
         size: 0x200_0000,
+        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::PayloadLoad);
     let parsed = test_parsed_board(caps);

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -21,12 +21,9 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
 
     let driver_instances = vec![DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x1000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     )];
 
@@ -383,12 +380,9 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
 
     let driver_instances = vec![
         DriverInstance::Ns16550(fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x1000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         }),
         DriverInstance::DesignwareI2c(fstart_driver_designware_i2c::DesignwareI2cConfig {
             base_addr: 0x1004_0000,
@@ -687,12 +681,9 @@ fn test_driver_init_with_bus_hierarchy_inits_parent_first() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x2000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     // i2c0 is at index 1
@@ -746,12 +737,9 @@ fn test_non_bus_parent_is_compile_error() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x2000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     // uart0 is at index 0
@@ -818,12 +806,9 @@ fn test_flexible_multi_driver_parsed_board(
 
     let driver_instances = vec![
         DriverInstance::Ns16550(fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x1000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         }),
         DriverInstance::Pl011(fstart_driver_pl011::Pl011Config {
             base_addr: 0x0900_0000,
@@ -1148,12 +1133,9 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
 
     let driver_instances = vec![DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x1000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x1000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     )];
 
@@ -1463,12 +1445,9 @@ fn test_device_tree_table_with_bus_children() {
     });
     parsed.driver_instances.push(DriverInstance::Ns16550(
         fstart_driver_ns16550::Ns16550Config {
-            base_addr: 0x2000_0000,
+            regs: fstart_driver_ns16550::AccessMode::Mmio(0x2000_0000, 0, 0),
             clock_freq: 3_686_400,
             baud_rate: 115_200,
-            reg_shift: 0,
-            reg_width: 0,
-            access_mode: fstart_driver_ns16550::AccessMode::Mmio,
         },
     ));
     parsed.device_tree.push(DeviceNode {

--- a/crates/fstart-codegen/src/stage_gen/validation.rs
+++ b/crates/fstart-codegen/src/stage_gen/validation.rs
@@ -150,6 +150,20 @@ pub(super) fn validate_capability_ordering(
                         .to_string(),
                 );
             }
+            Capability::AcpiLoad { .. } if !console_inited => {
+                return Some(
+                    "AcpiLoad capability requires ConsoleInit to appear earlier \
+                     in the capability list (needed for logging)"
+                        .to_string(),
+                );
+            }
+            Capability::MemoryDetect { .. } if !console_inited => {
+                return Some(
+                    "MemoryDetect capability requires ConsoleInit to appear earlier \
+                     in the capability list (needed for logging)"
+                        .to_string(),
+                );
+            }
             _ => {}
         }
     }

--- a/crates/fstart-crabefi/Cargo.toml
+++ b/crates/fstart-crabefi/Cargo.toml
@@ -7,3 +7,6 @@ license.workspace = true
 [dependencies]
 fstart-services = { workspace = true }
 crabefi = { path = "../../../CrabEFI", default-features = false }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+fstart-pio = { workspace = true }

--- a/crates/fstart-crabefi/src/lib.rs
+++ b/crates/fstart-crabefi/src/lib.rs
@@ -172,6 +172,11 @@ pub fn build_efi_memory_map(
     }
 
     // 3. Firmware BSS/data/heap -- RuntimeServicesData.
+    //    CrabEFI's EFI system table, runtime services, and ACPI pointers
+    //    live in fstart's BSS/stack and must survive ExitBootServices.
+    //    The caller must 2 MiB-align data_addr and stack regions to avoid
+    //    NX page-table conflicts (STRICT_KERNEL_RWX marks whole 2 MiB
+    //    pages containing RuntimeServicesData as NX).
     buf[idx] = MemoryRegion {
         base: fw_data_addr,
         size: fw_bss_reserve,
@@ -189,7 +194,7 @@ pub fn build_efi_memory_map(
         idx += 1;
     }
 
-    // 5. Firmware stack -- RuntimeServicesData (top of RAM, grows down).
+    // 5. Firmware stack -- RuntimeServicesData.
     buf[idx] = MemoryRegion {
         base: fw_stack_bottom,
         size: fw_stack_size,
@@ -198,6 +203,40 @@ pub fn build_efi_memory_map(
     idx += 1;
 
     idx
+}
+
+// Re-export types for codegen convenience.
+pub use crabefi::RuntimeRegion;
+pub use fstart_services::memory_detect::E820Entry;
+
+/// Compute the runtime memory region from linker-provided symbols.
+///
+/// Splits fstart's memory into code (RuntimeServicesCode) and data
+/// (RuntimeServicesData) so the OS kernel can mark them with the
+/// correct page protections after ExitBootServices.
+///
+/// Uses `_text_start`, `_text_end`, and `_stack_top` linker symbols.
+/// All boundaries are page-aligned (4 KiB).
+#[cfg(target_arch = "x86_64")]
+pub fn compute_runtime_region() -> RuntimeRegion {
+    extern "C" {
+        static _text_start: u8;
+        static _text_end: u8;
+        static _stack_top: u8;
+    }
+    const PAGE: u64 = 0x1000;
+    // SAFETY: these are linker-defined symbols — their addresses (not
+    // values) delimit the stage's text and stack regions.
+    let code_base = unsafe { &_text_start as *const u8 as u64 } & !(PAGE - 1);
+    let code_end = (unsafe { &_text_end as *const u8 as u64 } + PAGE - 1) & !(PAGE - 1);
+    let data_base = code_end;
+    let data_end = (unsafe { &_stack_top as *const u8 as u64 } + PAGE - 1) & !(PAGE - 1);
+    RuntimeRegion {
+        code_base,
+        code_size: code_end - code_base,
+        data_base,
+        data_size: data_end - data_base,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -295,4 +334,430 @@ impl crabefi::ResetHandler for PsciReset {
             core::hint::spin_loop();
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// x86_64 TSC Timer → CrabEFI Timer adapter
+// ---------------------------------------------------------------------------
+
+/// CrabEFI [`Timer`](crabefi::Timer) backed by the x86 TSC.
+///
+/// Calibrates the TSC frequency using the 8254 PIT (Programmable Interval
+/// Timer) channel 2. Works on QEMU and all modern x86 hardware.
+///
+/// The PIT runs at a fixed 1.193182 MHz. We program channel 2 for a
+/// known interval, measure the TSC delta, and compute tsc_freq.
+#[cfg(target_arch = "x86_64")]
+pub struct TscTimer {
+    tsc_freq: u64,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Default for TscTimer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl TscTimer {
+    /// PIT oscillator frequency: 1.193182 MHz.
+    const PIT_FREQ: u64 = 1_193_182;
+
+    /// PIT command register.
+    const PIT_CMD: u16 = 0x43;
+
+    /// Create a new timer by calibrating TSC against the PIT.
+    pub fn new() -> Self {
+        let tsc_freq = Self::calibrate_tsc();
+        Self { tsc_freq }
+    }
+
+    /// Read the Time Stamp Counter.
+    #[inline]
+    fn rdtsc() -> u64 {
+        let lo: u32;
+        let hi: u32;
+        unsafe {
+            core::arch::asm!(
+                "rdtsc",
+                out("eax") lo,
+                out("edx") hi,
+                options(nomem, nostack, preserves_flags)
+            );
+        }
+        ((hi as u64) << 32) | (lo as u64)
+    }
+
+    /// Calibrate TSC using PIT channel 0 count-down.
+    ///
+    /// Programs PIT channel 0 with a known count, reads the counter
+    /// back via latch commands to measure elapsed PIT ticks, and
+    /// computes the TSC frequency from the ratio.
+    ///
+    /// This approach avoids the speaker gate (port 0x61 bit 5) which
+    /// is unreliable on QEMU Q35 in KVM mode.
+    fn calibrate_tsc() -> u64 {
+        unsafe {
+            // Program channel 0: mode 2 (rate generator), binary,
+            // lobyte/hibyte access. Mode 2 counts down repeatedly.
+            fstart_pio::outb(Self::PIT_CMD, 0x34); // ch0, lobyte/hibyte, mode 2, binary
+
+            // Load a large count — 0xFFFF gives ~54.9 ms period.
+            fstart_pio::outb(0x40, 0xFF); // ch0 low byte
+            fstart_pio::outb(0x40, 0xFF); // ch0 high byte
+
+            // Small delay for count to load
+            for _ in 0..100 {
+                core::hint::spin_loop();
+            }
+
+            // Latch channel 0 and read starting count
+            fstart_pio::outb(Self::PIT_CMD, 0x00); // latch ch0
+            let lo = fstart_pio::inb(0x40) as u16;
+            let hi = fstart_pio::inb(0x40) as u16;
+            let count_start = (hi << 8) | lo;
+
+            let tsc_start = Self::rdtsc();
+
+            // Busy-wait for ~25000 PIT ticks (~20.9 ms)
+            let target_pit_ticks: u16 = 25000;
+            loop {
+                fstart_pio::outb(Self::PIT_CMD, 0x00); // latch ch0
+                let lo = fstart_pio::inb(0x40) as u16;
+                let hi = fstart_pio::inb(0x40) as u16;
+                let count_now = (hi << 8) | lo;
+
+                // Mode 2 counts down from loaded value. Elapsed =
+                // start - now (wraps handled by u16 subtraction).
+                let elapsed = count_start.wrapping_sub(count_now);
+                if elapsed >= target_pit_ticks {
+                    break;
+                }
+                core::hint::spin_loop();
+            }
+
+            let tsc_end = Self::rdtsc();
+
+            // Latch final count for precise measurement
+            fstart_pio::outb(Self::PIT_CMD, 0x00);
+            let lo = fstart_pio::inb(0x40) as u16;
+            let hi = fstart_pio::inb(0x40) as u16;
+            let count_end = (hi << 8) | lo;
+
+            let pit_elapsed = count_start.wrapping_sub(count_end) as u64;
+            let tsc_delta = tsc_end - tsc_start;
+
+            if pit_elapsed == 0 {
+                // Fallback: assume 1 GHz TSC
+                return 1_000_000_000;
+            }
+
+            // freq = tsc_delta / (pit_elapsed / PIT_FREQ)
+            //      = tsc_delta * PIT_FREQ / pit_elapsed
+            tsc_delta * Self::PIT_FREQ / pit_elapsed
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl crabefi::Timer for TscTimer {
+    fn current_ticks(&self) -> u64 {
+        Self::rdtsc()
+    }
+
+    fn ticks_per_second(&self) -> u64 {
+        self.tsc_freq
+    }
+}
+
+// ---------------------------------------------------------------------------
+// x86 Keyboard Controller Reset → CrabEFI ResetHandler
+// ---------------------------------------------------------------------------
+
+/// CrabEFI [`ResetHandler`](crabefi::ResetHandler) using the x86 keyboard
+/// controller reset (port 0x64) with triple-fault fallback.
+#[cfg(target_arch = "x86_64")]
+pub struct X86Reset;
+
+#[cfg(target_arch = "x86_64")]
+impl crabefi::ResetHandler for X86Reset {
+    fn reset(&self, reset_type: crabefi::ResetType) -> ! {
+        match reset_type {
+            crabefi::ResetType::Shutdown => {
+                // ACPI S5 (soft-off) via QEMU's ACPI PM1a control register.
+                // QEMU Q35: PM1a_CNT at I/O port 0x0404.
+                unsafe {
+                    fstart_pio::outw(0x0404, 0x2000); // SLP_EN (bit 13); QEMU _S5 defines SLP_TYP=0
+                }
+            }
+            _ => {
+                // Keyboard controller reset: pulse CPU reset line
+                unsafe {
+                    // Wait for input buffer empty
+                    for _ in 0..10000 {
+                        if fstart_pio::inb(0x64) & 0x02 == 0 {
+                            break;
+                        }
+                        core::hint::spin_loop();
+                    }
+                    fstart_pio::outb(0x64, 0xFE); // reset command
+                }
+            }
+        }
+
+        // Fallback: triple fault
+        unsafe {
+            // Load null IDT and trigger INT3
+            core::arch::asm!(
+                "lidt [{null_idt}]",
+                "int3",
+                null_idt = in(reg) &[0u16; 5] as *const _,
+                options(noreturn),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// x86 RDRAND → CrabEFI Rng adapter
+// ---------------------------------------------------------------------------
+
+/// CrabEFI [`Rng`](crabefi::Rng) backed by the x86 RDRAND instruction.
+///
+/// Falls back to a simple LFSR if RDRAND is not available (very old CPUs).
+#[cfg(target_arch = "x86_64")]
+pub struct X86Rng {
+    has_rdrand: bool,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl Default for X86Rng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl X86Rng {
+    /// Check CPUID for RDRAND support (ECX bit 30 of leaf 1).
+    pub fn new() -> Self {
+        let ecx: u32;
+        unsafe {
+            // CPUID clobbers EAX/EBX/ECX/EDX. RBX is reserved by LLVM,
+            // so we save/restore it manually.
+            core::arch::asm!(
+                "push rbx",
+                "mov eax, 1",
+                "cpuid",
+                "mov {ecx:e}, ecx",
+                "pop rbx",
+                ecx = out(reg) ecx,
+                out("eax") _,
+                out("ecx") _,
+                out("edx") _,
+                options(nomem),
+            );
+        }
+        Self {
+            has_rdrand: ecx & (1 << 30) != 0,
+        }
+    }
+
+    /// Read a 64-bit random value via RDRAND with retry.
+    fn rdrand64() -> Option<u64> {
+        let mut val: u64;
+        let mut ok: u8;
+        for _ in 0..10 {
+            unsafe {
+                core::arch::asm!(
+                    "rdrand {val}",
+                    "setc {ok}",
+                    val = out(reg) val,
+                    ok = out(reg_byte) ok,
+                    options(nomem, nostack),
+                );
+            }
+            if ok != 0 && val != !0u64 {
+                return Some(val);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl crabefi::Rng for X86Rng {
+    fn get_random(&self, buffer: &mut [u8]) -> Result<(), crabefi::RngError> {
+        if !self.has_rdrand {
+            return Err(crabefi::RngError::Unsupported);
+        }
+        let mut offset = 0;
+        while offset < buffer.len() {
+            let val = Self::rdrand64().ok_or(crabefi::RngError::HardwareError)?;
+            let bytes = val.to_le_bytes();
+            let remaining = buffer.len() - offset;
+            let copy_len = remaining.min(8);
+            buffer[offset..offset + copy_len].copy_from_slice(&bytes[..copy_len]);
+            offset += copy_len;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// e820 → EFI memory map conversion (x86_64)
+// ---------------------------------------------------------------------------
+
+/// Build an EFI memory map from e820 entries, carving out firmware regions.
+///
+/// Converts e820 type codes to EFI memory types, adds ROM as
+/// `RuntimeServicesCode`, and splits RAM regions that overlap with the
+/// firmware's BSS/stack areas (marked as `RuntimeServicesData`).
+///
+/// Returns the number of entries written to `buf`.
+///
+/// # Arguments
+///
+/// - `e820`: slice of e820 entries from MemoryDetect
+/// - `fw_data_addr`: start of firmware BSS/data in RAM
+/// - `fw_data_size`: size of firmware BSS/data/heap region
+/// - `fw_stack_addr`: start of firmware stack (grows down from here)
+/// - `fw_stack_size`: size of firmware stack
+/// - `rom_entries`: static ROM entries (flash as RuntimeServicesCode)
+/// - `buf`: output buffer for EFI memory regions
+#[allow(clippy::too_many_arguments)]
+pub fn build_efi_memory_map_from_e820(
+    e820: &[E820Entry],
+    fw_data_addr: u64,
+    fw_data_size: u64,
+    fw_stack_addr: u64,
+    fw_stack_size: u64,
+    rom_entries: &[MemoryRegion],
+    buf: &mut [MemoryRegion],
+) -> usize {
+    let mut idx = 0;
+
+    // 1. Static ROM entries.
+    for entry in rom_entries {
+        if idx >= buf.len() {
+            break;
+        }
+        buf[idx] = *entry;
+        idx += 1;
+    }
+
+    // 2. Firmware reserved regions (BSS/data/heap + stack).
+    let fw_data_end = fw_data_addr + fw_data_size;
+    let fw_stack_bottom = fw_stack_addr;
+    let fw_stack_top = fw_stack_addr + fw_stack_size;
+
+    // 3. Convert e820 entries, splitting RAM that overlaps firmware.
+    for e in e820 {
+        if idx >= buf.len() {
+            break;
+        }
+        let region_type = match e.kind {
+            1 => MemoryType::Ram,
+            2 => MemoryType::Reserved,
+            3 => MemoryType::AcpiReclaimable,
+            4 => MemoryType::AcpiNvs,
+            _ => MemoryType::Reserved,
+        };
+
+        if region_type != MemoryType::Ram {
+            // Non-RAM: pass through as-is.
+            buf[idx] = MemoryRegion {
+                base: e.addr,
+                size: e.size,
+                region_type,
+            };
+            idx += 1;
+            continue;
+        }
+
+        // RAM region — need to carve out firmware areas.
+        let r_start = e.addr;
+        let r_end = e.addr + e.size;
+
+        // Collect firmware holes that overlap this RAM region.
+        // Sort by start address for correct splitting.
+        let mut holes: [(u64, u64); 2] = [(0, 0); 2];
+        let mut n_holes = 0;
+
+        // Firmware data/BSS/heap hole
+        if fw_data_addr < r_end && fw_data_end > r_start {
+            let h_start = fw_data_addr.max(r_start);
+            let h_end = fw_data_end.min(r_end);
+            if h_start < h_end {
+                holes[n_holes] = (h_start, h_end);
+                n_holes += 1;
+            }
+        }
+
+        // Firmware stack hole
+        if fw_stack_bottom < r_end && fw_stack_top > r_start {
+            let h_start = fw_stack_bottom.max(r_start);
+            let h_end = fw_stack_top.min(r_end);
+            if h_start < h_end {
+                holes[n_holes] = (h_start, h_end);
+                n_holes += 1;
+            }
+        }
+
+        // Sort holes by start address
+        if n_holes == 2 && holes[0].0 > holes[1].0 {
+            holes.swap(0, 1);
+        }
+
+        if n_holes == 0 {
+            // No firmware overlap — entire region is free RAM.
+            buf[idx] = MemoryRegion {
+                base: r_start,
+                size: r_end - r_start,
+                region_type: MemoryType::Ram,
+            };
+            idx += 1;
+        } else {
+            // Split around firmware holes.
+            let mut cursor = r_start;
+            for i in 0..n_holes {
+                let (h_start, h_end) = holes[i];
+
+                // Free RAM before this hole
+                if cursor < h_start && idx < buf.len() {
+                    buf[idx] = MemoryRegion {
+                        base: cursor,
+                        size: h_start - cursor,
+                        region_type: MemoryType::Ram,
+                    };
+                    idx += 1;
+                }
+
+                // The hole itself (firmware runtime data)
+                if idx < buf.len() {
+                    buf[idx] = MemoryRegion {
+                        base: h_start,
+                        size: h_end - h_start,
+                        region_type: MemoryType::RuntimeServicesData,
+                    };
+                    idx += 1;
+                }
+
+                cursor = h_end;
+            }
+
+            // Free RAM after last hole
+            if cursor < r_end && idx < buf.len() {
+                buf[idx] = MemoryRegion {
+                    base: cursor,
+                    size: r_end - cursor,
+                    region_type: MemoryType::Ram,
+                };
+                idx += 1;
+            }
+        }
+    }
+
+    idx
 }

--- a/crates/fstart-device-registry/Cargo.toml
+++ b/crates/fstart-device-registry/Cargo.toml
@@ -28,6 +28,7 @@ fstart-driver-fu740-ddr = { path = "../fstart-driver-fu740-ddr", optional = true
 fstart-driver-pci-ecam = { path = "../fstart-driver-pci-ecam", optional = true }
 fstart-driver-bochs-display = { path = "../fstart-driver-bochs-display", optional = true }
 fstart-driver-qemu-fw-cfg = { path = "../fstart-driver-qemu-fw-cfg", optional = true }
+fstart-driver-q35-hostbridge = { path = "../fstart-driver-q35-hostbridge", optional = true }
 
 [features]
 # Driver feature flags - enable to include that driver in the registry
@@ -49,6 +50,7 @@ fu740-ddr = ["dep:fstart-driver-fu740-ddr"]
 pci-ecam = ["dep:fstart-driver-pci-ecam"]
 bochs-display = ["dep:fstart-driver-bochs-display"]
 qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
+q35-hostbridge = ["dep:fstart-driver-q35-hostbridge"]
 
 # Meta-feature to enable all drivers (used by codegen on host)
 all-drivers = [
@@ -69,4 +71,5 @@ all-drivers = [
     "pci-ecam",
     "bochs-display",
     "qemu-fw-cfg",
+    "q35-hostbridge",
 ]

--- a/crates/fstart-device-registry/Cargo.toml
+++ b/crates/fstart-device-registry/Cargo.toml
@@ -27,6 +27,7 @@ fstart-driver-fu740-prci = { path = "../fstart-driver-fu740-prci", optional = tr
 fstart-driver-fu740-ddr = { path = "../fstart-driver-fu740-ddr", optional = true }
 fstart-driver-pci-ecam = { path = "../fstart-driver-pci-ecam", optional = true }
 fstart-driver-bochs-display = { path = "../fstart-driver-bochs-display", optional = true }
+fstart-driver-qemu-fw-cfg = { path = "../fstart-driver-qemu-fw-cfg", optional = true }
 
 [features]
 # Driver feature flags - enable to include that driver in the registry
@@ -47,6 +48,7 @@ fu740-prci = ["dep:fstart-driver-fu740-prci"]
 fu740-ddr = ["dep:fstart-driver-fu740-ddr"]
 pci-ecam = ["dep:fstart-driver-pci-ecam"]
 bochs-display = ["dep:fstart-driver-bochs-display"]
+qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
 
 # Meta-feature to enable all drivers (used by codegen on host)
 all-drivers = [
@@ -66,4 +68,5 @@ all-drivers = [
     "fu740-ddr",
     "pci-ecam",
     "bochs-display",
+    "qemu-fw-cfg",
 ]

--- a/crates/fstart-device-registry/src/lib.rs
+++ b/crates/fstart-device-registry/src/lib.rs
@@ -99,6 +99,11 @@ pub mod bochs_display {
     pub use fstart_driver_bochs_display::BochsDisplayConfig;
 }
 
+#[cfg(feature = "qemu-fw-cfg")]
+pub mod qemu_fw_cfg {
+    pub use fstart_driver_qemu_fw_cfg::QemuFwCfgConfig;
+}
+
 // ---------------------------------------------------------------------------
 // DriverMeta — static metadata about a driver
 // ---------------------------------------------------------------------------
@@ -228,6 +233,10 @@ pub enum DriverInstance {
     /// Bochs VBE display (QEMU bochs-display, PCI MMIO mode).
     #[cfg(feature = "bochs-display")]
     BochsDisplay(bochs_display::BochsDisplayConfig),
+
+    /// QEMU fw_cfg device — provides ACPI tables and e820 memory map.
+    #[cfg(feature = "qemu-fw-cfg")]
+    QemuFwCfg(qemu_fw_cfg::QemuFwCfgConfig),
 }
 
 impl DriverInstance {
@@ -430,6 +439,16 @@ impl DriverInstance {
                 compatible: &["bochs-display", "qemu-stdvga"],
                 has_acpi: false,
             },
+            #[cfg(feature = "qemu-fw-cfg")]
+            Self::QemuFwCfg(_) => &DriverMeta {
+                name: "qemu-fw-cfg",
+                type_name: "QemuFwCfg",
+                module_path: "fstart_driver_qemu_fw_cfg",
+                config_type: "QemuFwCfgConfig",
+                services: &["AcpiTableProvider", "MemoryDetector"],
+                compatible: &["qemu,fw-cfg"],
+                has_acpi: false,
+            },
         }
     }
 
@@ -504,6 +523,8 @@ impl DriverInstance {
             Self::PciEcam(cfg) => serde::Serialize::serialize(cfg, ser),
             #[cfg(feature = "bochs-display")]
             Self::BochsDisplay(cfg) => serde::Serialize::serialize(cfg, ser),
+            #[cfg(feature = "qemu-fw-cfg")]
+            Self::QemuFwCfg(cfg) => serde::Serialize::serialize(cfg, ser),
         }
     }
 }

--- a/crates/fstart-device-registry/src/lib.rs
+++ b/crates/fstart-device-registry/src/lib.rs
@@ -104,6 +104,11 @@ pub mod qemu_fw_cfg {
     pub use fstart_driver_qemu_fw_cfg::QemuFwCfgConfig;
 }
 
+#[cfg(feature = "q35-hostbridge")]
+pub mod q35_hostbridge {
+    pub use fstart_driver_q35_hostbridge::Q35HostBridgeConfig;
+}
+
 // ---------------------------------------------------------------------------
 // DriverMeta — static metadata about a driver
 // ---------------------------------------------------------------------------
@@ -237,6 +242,11 @@ pub enum DriverInstance {
     /// QEMU fw_cfg device — provides ACPI tables and e820 memory map.
     #[cfg(feature = "qemu-fw-cfg")]
     QemuFwCfg(qemu_fw_cfg::QemuFwCfgConfig),
+
+    /// Q35 PCI host bridge — ECAM with CF8/CFC bootstrap and runtime
+    /// MMIO window computation from e820.
+    #[cfg(feature = "q35-hostbridge")]
+    Q35HostBridge(q35_hostbridge::Q35HostBridgeConfig),
 }
 
 impl DriverInstance {
@@ -449,6 +459,16 @@ impl DriverInstance {
                 compatible: &["qemu,fw-cfg"],
                 has_acpi: false,
             },
+            #[cfg(feature = "q35-hostbridge")]
+            Self::Q35HostBridge(_) => &DriverMeta {
+                name: "q35-hostbridge",
+                type_name: "Q35HostBridge",
+                module_path: "fstart_driver_q35_hostbridge",
+                config_type: "Q35HostBridgeConfig",
+                services: &["PciRootBus"],
+                compatible: &["q35-hostbridge"],
+                has_acpi: false,
+            },
         }
     }
 
@@ -525,6 +545,8 @@ impl DriverInstance {
             Self::BochsDisplay(cfg) => serde::Serialize::serialize(cfg, ser),
             #[cfg(feature = "qemu-fw-cfg")]
             Self::QemuFwCfg(cfg) => serde::Serialize::serialize(cfg, ser),
+            #[cfg(feature = "q35-hostbridge")]
+            Self::Q35HostBridge(cfg) => serde::Serialize::serialize(cfg, ser),
         }
     }
 }

--- a/crates/fstart-driver-bochs-display/src/lib.rs
+++ b/crates/fstart-driver-bochs-display/src/lib.rs
@@ -159,7 +159,7 @@ impl BusDevice for BochsDisplay {
 
     fn new_on_bus(config: &BochsDisplayConfig, bus: &dyn PciRootBus) -> Result<Self, DeviceError> {
         let addr = PciAddr {
-            bus: 0, // bus 0 (child of root bus)
+            bus: bus.bus_start(),
             dev: config.device,
             func: config.function,
         };

--- a/crates/fstart-driver-bochs-display/src/lib.rs
+++ b/crates/fstart-driver-bochs-display/src/lib.rs
@@ -23,7 +23,9 @@
 
 use fstart_services::device::{BusDevice, DeviceError};
 use fstart_services::framebuffer::{Framebuffer, FramebufferInfo};
-use fstart_services::pci::{PciAddr, PciRootBus};
+use fstart_services::pci::{
+    PciAddr, PciRootBus, PCI_BAR0, PCI_BAR2, PCI_VENDOR_ID, PCI_VENDOR_INVALID,
+};
 use serde::{Deserialize, Serialize};
 
 // -----------------------------------------------------------------------
@@ -52,10 +54,6 @@ const VBE_DISPI_LFB_ENABLED: u16 = 0x40;
 // BAR2 MMIO offsets (bochs-display, non-VGA class 0x0380)
 const MMIO_VGA_OFFSET: usize = 0x400;
 const MMIO_DISPI_OFFSET: usize = 0x500;
-
-// PCI config space offsets
-const PCI_BAR0: u16 = 0x10;
-const PCI_BAR2: u16 = 0x18;
 
 // -----------------------------------------------------------------------
 // Config
@@ -166,9 +164,9 @@ impl BusDevice for BochsDisplay {
 
         // Verify the device is present by reading vendor:device ID.
         let vendor_device = bus
-            .config_read32(addr, 0x00)
+            .config_read32(addr, PCI_VENDOR_ID)
             .map_err(|_| DeviceError::BusError)?;
-        if vendor_device == 0xFFFF_FFFF {
+        if vendor_device == PCI_VENDOR_INVALID {
             fstart_log::error!(
                 "bochs-display: no PCI device at {:02x}:{:02x}.{}",
                 addr.bus,

--- a/crates/fstart-driver-ns16550/Cargo.toml
+++ b/crates/fstart-driver-ns16550/Cargo.toml
@@ -4,8 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+pio = ["dep:fstart-pio"]
+
 [dependencies]
 fstart-mmio = { workspace = true }
+fstart-pio = { workspace = true, optional = true }
 fstart-services = { workspace = true }
 serde = { workspace = true }
 tock-registers = { workspace = true }

--- a/crates/fstart-driver-ns16550/src/lib.rs
+++ b/crates/fstart-driver-ns16550/src/lib.rs
@@ -34,6 +34,15 @@
 //! Init sequence is an exact match of U-Boot `ns16550_init()` +
 //! `ns16550_setbrg()` (drivers/serial/ns16550.c).
 //!
+//! ## Register access mode (`access_mode`)
+//!
+//! The `access_mode` config selects between memory-mapped and port I/O access:
+//!   - `Mmio` (default): Memory-mapped I/O via `read_volatile`/`write_volatile`.
+//!     Used by all non-x86 platforms and MMIO-mapped x86 UARTs.
+//!   - `Pio`: x86 port I/O via `in`/`out` instructions.  Used by legacy
+//!     PC UARTs (COM1 at 0x3F8, COM2 at 0x2F8, etc.).  Requires the `pio`
+//!     feature on this crate.
+//!
 //! Compatible: `"ns16550a"`, `"ns16550"`, `"snps,dw-apb-uart"`,
 //!             `"allwinner,sun7i-a20-uart"`.
 
@@ -109,6 +118,26 @@ register_bitfields! [u8,
 // Config & driver
 // ---------------------------------------------------------------------------
 
+/// Register access mode: memory-mapped or port I/O.
+///
+/// Selects the bus transaction mechanism used to reach the UART registers.
+/// MMIO uses `read_volatile`/`write_volatile`; PIO uses x86 `in`/`out`
+/// instructions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AccessMode {
+    /// Memory-mapped I/O (all platforms).
+    Mmio,
+    /// x86 port I/O via `in`/`out` instructions.
+    /// Requires the `pio` feature on this crate.
+    Pio,
+}
+
+impl Default for AccessMode {
+    fn default() -> Self {
+        Self::Mmio
+    }
+}
+
 /// Typed configuration for the NS16550 driver.
 ///
 /// The `reg_shift` field controls the address stride between registers:
@@ -119,11 +148,16 @@ register_bitfields! [u8,
 ///   - `1` (default) -> byte access (`sb`/`lb`)
 ///   - `4` -> 32-bit word access (`sw`/`lw`), for DW APB UARTs
 ///
+/// The `access_mode` field selects MMIO or port I/O:
+///   - `Mmio` (default) -> memory-mapped register access
+///   - `Pio` -> x86 port I/O (`in`/`out` instructions)
+///
 /// Serde defaults ensure backward compatibility: existing board RON
-/// files without `reg_shift`/`reg_width` get byte-stride byte-access.
+/// files without `reg_shift`/`reg_width`/`access_mode` get MMIO
+/// byte-stride byte-access.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Ns16550Config {
-    /// MMIO base address of the register block.
+    /// MMIO base address or I/O port base of the register block.
     pub base_addr: u64,
     /// Input clock frequency in Hz.
     pub clock_freq: u32,
@@ -137,19 +171,26 @@ pub struct Ns16550Config {
     /// Default 0 means "auto": uses 4 when reg_shift >= 2, else 1.
     #[serde(default)]
     pub reg_width: u8,
+    /// Access mode: MMIO (default) or PIO (x86 port I/O).
+    #[serde(default)]
+    pub access_mode: AccessMode,
 }
 
-/// NS16550 UART driver — covers NS16550A, DW APB UART, and sunxi UART.
+/// NS16550 UART driver — covers NS16550A, DW APB UART, sunxi UART,
+/// and x86 legacy port-I/O UARTs.
 ///
-/// Register access uses width-aware MMIO (`read_reg`/`write_reg`) with
-/// tock-registers `LocalRegisterCopy` for typed bitfield operations.
+/// Register access uses width-aware MMIO or port I/O (`read_reg`/`write_reg`)
+/// with tock-registers `LocalRegisterCopy` for typed bitfield operations.
 /// The `reg_shift` controls address spacing; `reg_width` controls
-/// the bus transaction width (byte or 32-bit word).
+/// the bus transaction width (byte or 32-bit word); `access_mode` selects
+/// between MMIO and PIO.
 pub struct Ns16550 {
     base: usize,
     shift: u8,
     /// Effective I/O width: 1 = byte, 4 = word.
     width: u8,
+    /// Access mode: MMIO or PIO.
+    access_mode: AccessMode,
     clock_freq: u32,
     baud_rate: u32,
 }
@@ -166,41 +207,72 @@ impl Ns16550 {
         self.base + (index << self.shift)
     }
 
-    /// Read a register (respecting `reg_width`).
+    /// Read a register (respecting `access_mode` and `reg_width`).
     ///
-    /// When `width == 4`, performs a 32-bit read and returns the low byte.
-    /// When `width == 1`, performs a byte read.
+    /// - PIO mode: byte-width `in` from I/O port.
+    /// - MMIO mode, `width == 4`: 32-bit read, returns low byte.
+    /// - MMIO mode, `width == 1`: byte read.
     #[inline(always)]
     fn read_reg(&self, index: usize) -> u8 {
         let addr = self.addr(index);
-        if self.width == 4 {
-            // SAFETY: self.base + offset is a valid MMIO register address provided
-            // by the board config. When width == 4, alignment is guaranteed by
-            // reg_shift >= 2 (validated in new()).
-            (unsafe { fstart_mmio::read32(addr as *const u32) }) as u8
-        } else {
-            // SAFETY: self.base + offset is a valid MMIO register address provided
-            // by the board config. Byte access has no alignment requirement.
-            unsafe { fstart_mmio::read8(addr as *const u8) }
+        match self.access_mode {
+            #[cfg(feature = "pio")]
+            AccessMode::Pio => {
+                // SAFETY: I/O port address provided by board config.
+                unsafe { fstart_pio::inb(addr as u16) }
+            }
+            #[cfg(not(feature = "pio"))]
+            AccessMode::Pio => {
+                // PIO not compiled in — should not be reachable (constructor rejects).
+                0
+            }
+            AccessMode::Mmio => {
+                if self.width == 4 {
+                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // provided by the board config. When width == 4, alignment is
+                    // guaranteed by reg_shift >= 2 (validated in new()).
+                    (unsafe { fstart_mmio::read32(addr as *const u32) }) as u8
+                } else {
+                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // provided by the board config. Byte access has no alignment
+                    // requirement.
+                    unsafe { fstart_mmio::read8(addr as *const u8) }
+                }
+            }
         }
     }
 
-    /// Write a register (respecting `reg_width`).
+    /// Write a register (respecting `access_mode` and `reg_width`).
     ///
-    /// When `width == 4`, zero-extends to 32-bit and performs a word write.
-    /// When `width == 1`, performs a byte write.
+    /// - PIO mode: byte-width `out` to I/O port.
+    /// - MMIO mode, `width == 4`: zero-extends to 32-bit, word write.
+    /// - MMIO mode, `width == 1`: byte write.
     #[inline(always)]
     fn write_reg(&self, index: usize, val: u8) {
         let addr = self.addr(index);
-        if self.width == 4 {
-            // SAFETY: self.base + offset is a valid MMIO register address provided
-            // by the board config. When width == 4, alignment is guaranteed by
-            // reg_shift >= 2 (validated in new()).
-            unsafe { fstart_mmio::write32(addr as *mut u32, val as u32) }
-        } else {
-            // SAFETY: self.base + offset is a valid MMIO register address provided
-            // by the board config. Byte access has no alignment requirement.
-            unsafe { fstart_mmio::write8(addr as *mut u8, val) }
+        match self.access_mode {
+            #[cfg(feature = "pio")]
+            AccessMode::Pio => {
+                // SAFETY: I/O port address provided by board config.
+                unsafe { fstart_pio::outb(addr as u16, val) }
+            }
+            #[cfg(not(feature = "pio"))]
+            AccessMode::Pio => {
+                // PIO not compiled in — should not be reachable (constructor rejects).
+            }
+            AccessMode::Mmio => {
+                if self.width == 4 {
+                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // provided by the board config. When width == 4, alignment is
+                    // guaranteed by reg_shift >= 2 (validated in new()).
+                    unsafe { fstart_mmio::write32(addr as *mut u32, val as u32) }
+                } else {
+                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // provided by the board config. Byte access has no alignment
+                    // requirement.
+                    unsafe { fstart_mmio::write8(addr as *mut u8, val) }
+                }
+            }
         }
     }
 
@@ -255,7 +327,25 @@ impl Device for Ns16550 {
     type Config = Ns16550Config;
 
     fn new(config: &Ns16550Config) -> Result<Self, DeviceError> {
-        // Resolve effective I/O width: 0 = auto (word if reg_shift >= 2).
+        // PIO mode: always byte-width, ignore reg_width/reg_shift for
+        // width resolution. Port I/O UARTs are always byte-stride.
+        if config.access_mode == AccessMode::Pio {
+            #[cfg(not(feature = "pio"))]
+            return Err(DeviceError::ConfigError);
+
+            #[cfg(feature = "pio")]
+            return Ok(Self {
+                base: config.base_addr as usize,
+                shift: config.reg_shift,
+                width: 1,
+                access_mode: AccessMode::Pio,
+                clock_freq: config.clock_freq,
+                baud_rate: config.baud_rate,
+            });
+        }
+
+        // MMIO mode: resolve effective I/O width.
+        // 0 = auto (word if reg_shift >= 2).
         let width = match config.reg_width {
             0 => {
                 if config.reg_shift >= 2 {
@@ -278,6 +368,7 @@ impl Device for Ns16550 {
             base: config.base_addr as usize,
             shift: config.reg_shift,
             width,
+            access_mode: AccessMode::Mmio,
             clock_freq: config.clock_freq,
             baud_rate: config.baud_rate,
         })

--- a/crates/fstart-driver-ns16550/src/lib.rs
+++ b/crates/fstart-driver-ns16550/src/lib.rs
@@ -118,62 +118,50 @@ register_bitfields! [u8,
 // Config & driver
 // ---------------------------------------------------------------------------
 
-/// Register access mode: memory-mapped or port I/O.
+/// Register access mechanism — encodes the base address and bus
+/// transaction parameters as a single discriminated union.
 ///
-/// Selects the bus transaction mechanism used to reach the UART registers.
-/// MMIO uses `read_volatile`/`write_volatile`; PIO uses x86 `in`/`out`
-/// instructions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// PIO mode is byte-stride, byte-width by definition (x86 legacy UART).
+/// MMIO mode carries register shift and width to support both classic
+/// NS16550A (byte-stride) and DesignWare APB UARTs (4-byte stride,
+/// 32-bit width).
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum AccessMode {
-    /// Memory-mapped I/O (all platforms).
-    Mmio,
-    /// x86 port I/O via `in`/`out` instructions.
+    /// Memory-mapped I/O: base address, register shift, I/O width.
+    ///
+    /// `reg_shift` controls address stride: `0` = byte-packed,
+    /// `2` = 4-byte spacing (DW APB / sunxi).
+    ///
+    /// `reg_width` controls bus transaction width: `1` = byte,
+    /// `4` = 32-bit word. `0` = auto (word if shift >= 2, else byte).
+    Mmio(u64, u8, u8),
+    /// x86 port I/O: base I/O port address.
     /// Requires the `pio` feature on this crate.
-    Pio,
+    Pio(u64),
 }
 
 impl Default for AccessMode {
     fn default() -> Self {
-        Self::Mmio
+        Self::Mmio(0, 0, 0)
     }
 }
 
 /// Typed configuration for the NS16550 driver.
 ///
-/// The `reg_shift` field controls the address stride between registers:
-///   - `0` -> byte-packed (offset = reg_index), classic NS16550A
-///   - `2` -> 4-byte spacing (offset = reg_index << 2), DW APB / sunxi
-///
-/// The `reg_width` field controls the bus transaction width:
-///   - `1` (default) -> byte access (`sb`/`lb`)
-///   - `4` -> 32-bit word access (`sw`/`lw`), for DW APB UARTs
-///
-/// The `access_mode` field selects MMIO or port I/O:
-///   - `Mmio` (default) -> memory-mapped register access
-///   - `Pio` -> x86 port I/O (`in`/`out` instructions)
+/// The `regs` field selects the register access mechanism:
+///   - `Mmio(base, reg_shift, reg_width)` — memory-mapped I/O
+///   - `Pio(base)` — x86 port I/O (always byte-stride, byte-width)
 ///
 /// Serde defaults ensure backward compatibility: existing board RON
-/// files without `reg_shift`/`reg_width`/`access_mode` get MMIO
-/// byte-stride byte-access.
+/// files without explicit `regs` get `Mmio(0, 0, 0)`.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Ns16550Config {
-    /// MMIO base address or I/O port base of the register block.
-    pub base_addr: u64,
+    /// Register access mechanism (MMIO or PIO) with base address.
+    pub regs: AccessMode,
     /// Input clock frequency in Hz.
     pub clock_freq: u32,
     /// Desired baud rate.
     pub baud_rate: u32,
-    /// Register address shift (0 = byte-stride, 2 = 4-byte stride).
-    #[serde(default)]
-    pub reg_shift: u8,
-    /// Register I/O width in bytes (1 = byte, 4 = 32-bit word).
-    /// Corresponds to U-Boot's `reg-io-width` DTS property.
-    /// Default 0 means "auto": uses 4 when reg_shift >= 2, else 1.
-    #[serde(default)]
-    pub reg_width: u8,
-    /// Access mode: MMIO (default) or PIO (x86 port I/O).
-    #[serde(default)]
-    pub access_mode: AccessMode,
 }
 
 /// NS16550 UART driver — covers NS16550A, DW APB UART, sunxi UART,
@@ -181,18 +169,20 @@ pub struct Ns16550Config {
 ///
 /// Register access uses width-aware MMIO or port I/O (`read_reg`/`write_reg`)
 /// with tock-registers `LocalRegisterCopy` for typed bitfield operations.
-/// The `reg_shift` controls address spacing; `reg_width` controls
-/// the bus transaction width (byte or 32-bit word); `access_mode` selects
-/// between MMIO and PIO.
 pub struct Ns16550 {
-    base: usize,
-    shift: u8,
-    /// Effective I/O width: 1 = byte, 4 = word.
-    width: u8,
-    /// Access mode: MMIO or PIO.
-    access_mode: AccessMode,
+    /// Register access mechanism (resolved from config).
+    regs: ResolvedRegs,
     clock_freq: u32,
     baud_rate: u32,
+}
+
+/// Internal resolved register access parameters.
+#[derive(Debug, Clone, Copy)]
+enum ResolvedRegs {
+    /// MMIO: base address, shift, effective width (1 or 4).
+    Mmio { base: usize, shift: u8, width: u8 },
+    /// PIO: base I/O port.
+    Pio { base: u16 },
 }
 
 // SAFETY: MMIO registers are hardware-fixed addresses; access is safe
@@ -201,39 +191,32 @@ unsafe impl Send for Ns16550 {}
 unsafe impl Sync for Ns16550 {}
 
 impl Ns16550 {
-    /// Compute the MMIO address for register at `index`.
-    #[inline(always)]
-    fn addr(&self, index: usize) -> usize {
-        self.base + (index << self.shift)
-    }
-
-    /// Read a register (respecting `access_mode` and `reg_width`).
+    /// Read a register (respecting resolved register access mode).
     ///
     /// - PIO mode: byte-width `in` from I/O port.
     /// - MMIO mode, `width == 4`: 32-bit read, returns low byte.
     /// - MMIO mode, `width == 1`: byte read.
     #[inline(always)]
     fn read_reg(&self, index: usize) -> u8 {
-        let addr = self.addr(index);
-        match self.access_mode {
+        match self.regs {
             #[cfg(feature = "pio")]
-            AccessMode::Pio => {
+            ResolvedRegs::Pio { base } => {
                 // SAFETY: I/O port address provided by board config.
-                unsafe { fstart_pio::inb(addr as u16) }
+                unsafe { fstart_pio::inb(base + index as u16) }
             }
             #[cfg(not(feature = "pio"))]
-            AccessMode::Pio => {
-                // PIO not compiled in — should not be reachable (constructor rejects).
-                0
+            ResolvedRegs::Pio { .. } => {
+                unreachable!("PIO mode without pio feature should be rejected by constructor")
             }
-            AccessMode::Mmio => {
-                if self.width == 4 {
-                    // SAFETY: self.base + offset is a valid MMIO register address
+            ResolvedRegs::Mmio { base, shift, width } => {
+                let addr = base + (index << shift);
+                if width == 4 {
+                    // SAFETY: base + offset is a valid MMIO register address
                     // provided by the board config. When width == 4, alignment is
                     // guaranteed by reg_shift >= 2 (validated in new()).
                     (unsafe { fstart_mmio::read32(addr as *const u32) }) as u8
                 } else {
-                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // SAFETY: base + offset is a valid MMIO register address
                     // provided by the board config. Byte access has no alignment
                     // requirement.
                     unsafe { fstart_mmio::read8(addr as *const u8) }
@@ -242,32 +225,32 @@ impl Ns16550 {
         }
     }
 
-    /// Write a register (respecting `access_mode` and `reg_width`).
+    /// Write a register (respecting resolved register access mode).
     ///
     /// - PIO mode: byte-width `out` to I/O port.
     /// - MMIO mode, `width == 4`: zero-extends to 32-bit, word write.
     /// - MMIO mode, `width == 1`: byte write.
     #[inline(always)]
     fn write_reg(&self, index: usize, val: u8) {
-        let addr = self.addr(index);
-        match self.access_mode {
+        match self.regs {
             #[cfg(feature = "pio")]
-            AccessMode::Pio => {
+            ResolvedRegs::Pio { base } => {
                 // SAFETY: I/O port address provided by board config.
-                unsafe { fstart_pio::outb(addr as u16, val) }
+                unsafe { fstart_pio::outb(base + index as u16, val) }
             }
             #[cfg(not(feature = "pio"))]
-            AccessMode::Pio => {
-                // PIO not compiled in — should not be reachable (constructor rejects).
+            ResolvedRegs::Pio { .. } => {
+                unreachable!("PIO mode without pio feature should be rejected by constructor")
             }
-            AccessMode::Mmio => {
-                if self.width == 4 {
-                    // SAFETY: self.base + offset is a valid MMIO register address
+            ResolvedRegs::Mmio { base, shift, width } => {
+                let addr = base + (index << shift);
+                if width == 4 {
+                    // SAFETY: base + offset is a valid MMIO register address
                     // provided by the board config. When width == 4, alignment is
                     // guaranteed by reg_shift >= 2 (validated in new()).
                     unsafe { fstart_mmio::write32(addr as *mut u32, val as u32) }
                 } else {
-                    // SAFETY: self.base + offset is a valid MMIO register address
+                    // SAFETY: base + offset is a valid MMIO register address
                     // provided by the board config. Byte access has no alignment
                     // requirement.
                     unsafe { fstart_mmio::write8(addr as *mut u8, val) }
@@ -327,48 +310,45 @@ impl Device for Ns16550 {
     type Config = Ns16550Config;
 
     fn new(config: &Ns16550Config) -> Result<Self, DeviceError> {
-        // PIO mode: always byte-width, ignore reg_width/reg_shift for
-        // width resolution. Port I/O UARTs are always byte-stride.
-        if config.access_mode == AccessMode::Pio {
-            #[cfg(not(feature = "pio"))]
-            return Err(DeviceError::ConfigError);
+        let regs = match config.regs {
+            AccessMode::Pio(base) => {
+                #[cfg(not(feature = "pio"))]
+                return Err(DeviceError::ConfigError);
 
-            #[cfg(feature = "pio")]
-            return Ok(Self {
-                base: config.base_addr as usize,
-                shift: config.reg_shift,
-                width: 1,
-                access_mode: AccessMode::Pio,
-                clock_freq: config.clock_freq,
-                baud_rate: config.baud_rate,
-            });
-        }
+                #[cfg(feature = "pio")]
+                ResolvedRegs::Pio { base: base as u16 }
+            }
+            AccessMode::Mmio(base, reg_shift, reg_width) => {
+                // Resolve effective I/O width.
+                // 0 = auto (word if reg_shift >= 2).
+                let width = match reg_width {
+                    0 => {
+                        if reg_shift >= 2 {
+                            4
+                        } else {
+                            1
+                        }
+                    }
+                    1 | 4 => reg_width,
+                    _ => return Err(DeviceError::ConfigError),
+                };
 
-        // MMIO mode: resolve effective I/O width.
-        // 0 = auto (word if reg_shift >= 2).
-        let width = match config.reg_width {
-            0 => {
-                if config.reg_shift >= 2 {
-                    4
-                } else {
-                    1
+                // 32-bit accesses require 4-byte alignment: reg_shift >= 2
+                // guarantees offsets are multiples of 4.
+                if width == 4 && reg_shift < 2 {
+                    return Err(DeviceError::ConfigError);
+                }
+
+                ResolvedRegs::Mmio {
+                    base: base as usize,
+                    shift: reg_shift,
+                    width,
                 }
             }
-            1 | 4 => config.reg_width,
-            _ => return Err(DeviceError::ConfigError),
         };
 
-        // 32-bit accesses require 4-byte alignment: reg_shift >= 2
-        // guarantees offsets are multiples of 4.
-        if width == 4 && config.reg_shift < 2 {
-            return Err(DeviceError::ConfigError);
-        }
-
         Ok(Self {
-            base: config.base_addr as usize,
-            shift: config.reg_shift,
-            width,
-            access_mode: AccessMode::Mmio,
+            regs,
             clock_freq: config.clock_freq,
             baud_rate: config.baud_rate,
         })

--- a/crates/fstart-driver-ns16550/src/lib.rs
+++ b/crates/fstart-driver-ns16550/src/lib.rs
@@ -127,33 +127,47 @@ register_bitfields! [u8,
 /// 32-bit width).
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum AccessMode {
-    /// Memory-mapped I/O: base address, register shift, I/O width.
+    /// Memory-mapped I/O with configurable register layout.
     ///
     /// `reg_shift` controls address stride: `0` = byte-packed,
     /// `2` = 4-byte spacing (DW APB / sunxi).
     ///
     /// `reg_width` controls bus transaction width: `1` = byte,
     /// `4` = 32-bit word. `0` = auto (word if shift >= 2, else byte).
-    Mmio(u64, u8, u8),
-    /// x86 port I/O: base I/O port address.
+    Mmio {
+        /// Base address of the register block.
+        base: u64,
+        /// Register index shift (0 = byte stride, 2 = 4-byte stride).
+        reg_shift: u8,
+        /// Bus transaction width (0 = auto, 1 = byte, 4 = word).
+        reg_width: u8,
+    },
+    /// x86 port I/O with base I/O port address.
     /// Requires the `pio` feature on this crate.
-    Pio(u64),
+    Pio {
+        /// Base I/O port address (e.g., 0x3F8 for COM1).
+        base: u64,
+    },
 }
 
 impl Default for AccessMode {
     fn default() -> Self {
-        Self::Mmio(0, 0, 0)
+        Self::Mmio {
+            base: 0,
+            reg_shift: 0,
+            reg_width: 0,
+        }
     }
 }
 
 /// Typed configuration for the NS16550 driver.
 ///
 /// The `regs` field selects the register access mechanism:
-///   - `Mmio(base, reg_shift, reg_width)` — memory-mapped I/O
-///   - `Pio(base)` — x86 port I/O (always byte-stride, byte-width)
+///   - `Mmio { base, reg_shift, reg_width }` — memory-mapped I/O
+///   - `Pio { base }` — x86 port I/O (always byte-stride, byte-width)
 ///
 /// Serde defaults ensure backward compatibility: existing board RON
-/// files without explicit `regs` get `Mmio(0, 0, 0)`.
+/// files without explicit `regs` get `Mmio { base: 0, reg_shift: 0, reg_width: 0 }`.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Ns16550Config {
     /// Register access mechanism (MMIO or PIO) with base address.
@@ -311,14 +325,18 @@ impl Device for Ns16550 {
 
     fn new(config: &Ns16550Config) -> Result<Self, DeviceError> {
         let regs = match config.regs {
-            AccessMode::Pio(base) => {
+            AccessMode::Pio { base } => {
                 #[cfg(not(feature = "pio"))]
                 return Err(DeviceError::ConfigError);
 
                 #[cfg(feature = "pio")]
                 ResolvedRegs::Pio { base: base as u16 }
             }
-            AccessMode::Mmio(base, reg_shift, reg_width) => {
+            AccessMode::Mmio {
+                base,
+                reg_shift,
+                reg_width,
+            } => {
                 // Resolve effective I/O width.
                 // 0 = auto (word if reg_shift >= 2).
                 let width = match reg_width {

--- a/crates/fstart-driver-pci-ecam/Cargo.toml
+++ b/crates/fstart-driver-pci-ecam/Cargo.toml
@@ -4,8 +4,15 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+## Use x86 CF8/CFC I/O ports to program the host bridge's PCIEXBAR
+## register, enabling ECAM before the first MMIO config access.
+pio = ["dep:fstart-pio"]
+
 [dependencies]
 fstart-mmio = { workspace = true }
+fstart-pio = { workspace = true, optional = true }
 fstart-services = { workspace = true }
 fstart-log = { workspace = true }
 ufmt = { workspace = true }

--- a/crates/fstart-driver-pci-ecam/src/lib.rs
+++ b/crates/fstart-driver-pci-ecam/src/lib.rs
@@ -24,32 +24,15 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use fstart_services::device::{Device, DeviceError};
-use fstart_services::pci::{PciAddr, PciRootBus, PciWindow, PciWindowKind};
+use fstart_services::pci::{
+    PciAddr, PciRootBus, PciWindow, PciWindowKind, PCI_BAR0, PCI_CLASS_REVISION,
+    PCI_CMD_BUS_MASTER, PCI_CMD_IO, PCI_CMD_MEMORY, PCI_COMMAND, PCI_HEADER_TYPE,
+    PCI_HEADER_TYPE_BRIDGE, PCI_HEADER_TYPE_MULTI_FUNC, PCI_IO_BASE, PCI_MEMORY_BASE,
+    PCI_PREF_BASE_UPPER32, PCI_PREF_LIMIT_UPPER32, PCI_PREF_MEMORY_BASE, PCI_PRIMARY_BUS,
+    PCI_VENDOR_ID, PCI_VENDOR_INVALID,
+};
 use fstart_services::ServiceError;
 use serde::{Deserialize, Serialize};
-
-// -----------------------------------------------------------------------
-// PCI standard register offsets and bits
-// -----------------------------------------------------------------------
-
-const PCI_VENDOR_ID: u16 = 0x00;
-const PCI_COMMAND: u16 = 0x04;
-const PCI_CLASS_REVISION: u16 = 0x08;
-const PCI_HEADER_TYPE: u16 = 0x0E;
-const PCI_BAR0: u16 = 0x10;
-const PCI_PRIMARY_BUS: u16 = 0x18;
-const PCI_IO_BASE: u16 = 0x1C;
-const PCI_MEMORY_BASE: u16 = 0x20;
-const PCI_PREF_MEMORY_BASE: u16 = 0x24;
-const PCI_PREF_BASE_UPPER32: u16 = 0x28;
-const PCI_PREF_LIMIT_UPPER32: u16 = 0x2C;
-
-const PCI_CMD_IO: u16 = 0x0001;
-const PCI_CMD_MEMORY: u16 = 0x0002;
-const PCI_CMD_BUS_MASTER: u16 = 0x0004;
-
-const PCI_HEADER_TYPE_BRIDGE: u8 = 0x01;
-const PCI_HEADER_TYPE_MULTI_FUNC: u8 = 0x80;
 
 // -----------------------------------------------------------------------
 // Config
@@ -354,7 +337,7 @@ impl PciEcam {
     /// Probe a single device/function, size its BARs.
     fn probe_device(&self, addr: PciAddr) -> Option<PciDev> {
         let vendor_device = self.read32(addr, PCI_VENDOR_ID);
-        if vendor_device == 0xFFFF_FFFF {
+        if vendor_device == PCI_VENDOR_INVALID {
             return None;
         }
         let hdr = self.read32(addr, PCI_HEADER_TYPE);
@@ -400,7 +383,7 @@ impl PciEcam {
     fn enumerate_bus(&mut self, bus: u8) {
         for dev in 0..32u8 {
             let addr = PciAddr::new(bus, dev, 0);
-            if self.read32(addr, PCI_VENDOR_ID) == 0xFFFF_FFFF {
+            if self.read32(addr, PCI_VENDOR_ID) == PCI_VENDOR_INVALID {
                 continue;
             }
 
@@ -411,7 +394,7 @@ impl PciEcam {
 
             for func in 0..max_func {
                 let faddr = PciAddr::new(bus, dev, func);
-                if func > 0 && self.read32(faddr, PCI_VENDOR_ID) == 0xFFFF_FFFF {
+                if func > 0 && self.read32(faddr, PCI_VENDOR_ID) == PCI_VENDOR_INVALID {
                     continue;
                 }
 

--- a/crates/fstart-driver-pci-ecam/src/lib.rs
+++ b/crates/fstart-driver-pci-ecam/src/lib.rs
@@ -172,6 +172,59 @@ unsafe impl Send for PciEcam {}
 unsafe impl Sync for PciEcam {}
 
 impl PciEcam {
+    // -- PCIEXBAR bootstrap (x86 only) --
+
+    /// Program the host bridge's PCIEXBAR register to enable ECAM.
+    ///
+    /// On x86, ECAM is not active at reset. The MCH (bus 0, device 0,
+    /// function 0) has a PCIEXBAR register at config offset 0x60 that
+    /// must be programmed via legacy CF8/CFC I/O port config access
+    /// before memory-mapped config space works.
+    ///
+    /// This follows the coreboot Q35 bootblock pattern:
+    ///   1. Write 0 to PCIEXBAR_HI (offset 0x64)
+    ///   2. Write base | length_encoding | enable to PCIEXBAR_LO (0x60)
+    ///
+    /// After these writes, ECAM is live and all subsequent config
+    /// access uses MMIO.
+    #[cfg(feature = "pio")]
+    fn enable_ecam(&self) {
+        const CF8: u16 = 0xCF8;
+        const CFC: u16 = 0xCFC;
+        const PCIEXBAR_LO: u8 = 0x60;
+        const PCIEXBAR_HI: u8 = 0x64;
+
+        // Encode the length field (bits 2:1 of PCIEXBAR_LO).
+        let bus_count = (self.bus_end as u32) - (self.bus_start as u32) + 1;
+        let length_bits: u32 = match bus_count {
+            256 => 0 << 1, // 256 MiB
+            128 => 1 << 1, // 128 MiB
+            64 => 2 << 1,  // 64 MiB
+            _ => 0 << 1,   // default to 256
+        };
+
+        // CF8 address format: (1<<31) | (bus<<16) | (dev<<11) | (fn<<8) | (reg & 0xFC)
+        // Host bridge = bus 0, dev 0, fn 0.
+        let cf8_hi = 0x8000_0000u32 | (PCIEXBAR_HI as u32 & 0xFC);
+        let cf8_lo = 0x8000_0000u32 | (PCIEXBAR_LO as u32 & 0xFC);
+
+        let pciexbar_val = (self.ecam_base as u32) | length_bits | 1; // enable bit
+
+        // SAFETY: CF8/CFC are standard x86 PCI config I/O ports.
+        unsafe {
+            fstart_pio::outl(CF8, cf8_hi);
+            fstart_pio::outl(CFC, 0); // PCIEXBAR high = 0 (below 4 GiB)
+            fstart_pio::outl(CF8, cf8_lo);
+            fstart_pio::outl(CFC, pciexbar_val);
+        }
+
+        fstart_log::info!(
+            "PCI: PCIEXBAR enabled at {:#x} ({} buses)",
+            self.ecam_base,
+            bus_count
+        );
+    }
+
     // -- ECAM helpers --
 
     fn ecam_addr(&self, addr: PciAddr, reg: u16) -> Option<usize> {
@@ -607,6 +660,13 @@ impl Device for PciEcam {
     }
 
     fn init(&mut self) -> Result<(), DeviceError> {
+        // On x86, enable ECAM by programming the host bridge's PCIEXBAR
+        // register via legacy CF8/CFC I/O port config access. After this,
+        // the ECAM MMIO region is live and all config reads/writes go
+        // through memory-mapped access.
+        #[cfg(feature = "pio")]
+        self.enable_ecam();
+
         fstart_log::info!(
             "PCI: enumerating buses {}..{}",
             self.bus_start,

--- a/crates/fstart-driver-pci-ecam/src/lib.rs
+++ b/crates/fstart-driver-pci-ecam/src/lib.rs
@@ -24,7 +24,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use fstart_services::device::{Device, DeviceError};
-use fstart_services::pci::{PciAddr, PciRootBus};
+use fstart_services::pci::{PciAddr, PciRootBus, PciWindow, PciWindowKind};
 use fstart_services::ServiceError;
 use serde::{Deserialize, Serialize};
 
@@ -152,6 +152,12 @@ impl ResourcePool {
 // Driver struct
 // -----------------------------------------------------------------------
 
+/// Maximum number of address windows a single root bridge can have.
+///
+/// Three is typical (low MMIO, high MMIO, I/O) but a few extra slots
+/// accommodate unusual platforms.
+const MAX_WINDOWS: usize = 8;
+
 /// PCI ECAM host bridge driver.
 pub struct PciEcam {
     ecam_base: usize,
@@ -161,6 +167,9 @@ pub struct PciEcam {
     mmio32: ResourcePool,
     mmio64: ResourcePool,
     io_pool: ResourcePool,
+    /// Decoded address windows (original config values, not modified by allocation).
+    windows: [PciWindow; MAX_WINDOWS],
+    window_count: usize,
     devices: Vec<PciDev>,
     /// Next bus number to assign to a bridge.
     next_bus: u8,
@@ -646,6 +655,48 @@ impl Device for PciEcam {
             return Err(DeviceError::ConfigError);
         }
 
+        // Build the window list from the config.  Only add windows that
+        // have a non-zero size (the platform may omit some).
+        let dummy = PciWindow {
+            kind: PciWindowKind::Mmio,
+            base: 0,
+            size: 0,
+            prefetchable: false,
+        };
+        let mut windows = [dummy; MAX_WINDOWS];
+        let mut wc = 0;
+
+        if config.mmio32_size > 0 {
+            windows[wc] = PciWindow {
+                kind: PciWindowKind::Mmio,
+                base: config.mmio32_base,
+                size: config.mmio32_size,
+                prefetchable: false,
+            };
+            wc += 1;
+        }
+        if config.mmio64_size > 0 {
+            windows[wc] = PciWindow {
+                kind: PciWindowKind::Mmio,
+                base: config.mmio64_base,
+                size: config.mmio64_size,
+                // The high MMIO window is typically used for prefetchable
+                // 64-bit BARs (framebuffers, NVMe, etc.).  Mark it
+                // prefetchable so ACPI _CRS descriptors are correct.
+                prefetchable: true,
+            };
+            wc += 1;
+        }
+        if config.pio_size > 0 {
+            windows[wc] = PciWindow {
+                kind: PciWindowKind::Io,
+                base: config.pio_base,
+                size: config.pio_size,
+                prefetchable: false,
+            };
+            wc += 1;
+        }
+
         Ok(Self {
             ecam_base: config.ecam_base as usize,
             ecam_size: config.ecam_size as usize,
@@ -654,6 +705,8 @@ impl Device for PciEcam {
             mmio32: ResourcePool::new(config.mmio32_base, config.mmio32_size),
             mmio64: ResourcePool::new(config.mmio64_base, config.mmio64_size),
             io_pool: ResourcePool::new(config.pio_base, config.pio_size),
+            windows,
+            window_count: wc,
             devices: Vec::new(),
             next_bus: config.bus_start + 1,
         })
@@ -717,5 +770,9 @@ impl PciRootBus for PciEcam {
 
     fn device_count(&self) -> usize {
         self.devices.len()
+    }
+
+    fn windows(&self) -> &[PciWindow] {
+        &self.windows[..self.window_count]
     }
 }

--- a/crates/fstart-driver-pci-ecam/src/lib.rs
+++ b/crates/fstart-driver-pci-ecam/src/lib.rs
@@ -181,57 +181,59 @@ unsafe impl Send for PciEcam {}
 unsafe impl Sync for PciEcam {}
 
 impl PciEcam {
-    // -- PCIEXBAR bootstrap (x86 only) --
+    // -- Window management (public for composition by platform drivers) --
 
-    /// Program the host bridge's PCIEXBAR register to enable ECAM.
+    /// Replace the resource pools and rebuild the external window list.
     ///
-    /// On x86, ECAM is not active at reset. The MCH (bus 0, device 0,
-    /// function 0) has a PCIEXBAR register at config offset 0x60 that
-    /// must be programmed via legacy CF8/CFC I/O port config access
-    /// before memory-mapped config space works.
-    ///
-    /// This follows the coreboot Q35 bootblock pattern:
-    ///   1. Write 0 to PCIEXBAR_HI (offset 0x64)
-    ///   2. Write base | length_encoding | enable to PCIEXBAR_LO (0x60)
-    ///
-    /// After these writes, ECAM is live and all subsequent config
-    /// access uses MMIO.
-    #[cfg(feature = "pio")]
-    fn enable_ecam(&self) {
-        const CF8: u16 = 0xCF8;
-        const CFC: u16 = 0xCFC;
-        const PCIEXBAR_LO: u8 = 0x60;
-        const PCIEXBAR_HI: u8 = 0x64;
+    /// Platform host-bridge drivers (e.g., Q35) use this to set MMIO/IO
+    /// windows computed at runtime from hardware state (TOLUD, e820).
+    /// Must be called **before** `init()`.
+    pub fn configure_windows(
+        &mut self,
+        mmio32_base: u64,
+        mmio32_size: u64,
+        mmio64_base: u64,
+        mmio64_size: u64,
+        pio_base: u64,
+        pio_size: u64,
+    ) {
+        self.mmio32 = ResourcePool::new(mmio32_base, mmio32_size);
+        self.mmio64 = ResourcePool::new(mmio64_base, mmio64_size);
+        self.io_pool = ResourcePool::new(pio_base, pio_size);
+        self.rebuild_windows();
+    }
 
-        // Encode the length field (bits 2:1 of PCIEXBAR_LO).
-        let bus_count = (self.bus_end as u32) - (self.bus_start as u32) + 1;
-        let length_bits: u32 = match bus_count {
-            256 => 0 << 1, // 256 MiB
-            128 => 1 << 1, // 128 MiB
-            64 => 2 << 1,  // 64 MiB
-            _ => 0 << 1,   // default to 256
-        };
+    /// Rebuild the external `windows` array from the current resource pools.
+    fn rebuild_windows(&mut self) {
+        self.window_count = 0;
 
-        // CF8 address format: (1<<31) | (bus<<16) | (dev<<11) | (fn<<8) | (reg & 0xFC)
-        // Host bridge = bus 0, dev 0, fn 0.
-        let cf8_hi = 0x8000_0000u32 | (PCIEXBAR_HI as u32 & 0xFC);
-        let cf8_lo = 0x8000_0000u32 | (PCIEXBAR_LO as u32 & 0xFC);
-
-        let pciexbar_val = (self.ecam_base as u32) | length_bits | 1; // enable bit
-
-        // SAFETY: CF8/CFC are standard x86 PCI config I/O ports.
-        unsafe {
-            fstart_pio::outl(CF8, cf8_hi);
-            fstart_pio::outl(CFC, 0); // PCIEXBAR high = 0 (below 4 GiB)
-            fstart_pio::outl(CF8, cf8_lo);
-            fstart_pio::outl(CFC, pciexbar_val);
+        if self.mmio32.limit > self.mmio32.next {
+            self.windows[self.window_count] = PciWindow {
+                kind: PciWindowKind::Mmio,
+                base: self.mmio32.next,
+                size: self.mmio32.limit - self.mmio32.next,
+                prefetchable: false,
+            };
+            self.window_count += 1;
         }
-
-        fstart_log::info!(
-            "PCI: PCIEXBAR enabled at {:#x} ({} buses)",
-            self.ecam_base,
-            bus_count
-        );
+        if self.mmio64.limit > self.mmio64.next {
+            self.windows[self.window_count] = PciWindow {
+                kind: PciWindowKind::Mmio,
+                base: self.mmio64.next,
+                size: self.mmio64.limit - self.mmio64.next,
+                prefetchable: true,
+            };
+            self.window_count += 1;
+        }
+        if self.io_pool.limit > self.io_pool.next {
+            self.windows[self.window_count] = PciWindow {
+                kind: PciWindowKind::Io,
+                base: self.io_pool.next,
+                size: self.io_pool.limit - self.io_pool.next,
+                prefetchable: false,
+            };
+            self.window_count += 1;
+        }
     }
 
     // -- ECAM helpers --
@@ -713,13 +715,6 @@ impl Device for PciEcam {
     }
 
     fn init(&mut self) -> Result<(), DeviceError> {
-        // On x86, enable ECAM by programming the host bridge's PCIEXBAR
-        // register via legacy CF8/CFC I/O port config access. After this,
-        // the ECAM MMIO region is live and all config reads/writes go
-        // through memory-mapped access.
-        #[cfg(feature = "pio")]
-        self.enable_ecam();
-
         fstart_log::info!(
             "PCI: enumerating buses {}..{}",
             self.bus_start,

--- a/crates/fstart-driver-q35-hostbridge/Cargo.toml
+++ b/crates/fstart-driver-q35-hostbridge/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "fstart-driver-pci-ecam"
+name = "fstart-driver-q35-hostbridge"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [dependencies]
-fstart-mmio = { workspace = true }
+fstart-driver-pci-ecam = { workspace = true }
+fstart-pio = { workspace = true }
 fstart-services = { workspace = true }
 fstart-log = { workspace = true }
 ufmt = { workspace = true }

--- a/crates/fstart-driver-q35-hostbridge/src/lib.rs
+++ b/crates/fstart-driver-q35-hostbridge/src/lib.rs
@@ -1,0 +1,280 @@
+//! Q35 PCI host bridge driver.
+//!
+//! This driver handles the Intel Q35 chipset's PCI root complex as
+//! emulated by QEMU.  It differs from the generic [`PciEcam`] driver in
+//! two ways:
+//!
+//! 1. **ECAM bootstrap via CF8/CFC** — on x86, the ECAM (PCIEXBAR) is
+//!    not active at reset and must be programmed through legacy I/O port
+//!    config access before memory-mapped config space works.
+//!
+//! 2. **Runtime MMIO window computation** — the 32-bit PCI MMIO hole
+//!    depends on the amount of installed DRAM.  The MMIO32 window starts
+//!    at `max(TOLUD, ecam_end)` and runs up to 0xFE00_0000 (below
+//!    IOAPIC / LAPIC / ROM).  TOLUD is derived from the e820 memory map
+//!    that `MemoryDetect` has already populated.
+//!
+//! The driver composes a [`PciEcam`] internally and delegates bus
+//! enumeration, BAR allocation, and `PciRootBus` queries to it.
+//!
+//! Compatible: `"q35-hostbridge"`.
+
+#![no_std]
+
+extern crate alloc;
+
+use fstart_driver_pci_ecam::{PciEcam, PciEcamConfig};
+use fstart_services::device::{Device, DeviceError};
+use fstart_services::memory_detect::E820Entry;
+use fstart_services::pci::{PciAddr, PciRootBus, PciWindow};
+use fstart_services::ServiceError;
+use serde::{Deserialize, Serialize};
+
+/// Upper bound of the 32-bit PCI MMIO window (exclusive).
+///
+/// Below this are the IOAPIC (0xFEC0_0000), LAPIC (0xFEE0_0000), and
+/// the flash/ROM region.  Matches coreboot's `DOMAIN_RESOURCE_32BIT_LIMIT`.
+const MMIO32_LIMIT: u64 = 0xFE00_0000;
+
+/// Fallback 64-bit MMIO limit when CPUID leaf 0x80000008 is unavailable.
+/// 39-bit physical = 512 GiB — conservative for QEMU Q35.
+const MMIO64_LIMIT_FALLBACK: u64 = 0x80_0000_0000;
+
+/// Full x86 I/O port range: 0x0000..0xFFFF (64 KiB).
+/// The PCI root bridge decodes the entire I/O space; legacy ISA
+/// devices below 0x1000 are handled by subtractive decode.
+const PIO_BASE: u64 = 0x0000;
+const PIO_SIZE: u64 = 0x10000;
+
+// -----------------------------------------------------------------------
+// Config
+// -----------------------------------------------------------------------
+
+/// Typed configuration for the Q35 host bridge.
+///
+/// Only the ECAM base/size and bus range are needed.  MMIO windows are
+/// computed at runtime from the e820 memory map.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Q35HostBridgeConfig {
+    /// ECAM base address (PCIEXBAR).  Typically 0xB000_0000 on Q35.
+    pub ecam_base: u64,
+    /// ECAM region size in bytes (256 MiB for 256 buses).
+    pub ecam_size: u64,
+    /// First bus number in this segment.
+    pub bus_start: u8,
+    /// Last bus number in this segment.
+    pub bus_end: u8,
+}
+
+// -----------------------------------------------------------------------
+// Driver
+// -----------------------------------------------------------------------
+
+/// Q35 PCI host bridge driver.
+///
+/// Wraps a [`PciEcam`] with x86-specific ECAM bootstrap and
+/// runtime MMIO window computation.
+pub struct Q35HostBridge {
+    config: Q35HostBridgeConfig,
+    ecam: PciEcam,
+}
+
+// SAFETY: Same as PciEcam — hardware-fixed MMIO addresses,
+// single-threaded firmware init.
+unsafe impl Send for Q35HostBridge {}
+unsafe impl Sync for Q35HostBridge {}
+
+impl Q35HostBridge {
+    /// Program the MCH's PCIEXBAR register via legacy CF8/CFC I/O ports.
+    ///
+    /// After this call, ECAM is live and all PCI config access goes
+    /// through memory-mapped MMIO.
+    fn enable_ecam(&self) {
+        const CF8: u16 = 0xCF8;
+        const CFC: u16 = 0xCFC;
+        const PCIEXBAR_LO: u8 = 0x60;
+        const PCIEXBAR_HI: u8 = 0x64;
+
+        let bus_count = (self.config.bus_end as u32) - (self.config.bus_start as u32) + 1;
+        let length_bits: u32 = match bus_count {
+            256 => 0 << 1, // 256 MiB
+            128 => 1 << 1, // 128 MiB
+            64 => 2 << 1,  // 64 MiB
+            _ => 0 << 1,   // default to 256
+        };
+
+        // CF8 address: (1<<31) | (bus<<16) | (dev<<11) | (fn<<8) | (reg & 0xFC)
+        // Host bridge = bus 0, dev 0, fn 0.
+        let cf8_hi = 0x8000_0000u32 | (PCIEXBAR_HI as u32 & 0xFC);
+        let cf8_lo = 0x8000_0000u32 | (PCIEXBAR_LO as u32 & 0xFC);
+        let pciexbar_val = (self.config.ecam_base as u32) | length_bits | 1;
+
+        // SAFETY: CF8/CFC are standard x86 PCI config I/O ports.
+        unsafe {
+            fstart_pio::outl(CF8, cf8_hi);
+            fstart_pio::outl(CFC, 0); // PCIEXBAR high = 0 (below 4 GiB)
+            fstart_pio::outl(CF8, cf8_lo);
+            fstart_pio::outl(CFC, pciexbar_val);
+        }
+
+        fstart_log::info!(
+            "Q35: PCIEXBAR enabled at {:#x} ({} buses)",
+            self.config.ecam_base,
+            bus_count
+        );
+    }
+
+    /// Compute TOLUD and TOUUD from e820 entries.
+    ///
+    /// - TOLUD: highest RAM end below 4 GiB.
+    /// - TOUUD: highest RAM end (any address).  When there is no RAM
+    ///   above 4 GiB, TOUUD equals 4 GiB so the MMIO64 window starts
+    ///   immediately at the top of the 32-bit space.
+    fn ram_tops_from_e820(entries: &[E820Entry]) -> (u64, u64) {
+        let mut tolud: u64 = 0;
+        let mut touud: u64 = 0x1_0000_0000; // default: 4 GiB
+        for e in entries {
+            // kind == 1 is E820Kind::Ram
+            if e.kind == 1 {
+                let top = e.addr.saturating_add(e.size);
+                if top <= 0x1_0000_0000 && top > tolud {
+                    tolud = top;
+                }
+                if top > touud {
+                    touud = top;
+                }
+            }
+        }
+        (tolud, touud)
+    }
+
+    /// Configure MMIO windows from the e820 memory map and call
+    /// `init()` on the inner PCI ECAM driver.
+    ///
+    /// This is the main entry point.  The codegen calls this instead of
+    /// the `Device::init()` trait method, passing the e820 data that
+    /// `MemoryDetect` has already populated.
+    ///
+    /// Window computation follows coreboot's Q35/i440fx pattern:
+    /// - **MMIO32**: `max(TOLUD, ecam_end)` up to `0xFE00_0000`
+    /// - **MMIO64**: starts above TOUUD (top of all RAM), extends to
+    ///   the CPU's physical address limit
+    /// - **I/O**: full 64 KiB port space (`0x0000..0xFFFF`)
+    pub fn init_with_e820(&mut self, entries: &[E820Entry]) -> Result<(), DeviceError> {
+        // Step 1: Enable ECAM via CF8/CFC.
+        self.enable_ecam();
+
+        // Step 2: Compute MMIO windows from memory layout.
+        let (tolud, touud) = Self::ram_tops_from_e820(entries);
+        let ecam_end = self.config.ecam_base + self.config.ecam_size;
+
+        // MMIO32 starts after both DRAM and ECAM.
+        let mmio32_base = core::cmp::max(tolud, ecam_end);
+        let mmio32_size = MMIO32_LIMIT.saturating_sub(mmio32_base);
+
+        // MMIO64 starts above all RAM (including high RAM above 4 GiB).
+        let mmio64_base = touud;
+        let mmio64_size = MMIO64_LIMIT_FALLBACK.saturating_sub(mmio64_base);
+
+        fstart_log::info!("Q35: TOLUD={:#x} TOUUD={:#x}", tolud, touud);
+        fstart_log::info!("Q35: MMIO32={:#x}..{:#x}", mmio32_base, MMIO32_LIMIT);
+        fstart_log::info!(
+            "Q35: MMIO64={:#x}..{:#x}",
+            mmio64_base,
+            mmio64_base + mmio64_size
+        );
+
+        self.ecam.configure_windows(
+            mmio32_base,
+            mmio32_size,
+            mmio64_base,
+            mmio64_size,
+            PIO_BASE,
+            PIO_SIZE,
+        );
+
+        // Step 3: Enumerate and allocate (delegated to PciEcam).
+        self.ecam.init()
+    }
+}
+
+// -----------------------------------------------------------------------
+// Device trait
+// -----------------------------------------------------------------------
+
+impl Device for Q35HostBridge {
+    const NAME: &'static str = "q35-hostbridge";
+    const COMPATIBLE: &'static [&'static str] = &["q35-hostbridge"];
+    type Config = Q35HostBridgeConfig;
+
+    fn new(config: &Q35HostBridgeConfig) -> Result<Self, DeviceError> {
+        // Create the inner PciEcam with zero-sized windows.  The real
+        // windows are set by init_with_e820() before enumeration.
+        let ecam_config = PciEcamConfig {
+            ecam_base: config.ecam_base,
+            ecam_size: config.ecam_size,
+            mmio32_base: 0,
+            mmio32_size: 0,
+            mmio64_base: 0,
+            mmio64_size: 0,
+            pio_base: 0,
+            pio_size: 0,
+            bus_start: config.bus_start,
+            bus_end: config.bus_end,
+        };
+        let ecam = PciEcam::new(&ecam_config)?;
+
+        Ok(Self {
+            config: *config,
+            ecam,
+        })
+    }
+
+    fn init(&mut self) -> Result<(), DeviceError> {
+        // Bare init() without e820 data cannot compute windows.
+        // Platform codegen should call init_with_e820() instead.
+        fstart_log::error!(
+            "Q35HostBridge::init() called without e820 data; \
+             use init_with_e820() instead"
+        );
+        Err(DeviceError::InitFailed)
+    }
+}
+
+// -----------------------------------------------------------------------
+// PciRootBus — delegate to inner PciEcam
+// -----------------------------------------------------------------------
+
+impl PciRootBus for Q35HostBridge {
+    fn config_read32(&self, addr: PciAddr, reg: u16) -> Result<u32, ServiceError> {
+        self.ecam.config_read32(addr, reg)
+    }
+
+    fn config_write32(&self, addr: PciAddr, reg: u16, val: u32) -> Result<(), ServiceError> {
+        self.ecam.config_write32(addr, reg, val)
+    }
+
+    fn ecam_base(&self) -> u64 {
+        self.ecam.ecam_base()
+    }
+
+    fn ecam_size(&self) -> u64 {
+        self.ecam.ecam_size()
+    }
+
+    fn bus_start(&self) -> u8 {
+        self.ecam.bus_start()
+    }
+
+    fn bus_end(&self) -> u8 {
+        self.ecam.bus_end()
+    }
+
+    fn device_count(&self) -> usize {
+        self.ecam.device_count()
+    }
+
+    fn windows(&self) -> &[PciWindow] {
+        self.ecam.windows()
+    }
+}

--- a/crates/fstart-driver-q35-hostbridge/src/lib.rs
+++ b/crates/fstart-driver-q35-hostbridge/src/lib.rs
@@ -62,9 +62,14 @@ const PAM0: u16 = 0x90;
 /// into this table.
 const Q35_IRQS: [u8; 8] = [10, 10, 11, 11, 10, 10, 11, 11];
 
-/// Fallback 64-bit MMIO limit when CPUID leaf 0x80000008 is unavailable.
-/// 39-bit physical = 512 GiB — conservative for QEMU Q35.
-const MMIO64_LIMIT_FALLBACK: u64 = 0x80_0000_0000;
+/// Default 64-bit MMIO limit: 39-bit physical = 512 GiB.
+/// Used as a conservative fallback when CPUID detection fails.
+const MMIO64_LIMIT_DEFAULT: u64 = 0x80_0000_0000;
+
+/// Expected Q35 MCH (host bridge) PCI vendor/device ID.
+/// Intel 82G33/G31/P35/P31 Express DRAM Controller (device 29c0).
+const Q35_MCH_VID: u16 = 0x8086;
+const Q35_MCH_DID: u16 = 0x29C0;
 
 /// Full x86 I/O port range: 0x0000..0xFFFF (64 KiB).
 /// The PCI root bridge decodes the entire I/O space; legacy ISA
@@ -249,6 +254,81 @@ impl Q35HostBridge {
         (tolud, touud)
     }
 
+    /// Read the CPU's physical address width from CPUID leaf 0x80000008.
+    ///
+    /// Returns the MMIO64 limit (1 << phys_bits). Falls back to
+    /// `MMIO64_LIMIT_DEFAULT` (39-bit / 512 GiB) if the leaf is
+    /// unavailable.
+    fn detect_phys_addr_limit() -> u64 {
+        // SAFETY: CPUID is always available on x86_64.
+        let (max_ext_leaf, _, _, _) = unsafe { Self::cpuid(0x80000000) };
+        if max_ext_leaf < 0x80000008 {
+            fstart_log::info!(
+                "Q35: CPUID 0x80000008 unavailable, using {}-bit default",
+                MMIO64_LIMIT_DEFAULT.trailing_zeros()
+            );
+            return MMIO64_LIMIT_DEFAULT;
+        }
+        let (eax, _, _, _) = unsafe { Self::cpuid(0x80000008) };
+        let phys_bits = (eax & 0xFF) as u32;
+        let limit = if phys_bits >= 64 {
+            u64::MAX
+        } else {
+            1u64 << phys_bits
+        };
+        fstart_log::info!("Q35: physical address width: {} bits", phys_bits);
+        limit
+    }
+
+    /// Execute CPUID instruction.
+    ///
+    /// # Safety
+    /// Only valid on x86/x86_64 targets.
+    #[inline]
+    unsafe fn cpuid(leaf: u32) -> (u32, u32, u32, u32) {
+        let (eax, ebx, ecx, edx): (u32, u32, u32, u32);
+        unsafe {
+            core::arch::asm!(
+                "push rbx",
+                "cpuid",
+                "mov {ebx_out:e}, ebx",
+                "pop rbx",
+                in("eax") leaf,
+                in("ecx") 0u32,
+                ebx_out = out(reg) ebx,
+                lateout("eax") eax,
+                lateout("ecx") ecx,
+                lateout("edx") edx,
+                options(nomem),
+            );
+        }
+        (eax, ebx, ecx, edx)
+    }
+
+    /// Verify that the MCH at bus 0, dev 0, fn 0 is the expected Q35 device.
+    ///
+    /// Reads the PCI vendor/device ID via legacy CF8/CFC before ECAM is
+    /// active. Matches coreboot's `mainboard_machine_check()` pattern.
+    fn verify_machine_type(&self) -> Result<(), DeviceError> {
+        // SAFETY: CF8/CFC is the standard x86 PCI config I/O port pair.
+        let vid = unsafe { fstart_pio::pci_cfg_read32(0, 0, 0, 0) };
+        let vendor = (vid & 0xFFFF) as u16;
+        let device = ((vid >> 16) & 0xFFFF) as u16;
+        if vendor != Q35_MCH_VID || device != Q35_MCH_DID {
+            fstart_log::error!(
+                "Q35: unexpected MCH at 00:00.0: vendor={:#06x} device={:#06x} \
+                 (expected {:#06x}:{:#06x})",
+                vendor,
+                device,
+                Q35_MCH_VID,
+                Q35_MCH_DID
+            );
+            return Err(DeviceError::InitFailed);
+        }
+        fstart_log::info!("Q35: MCH verified ({:#06x}:{:#06x})", vendor, device);
+        Ok(())
+    }
+
     /// Configure MMIO windows from the e820 memory map and call
     /// `init()` on the inner PCI ECAM driver.
     ///
@@ -259,9 +339,12 @@ impl Q35HostBridge {
     /// Window computation follows coreboot's Q35/i440fx pattern:
     /// - **MMIO32**: `max(TOLUD, ecam_end)` up to `0xFE00_0000`
     /// - **MMIO64**: starts above TOUUD (top of all RAM), extends to
-    ///   the CPU's physical address limit
+    ///   the CPU's physical address limit (from CPUID 0x80000008)
     /// - **I/O**: full 64 KiB port space (`0x0000..0xFFFF`)
     pub fn init_with_e820(&mut self, entries: &[E820Entry]) -> Result<(), DeviceError> {
+        // Step 0: Verify we're running on Q35 hardware (read MCH PCI ID).
+        self.verify_machine_type()?;
+
         // Step 1: Enable ECAM via CF8/CFC.
         self.enable_ecam();
 
@@ -277,8 +360,10 @@ impl Q35HostBridge {
         let mmio32_size = MMIO32_LIMIT.saturating_sub(mmio32_base);
 
         // MMIO64 starts above all RAM (including high RAM above 4 GiB).
+        // Use CPUID to determine the CPU's actual physical address width.
+        let mmio64_limit = Self::detect_phys_addr_limit();
         let mmio64_base = touud;
-        let mmio64_size = MMIO64_LIMIT_FALLBACK.saturating_sub(mmio64_base);
+        let mmio64_size = mmio64_limit.saturating_sub(mmio64_base);
 
         fstart_log::info!("Q35: TOLUD={:#x} TOUUD={:#x}", tolud, touud);
         fstart_log::info!("Q35: MMIO32={:#x}..{:#x}", mmio32_base, MMIO32_LIMIT);
@@ -340,13 +425,18 @@ impl Device for Q35HostBridge {
     }
 
     fn init(&mut self) -> Result<(), DeviceError> {
-        // Bare init() without e820 data cannot compute windows.
-        // Platform codegen should call init_with_e820() instead.
-        fstart_log::error!(
-            "Q35HostBridge::init() called without e820 data; \
-             use init_with_e820() instead"
-        );
-        Err(DeviceError::InitFailed)
+        // Read e820 data from the global state populated by MemoryDetect.
+        // SAFETY: single-threaded firmware init; MemoryDetect runs before
+        // PciInit in the capability pipeline order.
+        let state = unsafe { fstart_services::memory_detect::e820_state() };
+        if state.count() == 0 {
+            fstart_log::error!(
+                "Q35HostBridge::init(): no e820 data available. \
+                 Ensure MemoryDetect runs before PciInit."
+            );
+            return Err(DeviceError::InitFailed);
+        }
+        self.init_with_e820(state.entries())
     }
 }
 

--- a/crates/fstart-driver-q35-hostbridge/src/lib.rs
+++ b/crates/fstart-driver-q35-hostbridge/src/lib.rs
@@ -26,7 +26,10 @@ extern crate alloc;
 use fstart_driver_pci_ecam::{PciEcam, PciEcamConfig};
 use fstart_services::device::{Device, DeviceError};
 use fstart_services::memory_detect::E820Entry;
-use fstart_services::pci::{PciAddr, PciRootBus, PciWindow};
+use fstart_services::pci::{
+    PciAddr, PciRootBus, PciWindow, PCI_HEADER_TYPE, PCI_HEADER_TYPE_MULTI_FUNC,
+    PCI_INTERRUPT_LINE, PCI_INTERRUPT_PIN, PCI_VENDOR_ID,
+};
 use fstart_services::ServiceError;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +38,29 @@ use serde::{Deserialize, Serialize};
 /// Below this are the IOAPIC (0xFEC0_0000), LAPIC (0xFEE0_0000), and
 /// the flash/ROM region.  Matches coreboot's `DOMAIN_RESOURCE_32BIT_LIMIT`.
 const MMIO32_LIMIT: u64 = 0xFE00_0000;
+
+// -----------------------------------------------------------------------
+// Q35 MCH (bus 0, dev 0, fn 0) register offsets
+// -----------------------------------------------------------------------
+
+/// PAM registers: Programmable Attribute Map.
+///
+/// 7 registers (PAM0..PAM6) control access routing for the legacy
+/// 0xC0000-0xFFFFF region.  Each register has two 4-bit nibbles
+/// controlling two 16 KiB sub-regions.  Value `0x3` per nibble =
+/// full DRAM read+write.
+const PAM0: u16 = 0x90;
+
+// -----------------------------------------------------------------------
+// PCI IRQ routing table — matches coreboot qemu-q35 mainboard.c
+// -----------------------------------------------------------------------
+
+/// IRQ rotation table for PCI slots.
+///
+/// Uses legacy PIC IRQs 10 and 11 only.  Each PCI device has 4 interrupt
+/// pins (INTA-INTD); the slot number mod 4 selects a starting offset
+/// into this table.
+const Q35_IRQS: [u8; 8] = [10, 10, 11, 11, 10, 10, 11, 11];
 
 /// Fallback 64-bit MMIO limit when CPUID leaf 0x80000008 is unavailable.
 /// 39-bit physical = 512 GiB — conservative for QEMU Q35.
@@ -90,8 +116,6 @@ impl Q35HostBridge {
     /// After this call, ECAM is live and all PCI config access goes
     /// through memory-mapped MMIO.
     fn enable_ecam(&self) {
-        const CF8: u16 = 0xCF8;
-        const CFC: u16 = 0xCFC;
         const PCIEXBAR_LO: u8 = 0x60;
         const PCIEXBAR_HI: u8 = 0x64;
 
@@ -103,18 +127,13 @@ impl Q35HostBridge {
             _ => 0 << 1,   // default to 256
         };
 
-        // CF8 address: (1<<31) | (bus<<16) | (dev<<11) | (fn<<8) | (reg & 0xFC)
-        // Host bridge = bus 0, dev 0, fn 0.
-        let cf8_hi = 0x8000_0000u32 | (PCIEXBAR_HI as u32 & 0xFC);
-        let cf8_lo = 0x8000_0000u32 | (PCIEXBAR_LO as u32 & 0xFC);
         let pciexbar_val = (self.config.ecam_base as u32) | length_bits | 1;
 
-        // SAFETY: CF8/CFC are standard x86 PCI config I/O ports.
+        // SAFETY: MCH is at bus 0, dev 0, fn 0.  CF8/CFC are standard
+        // x86 PCI config I/O ports.
         unsafe {
-            fstart_pio::outl(CF8, cf8_hi);
-            fstart_pio::outl(CFC, 0); // PCIEXBAR high = 0 (below 4 GiB)
-            fstart_pio::outl(CF8, cf8_lo);
-            fstart_pio::outl(CFC, pciexbar_val);
+            fstart_pio::pci_cfg_write32(0, 0, 0, PCIEXBAR_HI, 0);
+            fstart_pio::pci_cfg_write32(0, 0, 0, PCIEXBAR_LO, pciexbar_val);
         }
 
         fstart_log::info!(
@@ -122,6 +141,88 @@ impl Q35HostBridge {
             self.config.ecam_base,
             bus_count
         );
+    }
+
+    /// Open the legacy 0xC0000-0xFFFFF region for DRAM read/write.
+    ///
+    /// PAM0 controls 0xF0000-0xFFFFF (the BIOS area) — read-modify-write
+    /// to preserve the lower nibble.  PAM1-6 each control two 16 KiB
+    /// sub-regions; `0x33` enables DRAM R/W for both.
+    ///
+    /// Matches coreboot `qemu_nb_init()` in `qemu-q35/mainboard.c`.
+    fn program_pam(&self) {
+        let mch = PciAddr::new(0, 0, 0);
+
+        // PAM0: preserve lower nibble, set upper nibble to 0x3 (DRAM R/W
+        // for 0xF0000-0xFFFFF).
+        let pam0 = self.ecam.config_read8(mch, PAM0).unwrap_or(0);
+        let _ = self.ecam.config_write8(mch, PAM0, pam0 | 0x30);
+
+        // PAM1-PAM6: full DRAM access for 0xC0000-0xEFFFF.
+        for i in 1u16..=6 {
+            let _ = self.ecam.config_write8(mch, PAM0 + i, 0x33);
+        }
+
+        fstart_log::info!("Q35: PAM0-6 programmed (legacy region -> DRAM)");
+    }
+
+    /// Assign PCI interrupt lines to all discovered devices.
+    ///
+    /// Follows coreboot's Q35 IRQ assignment pattern:
+    /// - Slots 0-24: IRQ table offset by `slot % 4` (standard swizzle)
+    /// - Slots 25-31: IRQ table at offset 0 (southbridge devices)
+    ///
+    /// For each device that has an interrupt pin configured, writes the
+    /// IRQ number to `PCI_INTERRUPT_LINE` (config reg 0x3C).
+    fn assign_irqs(&self) {
+        let bus = self.ecam.bus_start();
+        for slot in 0u8..32 {
+            // Check if a device exists at this slot (function 0).
+            let addr = PciAddr::new(bus, slot, 0);
+            let vendor = self
+                .ecam
+                .config_read16(addr, PCI_VENDOR_ID)
+                .unwrap_or(0xFFFF);
+            if vendor == 0xFFFF {
+                continue;
+            }
+
+            let offset = if slot < 25 { (slot as usize) % 4 } else { 0 };
+
+            // Assign IRQs for all functions of this device.
+            let max_func = if self.is_multifunction(addr) { 8 } else { 1 };
+            for func in 0..max_func {
+                let faddr = PciAddr::new(bus, slot, func);
+                if func > 0 {
+                    let fv = self
+                        .ecam
+                        .config_read16(faddr, PCI_VENDOR_ID)
+                        .unwrap_or(0xFFFF);
+                    if fv == 0xFFFF {
+                        continue;
+                    }
+                }
+                let pin = self
+                    .ecam
+                    .config_read8(faddr, PCI_INTERRUPT_PIN)
+                    .unwrap_or(0);
+                if pin == 0 || pin > 4 {
+                    continue; // no interrupt pin
+                }
+                // Pin 1=INTA..4=INTD, index into rotated table.
+                let irq_idx = (offset + (pin as usize) - 1) % Q35_IRQS.len();
+                let irq = Q35_IRQS[irq_idx];
+                let _ = self.ecam.config_write8(faddr, PCI_INTERRUPT_LINE, irq);
+            }
+        }
+
+        fstart_log::info!("Q35: PCI IRQ routing assigned");
+    }
+
+    /// Check if device at `addr` is multi-function (bit 7 of header type).
+    fn is_multifunction(&self, addr: PciAddr) -> bool {
+        let hdr = self.ecam.config_read8(addr, PCI_HEADER_TYPE).unwrap_or(0);
+        hdr & PCI_HEADER_TYPE_MULTI_FUNC != 0
     }
 
     /// Compute TOLUD and TOUUD from e820 entries.
@@ -164,7 +265,10 @@ impl Q35HostBridge {
         // Step 1: Enable ECAM via CF8/CFC.
         self.enable_ecam();
 
-        // Step 2: Compute MMIO windows from memory layout.
+        // Step 2: Open legacy region (0xC0000-0xFFFFF) for DRAM access.
+        self.program_pam();
+
+        // Step 3: Compute MMIO windows from memory layout.
         let (tolud, touud) = Self::ram_tops_from_e820(entries);
         let ecam_end = self.config.ecam_base + self.config.ecam_size;
 
@@ -193,8 +297,13 @@ impl Q35HostBridge {
             PIO_SIZE,
         );
 
-        // Step 3: Enumerate and allocate (delegated to PciEcam).
-        self.ecam.init()
+        // Step 4: Enumerate and allocate BARs (delegated to PciEcam).
+        self.ecam.init()?;
+
+        // Step 5: Assign PCI IRQ routing to all discovered devices.
+        self.assign_irqs();
+
+        Ok(())
     }
 }
 

--- a/crates/fstart-driver-qemu-fw-cfg/Cargo.toml
+++ b/crates/fstart-driver-qemu-fw-cfg/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fstart-driver-qemu-fw-cfg"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+fstart-log = { workspace = true }
+fstart-pio = { workspace = true }
+fstart-services = { workspace = true }
+serde = { workspace = true }
+ufmt = { workspace = true }

--- a/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
+++ b/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
@@ -1,0 +1,462 @@
+//! QEMU fw_cfg device driver.
+//!
+//! The fw_cfg device provides firmware configuration data from QEMU,
+//! including ACPI tables, the e820 memory map, CPU count, and more.
+//!
+//! On x86, the device uses I/O ports:
+//! - Control port (default `0x0510`): write 16-bit selector to choose a file
+//! - Data port (default `0x0511`): read data byte-by-byte
+//!
+//! The ACPI table loading uses the table-loader protocol (`etc/table-loader`),
+//! which is a sequence of ALLOCATE/ADD_POINTER/ADD_CHECKSUM commands that
+//! dynamically link ACPI tables into a memory buffer.
+//!
+//! Reference: QEMU `docs/specs/fw_cfg.rst` and coreboot
+//! `src/drivers/emulation/qemu/fw_cfg.c`.
+
+#![no_std]
+
+use fstart_services::acpi_provider::AcpiTableProvider;
+use fstart_services::device::{Device, DeviceError};
+use fstart_services::memory_detect::{E820Entry, E820Kind, MemoryDetector};
+use fstart_services::ServiceError;
+
+// ---------------------------------------------------------------------------
+// Well-known fw_cfg selectors
+// ---------------------------------------------------------------------------
+
+const FW_CFG_SIGNATURE: u16 = 0x0000;
+const FW_CFG_ID: u16 = 0x0001;
+const FW_CFG_FILE_DIR: u16 = 0x0019;
+
+// ---------------------------------------------------------------------------
+// Table-loader command types
+// ---------------------------------------------------------------------------
+
+const COMMAND_ALLOCATE: u32 = 1;
+const COMMAND_ADD_POINTER: u32 = 2;
+const COMMAND_ADD_CHECKSUM: u32 = 3;
+
+/// Zone hint for ALLOCATE: must be in the FSEG area (below 1MB).
+#[allow(dead_code)]
+const ALLOC_ZONE_HIGH: u8 = 1;
+/// Zone hint for ALLOCATE: can be anywhere in RAM.
+#[allow(dead_code)]
+const ALLOC_ZONE_FSEG: u8 = 2;
+
+// ---------------------------------------------------------------------------
+// Config type
+// ---------------------------------------------------------------------------
+
+/// Configuration for the QEMU fw_cfg driver.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct QemuFwCfgConfig {
+    /// I/O port for the control/selector register.
+    #[serde(default = "default_ctl_port")]
+    pub ctl_port: u16,
+    /// I/O port for the data register.
+    #[serde(default = "default_data_port")]
+    pub data_port: u16,
+}
+
+fn default_ctl_port() -> u16 {
+    0x0510
+}
+fn default_data_port() -> u16 {
+    0x0511
+}
+
+// ---------------------------------------------------------------------------
+// Driver struct
+// ---------------------------------------------------------------------------
+
+/// QEMU fw_cfg device driver.
+///
+/// Provides access to QEMU's firmware configuration interface via I/O ports.
+/// Implements `AcpiTableProvider` (table-loader protocol) and
+/// `MemoryDetector` (e820 from `etc/e820` file).
+pub struct QemuFwCfg {
+    ctl_port: u16,
+    data_port: u16,
+}
+
+// SAFETY: The I/O port addresses are fixed by board configuration and
+// access is inherently serialized by the single-threaded firmware.
+unsafe impl Send for QemuFwCfg {}
+unsafe impl Sync for QemuFwCfg {}
+
+impl QemuFwCfg {
+    /// Write a 16-bit selector to the control port.
+    fn select(&self, selector: u16) {
+        // SAFETY: port address is from board config; firmware is single-threaded.
+        unsafe { fstart_pio::outw(self.ctl_port, selector) };
+    }
+
+    /// Read `n` bytes from the data port into `buf`.
+    fn read_bytes(&self, buf: &mut [u8]) {
+        for byte in buf.iter_mut() {
+            // SAFETY: port address is from board config; firmware is single-threaded.
+            *byte = unsafe { fstart_pio::inb(self.data_port) };
+        }
+    }
+
+    /// Read a big-endian u16 from the data port.
+    fn read_be16(&self) -> u16 {
+        let mut buf = [0u8; 2];
+        self.read_bytes(&mut buf);
+        u16::from_be_bytes(buf)
+    }
+
+    /// Read a big-endian u32 from the data port.
+    fn read_be32(&self) -> u32 {
+        let mut buf = [0u8; 4];
+        self.read_bytes(&mut buf);
+        u32::from_be_bytes(buf)
+    }
+
+    /// Check that the fw_cfg device is present by reading the signature.
+    fn check_signature(&self) -> bool {
+        self.select(FW_CFG_SIGNATURE);
+        let mut sig = [0u8; 4];
+        self.read_bytes(&mut sig);
+        &sig == b"QEMU"
+    }
+
+    /// Find a named file in the fw_cfg directory.
+    ///
+    /// Returns `(selector, size)` if found.
+    fn find_file(&self, name: &str) -> Option<(u16, u32)> {
+        self.select(FW_CFG_FILE_DIR);
+        let count = self.read_be32();
+
+        for _ in 0..count {
+            let size = self.read_be32();
+            let selector = self.read_be16();
+            let _reserved = self.read_be16();
+            let mut fname = [0u8; 56];
+            self.read_bytes(&mut fname);
+
+            // Compare names (fname is NUL-terminated)
+            let fname_len = fname.iter().position(|&b| b == 0).unwrap_or(56);
+            if fname_len == name.len() && &fname[..fname_len] == name.as_bytes() {
+                return Some((selector, size));
+            }
+        }
+        fstart_log::error!(
+            "fw_cfg: find_file('{}') not found in {} entries",
+            name,
+            count
+        );
+        None
+    }
+
+    /// Read an entire fw_cfg file into `buf`.
+    fn read_file(&self, selector: u16, buf: &mut [u8]) {
+        self.select(selector);
+        self.read_bytes(buf);
+    }
+}
+
+impl Device for QemuFwCfg {
+    const NAME: &'static str = "qemu-fw-cfg";
+    const COMPATIBLE: &'static [&'static str] = &["qemu,fw-cfg"];
+    type Config = QemuFwCfgConfig;
+
+    fn new(config: &QemuFwCfgConfig) -> Result<Self, DeviceError> {
+        Ok(Self {
+            ctl_port: config.ctl_port,
+            data_port: config.data_port,
+        })
+    }
+
+    fn init(&mut self) -> Result<(), DeviceError> {
+        if !self.check_signature() {
+            return Err(DeviceError::InitFailed);
+        }
+        // Read the ID register to verify DMA capability (informational)
+        self.select(FW_CFG_ID);
+        let mut _id_buf = [0u8; 4];
+        self.read_bytes(&mut _id_buf);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AcpiTableProvider — table-loader protocol
+// ---------------------------------------------------------------------------
+
+/// Tracking entry for an allocated table in the buffer.
+struct AllocEntry {
+    /// File name (NUL-terminated, up to 56 bytes).
+    name: [u8; 56],
+    /// Offset within the output buffer where this file was placed.
+    offset: usize,
+    /// Size of the file data.
+    size: usize,
+}
+
+impl AcpiTableProvider for QemuFwCfg {
+    fn load_acpi_tables(&self, buffer: &mut [u8]) -> Result<u64, ServiceError> {
+        // Find the table-loader file
+        fstart_log::info!("fw_cfg: looking for etc/table-loader...");
+        let (loader_sel, loader_size) = self
+            .find_file("etc/table-loader")
+            .ok_or(ServiceError::NotSupported)?;
+        fstart_log::info!(
+            "fw_cfg: table-loader found (sel={}, size={})",
+            loader_sel as u32,
+            loader_size
+        );
+
+        // Read the loader commands into a temporary buffer on the stack.
+        // Each command is 128 bytes. Typical QEMU has < 20 commands.
+        const MAX_CMDS: usize = 64;
+        let mut loader_buf = [0u8; MAX_CMDS * 128];
+        let cmd_count = (loader_size as usize) / 128;
+        if cmd_count > MAX_CMDS {
+            return Err(ServiceError::InvalidParam);
+        }
+        self.read_file(loader_sel, &mut loader_buf[..loader_size as usize]);
+        fstart_log::info!("fw_cfg: {} table-loader commands", cmd_count as u32);
+
+        // Track allocations (file name → buffer offset)
+        let mut allocs: [Option<AllocEntry>; 32] = core::array::from_fn(|_| None);
+        let mut alloc_count = 0usize;
+        let mut cursor = 0usize; // next free position in buffer
+
+        // Process commands
+        for i in 0..cmd_count {
+            let cmd_base = i * 128;
+            let command =
+                u32::from_le_bytes(loader_buf[cmd_base..cmd_base + 4].try_into().unwrap());
+
+            match command {
+                COMMAND_ALLOCATE => {
+                    // Bytes 4..60: file name (56 bytes, NUL-terminated)
+                    let mut name = [0u8; 56];
+                    name.copy_from_slice(&loader_buf[cmd_base + 4..cmd_base + 60]);
+                    // Bytes 60..64: alignment
+                    let align = u32::from_le_bytes(
+                        loader_buf[cmd_base + 60..cmd_base + 64].try_into().unwrap(),
+                    ) as usize;
+
+                    // Find and read the file
+                    let name_len = name.iter().position(|&b| b == 0).unwrap_or(56);
+                    let name_str = core::str::from_utf8(&name[..name_len]).unwrap_or("?");
+                    fstart_log::info!("fw_cfg: ALLOCATE '{}'", name_str);
+                    let (file_sel, file_size) = match self.find_file(name_str) {
+                        Some(v) => v,
+                        None => {
+                            fstart_log::error!("fw_cfg: file '{}' not found", name_str);
+                            return Err(ServiceError::IoError);
+                        }
+                    };
+
+                    fstart_log::info!(
+                        "fw_cfg:   found sel={} size={} align={}",
+                        file_sel as u32,
+                        file_size,
+                        align as u32
+                    );
+
+                    // Align cursor
+                    let align = align.max(1);
+                    cursor = (cursor + align - 1) & !(align - 1);
+
+                    if cursor + file_size as usize > buffer.len() {
+                        fstart_log::error!(
+                            "fw_cfg: buffer overflow: cursor={} + size={} > buf={}",
+                            cursor as u32,
+                            file_size,
+                            buffer.len() as u32
+                        );
+                        return Err(ServiceError::InvalidParam);
+                    }
+
+                    // Read file data into buffer
+                    self.read_file(file_sel, &mut buffer[cursor..cursor + file_size as usize]);
+
+                    if alloc_count < allocs.len() {
+                        allocs[alloc_count] = Some(AllocEntry {
+                            name,
+                            offset: cursor,
+                            size: file_size as usize,
+                        });
+                        alloc_count += 1;
+                    }
+                    cursor += file_size as usize;
+                }
+
+                COMMAND_ADD_POINTER => {
+                    // Bytes 4..60: dest_file (56 bytes)
+                    let dest_name = &loader_buf[cmd_base + 4..cmd_base + 60];
+                    // Bytes 60..116: src_file (56 bytes)
+                    let src_name = &loader_buf[cmd_base + 60..cmd_base + 116];
+                    // Bytes 116..120: offset within dest_file
+                    let ptr_offset = u32::from_le_bytes(
+                        loader_buf[cmd_base + 116..cmd_base + 120]
+                            .try_into()
+                            .unwrap(),
+                    ) as usize;
+                    // Bytes 120: pointer size (1, 2, 4, or 8)
+                    let ptr_size = loader_buf[cmd_base + 120];
+
+                    // Find dest and src allocations
+                    let dest_off = find_alloc(&allocs, dest_name).ok_or(ServiceError::IoError)?;
+                    let src_off = find_alloc(&allocs, src_name).ok_or(ServiceError::IoError)?;
+
+                    // Read existing value, add src's physical address, write back
+                    let patch_off = dest_off + ptr_offset;
+                    let src_phys = buffer.as_ptr() as u64 + src_off as u64;
+
+                    match ptr_size {
+                        4 => {
+                            let mut val = u32::from_le_bytes(
+                                buffer[patch_off..patch_off + 4].try_into().unwrap(),
+                            );
+                            val = val.wrapping_add(src_phys as u32);
+                            buffer[patch_off..patch_off + 4].copy_from_slice(&val.to_le_bytes());
+                        }
+                        8 => {
+                            let mut val = u64::from_le_bytes(
+                                buffer[patch_off..patch_off + 8].try_into().unwrap(),
+                            );
+                            val = val.wrapping_add(src_phys);
+                            buffer[patch_off..patch_off + 8].copy_from_slice(&val.to_le_bytes());
+                        }
+                        _ => {
+                            // 1-byte and 2-byte pointers are unusual but handled
+                        }
+                    }
+                }
+
+                COMMAND_ADD_CHECKSUM => {
+                    // Bytes 4..60: file name (56 bytes)
+                    let cksum_name = &loader_buf[cmd_base + 4..cmd_base + 60];
+                    // Bytes 60..64: offset for checksum byte
+                    let cksum_offset = u32::from_le_bytes(
+                        loader_buf[cmd_base + 60..cmd_base + 64].try_into().unwrap(),
+                    ) as usize;
+                    // Bytes 64..68: start offset for sum range
+                    let start = u32::from_le_bytes(
+                        loader_buf[cmd_base + 64..cmd_base + 68].try_into().unwrap(),
+                    ) as usize;
+                    // Bytes 68..72: length of sum range
+                    let length = u32::from_le_bytes(
+                        loader_buf[cmd_base + 68..cmd_base + 72].try_into().unwrap(),
+                    ) as usize;
+
+                    let file_off = find_alloc(&allocs, cksum_name).ok_or(ServiceError::IoError)?;
+
+                    // Zero the checksum byte first
+                    buffer[file_off + cksum_offset] = 0;
+
+                    // Compute ACPI checksum: sum of all bytes in range must be 0
+                    let sum: u8 = buffer[file_off + start..file_off + start + length]
+                        .iter()
+                        .fold(0u8, |acc, &b| acc.wrapping_add(b));
+                    buffer[file_off + cksum_offset] = 0u8.wrapping_sub(sum);
+                }
+
+                _ => {
+                    // Unknown command — skip
+                }
+            }
+        }
+
+        // Find the RSDP. It's typically in "etc/acpi/rsdp".
+        let rsdp_off =
+            find_alloc_by_name(&allocs, b"etc/acpi/rsdp").ok_or(ServiceError::IoError)?;
+        let rsdp_phys = buffer.as_ptr() as u64 + rsdp_off as u64;
+        Ok(rsdp_phys)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryDetector — e820 from fw_cfg
+// ---------------------------------------------------------------------------
+
+impl MemoryDetector for QemuFwCfg {
+    fn detect_memory(&self, entries: &mut [E820Entry]) -> Result<usize, ServiceError> {
+        let (sel, size) = self
+            .find_file("etc/e820")
+            .ok_or(ServiceError::NotSupported)?;
+        fstart_log::info!("fw_cfg: etc/e820 sel={} size={}", sel as u32, size);
+
+        // Each e820 entry from QEMU is 20 bytes: addr(u64) + size(u64) + type(u32).
+        // No padding — this matches QEMU's `struct e820_entry` in hw/i386/e820.c.
+        let entry_size = 20;
+        let count = (size as usize) / entry_size;
+        let count = count.min(entries.len());
+
+        self.select(sel);
+        for (i, entry) in entries.iter_mut().take(count).enumerate() {
+            let mut buf = [0u8; 20];
+            self.read_bytes(&mut buf);
+            entry.addr = u64::from_le_bytes(buf[0..8].try_into().unwrap());
+            entry.size = u64::from_le_bytes(buf[8..16].try_into().unwrap());
+            let raw_kind = u32::from_le_bytes(buf[16..20].try_into().unwrap());
+            entry.kind = raw_kind;
+            let e_addr = entry.addr;
+            let e_size = entry.size;
+            fstart_log::info!(
+                "  e820[{}]: addr={:#x} size={:#x} type={}",
+                i as u32,
+                e_addr,
+                e_size,
+                raw_kind
+            );
+        }
+
+        Ok(count)
+    }
+
+    fn total_ram_bytes(&self) -> Result<u64, ServiceError> {
+        // Read e820 entries and sum RAM-type regions.
+        // Each read consumes the fw_cfg data pointer so we must re-select.
+        let (sel, size) = self
+            .find_file("etc/e820")
+            .ok_or(ServiceError::NotSupported)?;
+
+        let entry_size = 20; // matches detect_memory
+        let count = (size as usize) / entry_size;
+
+        self.select(sel);
+        let mut total: u64 = 0;
+        for _ in 0..count {
+            let mut buf = [0u8; 20];
+            self.read_bytes(&mut buf);
+            let region_size = u64::from_le_bytes(buf[8..16].try_into().unwrap());
+            let raw_kind = u32::from_le_bytes(buf[16..20].try_into().unwrap());
+            if raw_kind == E820Kind::Ram as u32 {
+                total += region_size;
+            }
+        }
+        Ok(total)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Find the buffer offset of an allocated file by its raw 56-byte name.
+fn find_alloc(allocs: &[Option<AllocEntry>; 32], name: &[u8]) -> Option<usize> {
+    for entry in allocs.iter().flatten() {
+        if entry.name[..name.len()] == *name {
+            return Some(entry.offset);
+        }
+    }
+    None
+}
+
+/// Find the buffer offset of an allocated file by a NUL-terminated name string.
+fn find_alloc_by_name(allocs: &[Option<AllocEntry>; 32], name: &[u8]) -> Option<usize> {
+    for entry in allocs.iter().flatten() {
+        let entry_len = entry.name.iter().position(|&b| b == 0).unwrap_or(56);
+        if entry_len == name.len() && &entry.name[..entry_len] == name {
+            return Some(entry.offset);
+        }
+    }
+    None
+}

--- a/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
+++ b/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
@@ -276,14 +276,19 @@ impl AcpiTableProvider for QemuFwCfg {
                     // Read file data into buffer
                     self.read_file(file_sel, &mut buffer[cursor..cursor + file_size as usize]);
 
-                    if alloc_count < allocs.len() {
-                        allocs[alloc_count] = Some(AllocEntry {
-                            name,
-                            offset: cursor,
-                            size: file_size as usize,
-                        });
-                        alloc_count += 1;
+                    if alloc_count >= allocs.len() {
+                        fstart_log::error!(
+                            "fw_cfg: too many ACPI allocations (max {})",
+                            allocs.len()
+                        );
+                        return Err(ServiceError::InvalidParam);
                     }
+                    allocs[alloc_count] = Some(AllocEntry {
+                        name,
+                        offset: cursor,
+                        size: file_size as usize,
+                    });
+                    alloc_count += 1;
                     cursor += file_size as usize;
                 }
 

--- a/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
+++ b/crates/fstart-driver-qemu-fw-cfg/src/lib.rs
@@ -186,6 +186,7 @@ impl Device for QemuFwCfg {
 // ---------------------------------------------------------------------------
 
 /// Tracking entry for an allocated table in the buffer.
+#[derive(Clone)]
 struct AllocEntry {
     /// File name (NUL-terminated, up to 56 bytes).
     name: [u8; 56],
@@ -208,10 +209,14 @@ impl AcpiTableProvider for QemuFwCfg {
             loader_size
         );
 
-        // Read the loader commands into a temporary buffer on the stack.
+        // Read the loader commands into a static buffer to avoid 10 KiB
+        // stack usage. On real hardware with CAR, stack may be only 4-8 KiB.
         // Each command is 128 bytes. Typical QEMU has < 20 commands.
         const MAX_CMDS: usize = 64;
-        let mut loader_buf = [0u8; MAX_CMDS * 128];
+        // SAFETY: firmware is single-threaded; this static is accessed
+        // only from load_acpi_tables() which runs once during AcpiLoad.
+        static mut LOADER_BUF: [u8; MAX_CMDS * 128] = [0u8; MAX_CMDS * 128];
+        let loader_buf = unsafe { &mut *core::ptr::addr_of_mut!(LOADER_BUF) };
         let cmd_count = (loader_size as usize) / 128;
         if cmd_count > MAX_CMDS {
             return Err(ServiceError::InvalidParam);
@@ -219,8 +224,13 @@ impl AcpiTableProvider for QemuFwCfg {
         self.read_file(loader_sel, &mut loader_buf[..loader_size as usize]);
         fstart_log::info!("fw_cfg: {} table-loader commands", cmd_count as u32);
 
-        // Track allocations (file name → buffer offset)
-        let mut allocs: [Option<AllocEntry>; 32] = core::array::from_fn(|_| None);
+        // Track allocations (file name -> buffer offset).
+        // Static to avoid ~2 KiB on the stack.
+        // SAFETY: single-threaded firmware init.
+        static mut ALLOCS: [Option<AllocEntry>; 32] = [const { None }; 32];
+        let allocs = unsafe { &mut *core::ptr::addr_of_mut!(ALLOCS) };
+        // Clear any stale data from a previous call.
+        allocs.fill(None);
         let mut alloc_count = 0usize;
         let mut cursor = 0usize; // next free position in buffer
 
@@ -446,9 +456,16 @@ impl MemoryDetector for QemuFwCfg {
 // ---------------------------------------------------------------------------
 
 /// Find the buffer offset of an allocated file by its raw 56-byte name.
+///
+/// Both `entry.name` and `name` are NUL-padded 56-byte arrays from
+/// table-loader commands.  We compare the NUL-terminated prefix of each
+/// to avoid false prefix matches (e.g., "etc/acpi/rsdt" matching
+/// "etc/acpi/rsdtx").
 fn find_alloc(allocs: &[Option<AllocEntry>; 32], name: &[u8]) -> Option<usize> {
+    let name_len = name.iter().position(|&b| b == 0).unwrap_or(name.len());
     for entry in allocs.iter().flatten() {
-        if entry.name[..name.len()] == *name {
+        let entry_len = entry.name.iter().position(|&b| b == 0).unwrap_or(56);
+        if entry_len == name_len && entry.name[..entry_len] == name[..name_len] {
             return Some(entry.offset);
         }
     }

--- a/crates/fstart-ffs/src/builder.rs
+++ b/crates/fstart-ffs/src/builder.rs
@@ -331,7 +331,7 @@ fn lay_out_file(
     file: &InputFile,
     region_base: u32,
 ) -> Result<RegionEntry, String> {
-    let mut segments: heapless::Vec<Segment, 4> = heapless::Vec::new();
+    let mut segments: heapless::Vec<Segment, 8> = heapless::Vec::new();
     let mut digest_input: Vec<u8> = Vec::new();
 
     let entry_offset = image.len() as u32 - region_base;

--- a/crates/fstart-ffs/src/lz4.rs
+++ b/crates/fstart-ffs/src/lz4.rs
@@ -206,30 +206,46 @@ fn copy_within(src: &[u8], si: usize, dst: &mut [u8], di: usize, len: usize) {
 fn wild_copy(src: &[u8], si: usize, dst: &mut [u8], di: usize, dst_end: usize) {
     let mut s = si;
     let mut d = di;
-    while d < dst_end {
-        let remaining_src = src.len() - s;
-        let remaining_dst = dst.len() - d;
-        let chunk = 8.min(remaining_src).min(remaining_dst);
-        dst[d..d + chunk].copy_from_slice(&src[s..s + chunk]);
+    // Fast path: full 8-byte chunks with bounds checked once.
+    while d + 8 <= dst.len() && s + 8 <= src.len() && d < dst_end {
+        dst[d..d + 8].copy_from_slice(&src[s..s + 8]);
         s += 8;
         d += 8;
+    }
+    // Remainder: byte-by-byte for the tail.
+    while d < dst_end && d < dst.len() && s < src.len() {
+        dst[d] = src[s];
+        d += 1;
+        s += 1;
     }
 }
 
 /// Wild copy within the same buffer (for match copies with offset >= 8).
+///
+/// When offset >= 8, each 8-byte chunk is non-overlapping with the source,
+/// so we can use `ptr::copy_nonoverlapping` for the fast path. For the
+/// last partial chunk we fall back to byte copy.
 #[inline(always)]
 fn wild_copy_within(buf: &mut [u8], src: usize, dst: usize, dst_end: usize) {
     let mut s = src;
     let mut d = dst;
-    while d < dst_end {
-        // Copy byte-by-byte to handle potential overlap correctly
-        // (even with offset >= 8, the match may catch up during long copies)
-        let chunk_end = (d + 8).min(dst_end);
-        while d < chunk_end {
-            buf[d] = buf[s];
-            d += 1;
-            s += 1;
+    // Fast path: copy 8-byte chunks. Since offset >= 8 (caller guarantees),
+    // the source and destination of each chunk are non-overlapping.
+    while d + 8 <= dst_end && s + 8 <= buf.len() {
+        // SAFETY: s < d (match is from earlier output) and d - s >= 8
+        // (offset >= 8), so [s..s+8] and [d..d+8] don't overlap.
+        // Both ranges are within buf bounds (checked above).
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr().add(s), buf.as_mut_ptr().add(d), 8);
         }
+        s += 8;
+        d += 8;
+    }
+    // Remainder: byte-by-byte for the last partial chunk.
+    while d < dst_end {
+        buf[d] = buf[s];
+        d += 1;
+        s += 1;
     }
 }
 

--- a/crates/fstart-mmio/src/lib.rs
+++ b/crates/fstart-mmio/src/lib.rs
@@ -88,6 +88,14 @@ fn iomb() {
     unsafe {
         core::arch::asm!("fence iorw, iorw", options(nostack, preserves_flags));
     }
+
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: `mfence` is a full serializing fence for loads and stores.
+    // On x86 MMIO (mapped as UC/WC), this ensures all prior writes are
+    // visible to the device before subsequent reads/writes.
+    unsafe {
+        core::arch::asm!("mfence", options(nostack, preserves_flags));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/fstart-pio/Cargo.toml
+++ b/crates/fstart-pio/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fstart-pio"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/crates/fstart-pio/src/lib.rs
+++ b/crates/fstart-pio/src/lib.rs
@@ -1,0 +1,140 @@
+//! x86 port I/O primitives.
+//!
+//! Provides inline-asm wrappers for the x86 `in` and `out` instructions,
+//! which access the separate 64 KiB I/O port address space (ports 0x0000
+//! through 0xFFFF).
+//!
+//! Legacy x86 devices (UART at 0x3F8, PCI config at 0xCF8/0xCFC, PIT at
+//! 0x40-0x43, fw_cfg at 0x510/0x511) use port I/O rather than
+//! memory-mapped I/O.
+//!
+//! # Safety
+//!
+//! All functions are `unsafe` because accessing arbitrary I/O ports can
+//! trigger side effects in hardware. Callers must ensure the port address
+//! corresponds to an actual device register.
+
+#![no_std]
+
+/// Read a byte from an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn inb(port: u16) -> u8 {
+    let val: u8;
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "in al, dx",
+            out("al") val,
+            in("dx") port,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+    val
+}
+
+/// Write a byte to an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn outb(port: u16, val: u8) {
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "out dx, al",
+            in("dx") port,
+            in("al") val,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+}
+
+/// Read a 16-bit word from an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn inw(port: u16) -> u16 {
+    let val: u16;
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "in ax, dx",
+            out("ax") val,
+            in("dx") port,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+    val
+}
+
+/// Write a 16-bit word to an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn outw(port: u16, val: u16) {
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "out dx, ax",
+            in("dx") port,
+            in("ax") val,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+}
+
+/// Read a 32-bit doubleword from an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn inl(port: u16) -> u32 {
+    let val: u32;
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "in eax, dx",
+            out("eax") val,
+            in("dx") port,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+    val
+}
+
+/// Write a 32-bit doubleword to an I/O port.
+///
+/// # Safety
+/// `port` must be a valid I/O port address for the target device.
+#[inline(always)]
+pub unsafe fn outl(port: u16, val: u32) {
+    // SAFETY: caller guarantees port validity.
+    unsafe {
+        core::arch::asm!(
+            "out dx, eax",
+            in("dx") port,
+            in("eax") val,
+            options(nostack, nomem, preserves_flags),
+        );
+    }
+}
+
+/// Tiny I/O delay via a dummy write to port 0x80 (POST code port).
+///
+/// This is the standard Linux/coreboot technique for I/O delay on x86.
+/// Port 0x80 is the BIOS POST code display port; writing to it has no
+/// harmful side effects but introduces enough bus delay to satisfy
+/// legacy device timing requirements.
+///
+/// # Safety
+/// Only valid on x86 systems where port 0x80 is the POST code port.
+#[inline(always)]
+pub unsafe fn io_delay() {
+    // SAFETY: port 0x80 write is a standard x86 I/O delay mechanism.
+    unsafe { outb(0x80, 0) };
+}

--- a/crates/fstart-pio/src/lib.rs
+++ b/crates/fstart-pio/src/lib.rs
@@ -124,6 +124,51 @@ pub unsafe fn outl(port: u16, val: u32) {
     }
 }
 
+// -----------------------------------------------------------------------
+// Legacy PCI configuration access via CF8/CFC I/O ports
+// -----------------------------------------------------------------------
+
+/// CF8 address port for legacy PCI config access.
+const PCI_CF8: u16 = 0xCF8;
+/// CFC data port for legacy PCI config access.
+const PCI_CFC: u16 = 0xCFC;
+
+/// Build a CF8 address for legacy PCI config access.
+///
+/// Format: `(1 << 31) | (bus << 16) | (dev << 11) | (func << 8) | (reg & 0xFC)`
+#[inline]
+const fn cf8_addr(bus: u8, dev: u8, func: u8, reg: u8) -> u32 {
+    0x8000_0000
+        | ((bus as u32) << 16)
+        | ((dev as u32) << 11)
+        | ((func as u32) << 8)
+        | ((reg as u32) & 0xFC)
+}
+
+/// Read a 32-bit PCI config register via legacy CF8/CFC I/O ports.
+///
+/// # Safety
+/// Must only be called on x86 systems with legacy PCI config access.
+#[inline]
+pub unsafe fn pci_cfg_read32(bus: u8, dev: u8, func: u8, reg: u8) -> u32 {
+    unsafe {
+        outl(PCI_CF8, cf8_addr(bus, dev, func, reg));
+        inl(PCI_CFC)
+    }
+}
+
+/// Write a 32-bit PCI config register via legacy CF8/CFC I/O ports.
+///
+/// # Safety
+/// Must only be called on x86 systems with legacy PCI config access.
+#[inline]
+pub unsafe fn pci_cfg_write32(bus: u8, dev: u8, func: u8, reg: u8, val: u32) {
+    unsafe {
+        outl(PCI_CF8, cf8_addr(bus, dev, func, reg));
+        outl(PCI_CFC, val);
+    }
+}
+
 /// Tiny I/O delay via a dummy write to port 0x80 (POST code port).
 ///
 /// This is the standard Linux/coreboot technique for I/O delay on x86.

--- a/crates/fstart-platform-x86_64/Cargo.toml
+++ b/crates/fstart-platform-x86_64/Cargo.toml
@@ -12,3 +12,6 @@ ufmt = { workspace = true }
 
 [features]
 default = []
+# Use 1 GiB pages for identity mapping (requires PDPE1GB).
+# Without this feature, 2 MiB pages are used (universally supported).
+x86-1g-pages = []

--- a/crates/fstart-platform-x86_64/Cargo.toml
+++ b/crates/fstart-platform-x86_64/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fstart-platform-x86_64"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+fstart-log = { workspace = true }
+fstart-pio = { workspace = true }
+fstart-services = { workspace = true }
+ufmt = { workspace = true }
+
+[features]
+default = []

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -1,0 +1,549 @@
+//! x86_64 platform support for fstart.
+//!
+//! Provides the entry point (reset vector through 16-bit real mode,
+//! 32-bit protected mode, to 64-bit long mode), GDT setup, identity-mapped
+//! page tables, and the Linux boot protocol handoff.
+//!
+//! # Entry Flow
+//!
+//! 1. Reset vector at `0xFFFFFFF0`: `jmp _start16bit`
+//! 2. 16-bit real mode: load GDT, enable protected mode
+//! 3. 32-bit protected mode: set up page tables, enable long mode
+//! 4. 64-bit long mode: set stack, clear BSS, call `fstart_main(0)`
+//!
+//! # QEMU Q35
+//!
+//! On QEMU Q35, RAM works immediately without Cache-as-RAM setup.
+//! MTRRs are no-ops. The firmware runs XIP from pflash mapped at the
+//! top of the 4 GiB address space.
+
+#![no_std]
+
+use fstart_services::memory_detect::E820Entry;
+
+// ---------------------------------------------------------------------------
+// Entry point — 16-bit real mode → 32-bit protected mode → 64-bit long mode
+// ---------------------------------------------------------------------------
+
+/// The entry sequence is written as `global_asm!` because it transitions
+/// through three CPU modes before reaching Rust code. The `_start16bit`
+/// label is placed in `.text.entry` by the linker script.
+///
+/// GDT layout (matches Linux __BOOT_CS/DS expectations):
+/// - 0x00: null descriptor
+/// - 0x08: 32-bit flat code (used only for 16→32 bit transition)
+/// - 0x10: 64-bit code (__BOOT_CS, Long mode, Execute/Read)
+/// - 0x18: flat data (__BOOT_DS, 4 GiB, Read/Write)
+///
+/// Page tables: identity-mapped 2 MiB pages covering 4 GiB.
+/// PML4 → 1 PDPT → 4 PDTs → 512 × 2 MiB pages each.
+core::arch::global_asm!(
+    // Use AT&T syntax throughout — matches coreboot convention and is
+    // the natural syntax for 16-bit / mixed-mode x86 assembly.
+    ".att_syntax prefix",
+    // =====================================================================
+    // Entire entry sequence in .text.entry section.
+    //
+    // The .reset section contains ONLY the reset vector jump (16 bytes at
+    // 0xFFFFFFF0). The rest of the 16-bit/32-bit/64-bit entry code lives
+    // in .text.entry which is placed by the linker script at the start
+    // of the ROM image. The reset vector uses an absolute far jump (via
+    // raw bytes) to reach _start16bit regardless of distance.
+    // =====================================================================
+
+    // --- Reset vector (pinned to 0xFFFFFFF0 by linker) ---
+    ".section .reset, \"ax\"",
+    ".code16",
+    ".global _start",
+    "_start:",
+    // Long jump to the 16-bit entry. We encode this as raw bytes because
+    // the target may be >32KB away (outside 16-bit relative range).
+    // EA xx xx xx xx 08 00 = ljmpw $0x08, $abs32
+    // But we are still in real mode before GDT is loaded, so we use a
+    // simple near relative jump. The linker will compute the 16-bit
+    // offset. If it's out of range, we fall back to a long form.
+    // Actually: at reset, CS=0xF000 and IP=0xFFF0 (flat = 0xFFFF_FFF0).
+    // CS base is 0xFFFF_0000 in the hidden portion. A near jmp to
+    // _start16bit works if it's within 64K below 0xFFFF_FFF0, i.e.
+    // anywhere in 0xFFFF_0000..0xFFFF_FFFF. So we place .text.entry
+    // near the end of ROM (within the last 64K).
+    "jmp _start16bit",
+    ".align 16",
+    // --- 16-bit entry code (must be within 4K of reset vector) ---
+    //
+    // Follows coreboot entry16.S conventions:
+    //   - GAS mnemonics only (no manual .byte encoding)
+    //   - CS-relative addressing for lgdtl/lidt via runtime offset
+    //     computation, avoiding the 0x67 address-size prefix that
+    //     breaks KVM real-mode instruction emulation
+    //   - linker resolves label offsets within the boot block
+    ".section .x86boot, \"ax\"",
+    ".code16",
+    ".global _start16bit",
+    "_start16bit:",
+    "cli",
+    // Save BIST result
+    "movl %eax, %ebp",
+    // Invalidate TLB
+    "xorl %eax, %eax",
+    "movl %eax, %cr3",
+    // Compute CS-relative base for descriptor lookups.
+    // At reset CS = 0xF000, hidden base = 0xFFFF0000.
+    // shlw $4 on 0xF000 overflows to 0 (16-bit), so the subtraction
+    // below is effectively a no-op — but keeps the code relocatable
+    // for AP startup where CS may differ (same pattern as coreboot).
+    "movw %cs, %ax",
+    "shlw $4, %ax",
+    // Load null IDT — CPU will shutdown on any exception before the
+    // 64-bit IDT is set up in _setup_idt. No 'l' suffix: 16-bit
+    // operand size loads a 5-byte descriptor (24-bit base = 0).
+    "movw $(_null_idt - _start16bit + 0xf000), %bx",
+    "subw %ax, %bx",
+    "lidt %cs:(%bx)",
+    // Load GDT — 'l' suffix forces 32-bit operand size so the full
+    // 32-bit GDT base address is loaded from the 6-byte descriptor.
+    "movw $(_gdt_desc - _start16bit + 0xf000), %bx",
+    "subw %ax, %bx",
+    "lgdtl %cs:(%bx)",
+    // Enable protected mode: set PE, disable caching (CD+NW)
+    "movl %cr0, %eax",
+    "andl $0x7FFAFFD1, %eax", // PG,AM,WP,NE,TS,EM,MP = 0
+    "orl $0x60000001, %eax",  // CD, NW, PE = 1
+    "movl %eax, %cr0",
+    // Far jump to 32-bit protected mode (GDT selector 0x08)
+    "ljmpl $0x08, $_start32bit",
+    // =====================================================================
+    // Null IDT descriptor (limit=0, base=0)
+    // =====================================================================
+    ".align 4",
+    "_null_idt:",
+    ".word 0", // limit
+    ".long 0", // base
+    ".word 0", // padding
+    // =====================================================================
+    // GDT and descriptor
+    // =====================================================================
+    ".align 4",
+    "_gdt:",
+    // Entry 0x00: null descriptor
+    ".word 0x0000, 0x0000",
+    ".byte 0x00, 0x00, 0x00, 0x00",
+    // Entry 0x08: 32-bit flat code (base=0, limit=4G, G=1, D=1)
+    // Used only for the 16-bit → 32-bit ljmpl transition.
+    ".word 0xffff, 0x0000",
+    ".byte 0x00, 0x9b, 0xcf, 0x00",
+    // Entry 0x10: 64-bit code (L=1, D=0, base=0, limit=4G)
+    // Linux __BOOT_CS = 0x10 — must be at this selector.
+    ".word 0xffff, 0x0000",
+    ".byte 0x00, 0x9b, 0xaf, 0x00",
+    // Entry 0x18: 64-bit/32-bit flat data (base=0, limit=4G, G=1, B=1)
+    // Linux __BOOT_DS = 0x18 — must be at this selector.
+    // Also used as the 32-bit data segment during early init.
+    ".word 0xffff, 0x0000",
+    ".byte 0x00, 0x93, 0xcf, 0x00",
+    "_gdt_end:",
+    "_gdt_desc:",
+    ".word _gdt_end - _gdt - 1", // limit
+    ".long _gdt",                // base
+    // =====================================================================
+    // 32-bit protected mode entry — in .text (linked at ROM base)
+    //
+    // The far jump from 16-bit code uses an absolute 32-bit address so
+    // this can be anywhere in the 4 GiB address space.
+    // =====================================================================
+    ".section .text, \"ax\"",
+    ".code32",
+    ".global _start32bit",
+    "_start32bit:",
+    // Load data segment selectors (0x18 = flat data, __BOOT_DS)
+    "movw $0x18, %ax",
+    "movw %ax, %ds",
+    "movw %ax, %es",
+    "movw %ax, %ss",
+    "movw %ax, %fs",
+    "movw %ax, %gs",
+    // Clear the early-RAM region (CAR on real hardware, just RAM on QEMU).
+    // This ensures BSS is zero before we touch any Rust statics.
+    // The linker provides _bss_start and _bss_end.
+    "movl $_bss_start, %edi",
+    "movl $_bss_end, %ecx",
+    "subl %edi, %ecx",
+    "shrl $2, %ecx", // count in dwords
+    "xorl %eax, %eax",
+    "rep",
+    "stosl",
+    // Set up identity-mapped page tables for long mode.
+    // We use static page tables in the .page_tables section.
+    // PML4[0] → PDPT, PDPT[0..3] → PDT[0..3], each PDT has 512 2MB pages.
+    //
+    // Clear page table area first
+    "movl $_page_tables_start, %edi",
+    "movl $_page_tables_end, %ecx",
+    "subl %edi, %ecx",
+    "shrl $2, %ecx",
+    "xorl %eax, %eax",
+    "rep",
+    "stosl",
+    // PML4[0] = address of PDPT | Present | Writable
+    "movl $_page_tables_start, %edi",
+    "leal 0x1003(%edi), %eax", // PDPT = page_tables + 0x1000, flags = 0x3
+    "movl %eax, (%edi)",
+    // PDPT[0..3] = address of PDT[0..3] | Present | Writable
+    "leal 0x1000(%edi), %esi", // ESI = PDPT base
+    "leal 0x2003(%edi), %eax", // PDT0 = page_tables + 0x2000, flags = 0x3
+    "movl %eax, 0(%esi)",      // PDPT[0]
+    "addl $0x1000, %eax",
+    "movl %eax, 8(%esi)", // PDPT[1]
+    "addl $0x1000, %eax",
+    "movl %eax, 16(%esi)", // PDPT[2]
+    "addl $0x1000, %eax",
+    "movl %eax, 24(%esi)", // PDPT[3]
+    // Fill PDT entries: 4 PDTs × 512 entries = 2048 × 2MB = 4GB
+    // Each entry: physical_addr | Present | Writable | PageSize(2MB)
+    "leal 0x2000(%edi), %esi", // ESI = PDT0 base
+    "movl $0x00000083, %eax",  // Start: PA=0, PS=1, RW=1, P=1
+    "movl $2048, %ecx",        // 2048 entries
+    "1:",
+    "movl %eax, (%esi)",
+    "movl $0, 4(%esi)",     // high 32 bits = 0 (below 4GB)
+    "addl $0x200000, %eax", // next 2MB page
+    "addl $8, %esi",
+    "decl %ecx",
+    "jnz 1b",
+    // Enable PAE (bit 5), OSFXSR (bit 9), OSXMMEXCPT (bit 10).
+    // OSFXSR + OSXMMEXCPT enable SSE/SSE2 (compiler_builtins memcpy).
+    "movl %cr4, %eax",
+    "orl $0x620, %eax", // PAE | OSFXSR | OSXMMEXCPT
+    "movl %eax, %cr4",
+    // Load PML4 base into CR3
+    "movl $_page_tables_start, %eax",
+    "movl %eax, %cr3",
+    // Enable long mode: set IA32_EFER.LME (bit 8)
+    "movl $0xC0000080, %ecx", // IA32_EFER MSR
+    "rdmsr",
+    "orl $0x100, %eax", // LME = 1
+    "wrmsr",
+    // Enable paging + SSE/AVX in one CR0 write:
+    //   Set:   PG (bit 31), MP (bit 1)
+    //   Clear: CD (bit 30), NW (bit 29), EM (bit 2)
+    "movl %cr0, %eax",
+    "andl $0x9FFFFFFB, %eax", // clear CD, NW, EM
+    "orl $0x80000002, %eax",  // set PG, MP
+    "movl %eax, %cr0",
+    // Far jump to 64-bit code segment (GDT selector 0x10 = __BOOT_CS)
+    ".byte 0xea",        // ljmpl opcode
+    ".long _start64bit", // 32-bit offset
+    ".word 0x10",        // 64-bit code segment selector
+    // =====================================================================
+    // 64-bit long mode entry
+    // =====================================================================
+    ".code64",
+    ".global _start64bit",
+    "_start64bit:",
+    // Reload data segments with 64-bit data selector (0x18 = __BOOT_DS)
+    "movw $0x18, %ax",
+    "movw %ax, %ds",
+    "movw %ax, %es",
+    "movw %ax, %ss",
+    "xorw %ax, %ax",
+    "movw %ax, %fs",
+    "movw %ax, %gs",
+    // Set up stack (grows down from _stack_top)
+    "movabs $_stack_top, %rsp",
+    // Copy .data initializers from ROM (LMA) to RAM (VMA).
+    // If src == dst (RAM-only build), the copy is a harmless no-op.
+    // Uses byte copy (rep movsb) instead of qword copy to handle
+    // .ldata sections that may be < 8 bytes (e.g., a single u8).
+    "movabs $_data_load, %rsi",
+    "movabs $_data_start, %rdi",
+    "movabs $_data_end, %rcx",
+    "subq %rdi, %rcx",
+    "cmpq %rsi, %rdi",
+    "je 2f",
+    "rep movsb",
+    "2:",
+    // Set up IDT with exception handlers before calling Rust code.
+    // Without an IDT, any exception causes a triple fault + silent reset.
+    "call _setup_idt",
+    // Call fstart_main(handoff_ptr=0)
+    "xorl %edi, %edi",
+    "call fstart_main",
+    // Should never return — halt
+    "3:",
+    "hlt",
+    "jmp 3b",
+    // =====================================================================
+    // IDT setup — builds a 256-entry IDT pointing to _exc_stub.
+    // =====================================================================
+    "_setup_idt:",
+    "pushq %rax",
+    "pushq %rbx",
+    "pushq %rcx",
+    "pushq %rdi",
+    // Zero the IDT area
+    "xorl %eax, %eax",
+    "movabs $_idt_table, %rdi",
+    "movl $512, %ecx",
+    "rep stosq",
+    // Fill all 256 entries → _exc_stub
+    "movabs $_exc_stub, %rbx",
+    "movabs $_idt_table, %rdi",
+    "movl $256, %ecx",
+    "4:",
+    "movw %bx, (%rdi)",
+    "movw $0x10, 2(%rdi)", // CS = 0x10 (__BOOT_CS, 64-bit code)
+    "movb $0, 4(%rdi)",
+    "movb $0x8E, 5(%rdi)",
+    "movl %ebx, %eax",
+    "shrl $16, %eax",
+    "movw %ax, 6(%rdi)",
+    "movq %rbx, %rax",
+    "shrq $32, %rax",
+    "movl %eax, 8(%rdi)",
+    "movl $0, 12(%rdi)",
+    "addq $16, %rdi",
+    "decl %ecx",
+    "jnz 4b",
+    // Load the IDT
+    "movabs $_idt_desc, %rax",
+    "lidt (%rax)",
+    "popq %rdi",
+    "popq %rcx",
+    "popq %rbx",
+    "popq %rax",
+    "ret",
+    ".align 16",
+    "_idt_desc:",
+    ".word 256 * 16 - 1",
+    ".quad _idt_table",
+    // =====================================================================
+    // Exception stub — saves frame and calls the Rust exception handler.
+    //
+    // The CPU pushes SS, RSP, RFLAGS, CS, RIP (and error code for some
+    // vectors). Since we use a single stub for all vectors, we can't
+    // distinguish error-code vs no-error-code exceptions by vector.
+    // The Rust handler reads CR2 directly for page faults.
+    //
+    // We pass RIP, RSP, and CR2 as arguments to the Rust handler:
+    //   rdi = RIP (from exception frame)
+    //   rsi = RSP at exception time
+    //   rdx = CR2 (page fault address)
+    // =====================================================================
+    ".align 16",
+    "_exc_stub:",
+    "movq (%rsp), %rdi",   // rdi = faulting RIP
+    "movq 24(%rsp), %rsi", // rsi = pre-exception RSP
+    "movq %cr2, %rdx",     // rdx = CR2 (page fault address)
+    "call x86_exception_handler",
+    // Should not return, but halt if it does
+    "5:",
+    "hlt",
+    "jmp 5b",
+);
+
+// IDT table at a fixed low address (after page tables).
+// Page tables: 0x1000..0x7000 (6 pages).
+// IDT: 0x7000..0x8000 (1 page, 256 entries × 16 bytes).
+core::arch::global_asm!(
+    ".section .idt_table, \"aw\", @nobits",
+    ".align 4096",
+    ".global _idt_table",
+    "_idt_table:",
+    ".skip 4096",
+);
+
+// Make sure the linker pulls in the entry code
+extern "Rust" {
+    fn fstart_main(handoff_ptr: usize) -> !;
+}
+
+// ---------------------------------------------------------------------------
+// Exception handler — called from the IDT stub with register state
+// ---------------------------------------------------------------------------
+
+/// Rust exception handler called from the assembly IDT stub.
+///
+/// Prints exception details using fstart_log (which uses the already-
+/// initialized NS16550 UART), then halts. This gives useful diagnostics
+/// instead of a silent triple-fault reset.
+///
+/// # Arguments
+/// - `rip`: instruction pointer at the time of the exception
+/// - `rsp`: stack pointer at the time of the exception
+/// - `cr2`: CR2 register (faulting address for page faults)
+#[no_mangle]
+pub extern "C" fn x86_exception_handler(rip: u64, rsp: u64, cr2: u64) -> ! {
+    fstart_log::error!("*** x86 EXCEPTION ***");
+    fstart_log::error!("  RIP = {:#x}", rip);
+    fstart_log::error!("  RSP = {:#x}", rsp);
+    fstart_log::error!("  CR2 = {:#x}", cr2);
+
+    // Also print via raw PIO in case the log infrastructure is broken
+    // (e.g., exception during console init).
+    unsafe {
+        let msg = b"\r\n!EXCEPTION HALT!\r\n";
+        for &b in msg {
+            fstart_pio::outb(0x3F8, b);
+        }
+    }
+
+    loop {
+        unsafe { core::arch::asm!("hlt", options(nostack, nomem, preserves_flags)) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — consumed by generated stage code via fstart_platform:: alias
+// ---------------------------------------------------------------------------
+
+/// Halt the processor in a low-power wait state (never returns).
+pub fn halt() -> ! {
+    loop {
+        // SAFETY: `hlt` puts the CPU in halt state until next interrupt.
+        unsafe { core::arch::asm!("hlt", options(nostack, nomem, preserves_flags)) };
+    }
+}
+
+/// Jump to an absolute 64-bit address (never returns).
+///
+/// Used for generic payload/stage jumps.
+pub fn jump_to(addr: u64) -> ! {
+    // SAFETY: caller guarantees `addr` points to valid executable code.
+    unsafe {
+        core::arch::asm!(
+            "jmp {0}",
+            in(reg) addr,
+            options(noreturn),
+        );
+    }
+}
+
+/// Boot a Linux kernel using the x86 64-bit boot protocol.
+///
+/// Uses the 64-bit entry point at `code32_start + 0x200` (available since
+/// boot protocol 2.12 when `XLF_KERNEL_64` is set in `xload_flags`).
+/// This avoids the complex long-mode → protected-mode teardown needed
+/// by the 32-bit protocol: we stay in long mode, set `%rsi` to the
+/// zero page, and jump directly to the kernel's `startup_64`.
+///
+/// Constructs the zero page (boot_params) at `0x90000`, fills e820
+/// entries and ACPI RSDP address, then jumps to the kernel.
+///
+/// # Arguments
+/// - `kernel_addr`: physical address of the loaded kernel (typically `0x100000`)
+/// - `rsdp_addr`: physical address of the ACPI RSDP (from AcpiLoad)
+/// - `e820_entries`: slice of e820 memory map entries (from MemoryDetect)
+pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) -> ! {
+    // The zero page is at a well-known location in conventional memory.
+    const ZERO_PAGE: u64 = 0x90000;
+    const CMD_LINE: u64 = 0x91000;
+
+    // SAFETY: these addresses are in conventional memory below 640K,
+    // cleared by the entry code, and not used by any other code at
+    // this point.
+    let params = unsafe { &mut *(ZERO_PAGE as *mut [u8; 4096]) };
+    params.fill(0);
+
+    // The loaded image is a raw bzImage: setup_header + protected-mode kernel.
+    // Read setup_sects (offset 0x1F1) from the setup header at kernel_addr
+    // to find where the protected-mode kernel starts within the image.
+    let setup_header = unsafe { core::slice::from_raw_parts(kernel_addr as *const u8, 0x4000) };
+    let setup_sects = setup_header[0x1F1] as u64;
+    let pm_kernel_offset = (setup_sects + 1) * 512;
+
+    // Copy the original setup header (first 0x200 bytes) into boot_params
+    // so Linux can read its own setup fields (protocol version, cmdline
+    // size, xloadflags, etc.). Then overlay our fields on top.
+    let hdr_len = 0x200usize.min(setup_header.len());
+    params[..hdr_len].copy_from_slice(&setup_header[..hdr_len]);
+
+    // Override fields that the bootloader must set
+    params[0x210] = 0xFF; // type_of_loader = unregistered
+    params[0x211] |= 0x01; // loadflags |= LOADED_HIGH
+
+    // Relocate the protected-mode kernel to pref_address (from setup header
+    // offset 0x258), which is properly aligned to kernel_alignment. The PM
+    // kernel sits at kernel_addr + pm_kernel_offset within the loaded
+    // bzImage; move it to pref_address so the decompressor's alignment
+    // requirements are satisfied. Since pref_address (0x1000000) < source
+    // (0x1004000), a forward copy is safe (no overlap corruption).
+    let pref_address = u64::from_le_bytes(setup_header[0x258..0x260].try_into().unwrap_or([0; 8]));
+    let pm_kernel_src = kernel_addr + pm_kernel_offset;
+    let pm_kernel_size = setup_header.len() as u64 * 512 - pm_kernel_offset; // approximate
+                                                                             // Use syssize (offset 0x1F4) for the actual protected-mode code size
+    let syssize =
+        u32::from_le_bytes(setup_header[0x1F4..0x1F8].try_into().unwrap_or([0; 4])) as u64 * 16; // syssize is in 16-byte paragraphs
+    let copy_len = syssize;
+    let pm_kernel_addr = if pref_address != 0 && pref_address != pm_kernel_src {
+        unsafe {
+            core::ptr::copy(
+                pm_kernel_src as *const u8,
+                pref_address as *mut u8,
+                copy_len as usize,
+            );
+        }
+        pref_address
+    } else {
+        pm_kernel_src
+    };
+
+    // code32_start — set to where the protected-mode kernel now sits
+    params[0x214..0x218].copy_from_slice(&(pm_kernel_addr as u32).to_le_bytes());
+
+    // vid_mode (offset 0x1FA) — 0xFFFF = "normal" (no video mode change)
+    params[0x1FA..0x1FC].copy_from_slice(&0xFFFFu16.to_le_bytes());
+
+    // cmd_line_ptr (offset 0x228) — write the command line to CMD_LINE addr
+    let cmdline = unsafe { &mut *(CMD_LINE as *mut [u8; 4096]) };
+    let bootargs = b"console=ttyS0 earlycon=uart8250,io,0x3f8,115200n8\0";
+    cmdline[..bootargs.len()].copy_from_slice(bootargs);
+    params[0x228..0x22C].copy_from_slice(&(CMD_LINE as u32).to_le_bytes());
+
+    // ACPI RSDP address (offset 0x070, protocol 2.14+)
+    params[0x070..0x078].copy_from_slice(&rsdp_addr.to_le_bytes());
+
+    // e820 map: count at 0x1E8, entries at 0x2D0 (20 bytes each)
+    let count = e820_entries.len().min(128) as u8;
+    params[0x1E8] = count;
+    for (i, entry) in e820_entries.iter().take(128).enumerate() {
+        let offset = 0x2D0 + i * 20;
+        params[offset..offset + 8].copy_from_slice(&entry.addr.to_le_bytes());
+        params[offset + 8..offset + 16].copy_from_slice(&entry.size.to_le_bytes());
+        params[offset + 16..offset + 20].copy_from_slice(&entry.kind.to_le_bytes());
+    }
+
+    // 64-bit entry = protected-mode kernel base + 0x200
+    let entry64 = pm_kernel_addr + 0x200;
+
+    fstart_log::info!("  setup_sects: {}", setup_sects);
+    fstart_log::info!("  pm_kernel @ {:#x}", pm_kernel_addr);
+    fstart_log::info!("  entry64 @ {:#x}", entry64);
+    fstart_log::info!("  zero_page @ {:#x}", ZERO_PAGE);
+    fstart_log::info!("  rsdp @ {:#x}", rsdp_addr);
+    fstart_log::info!("  e820 count: {}", e820_entries.len());
+
+    // Jump to the kernel's 64-bit entry.
+    // The 64-bit boot protocol expects:
+    //   - CPU in 64-bit long mode with paging enabled
+    //   - Identity-mapped page tables covering all of physical memory
+    //     that the kernel might access during early boot
+    //   - %rsi = physical address of the boot_params (zero page)
+    //   - Interrupts disabled
+    //   - GDT with __BOOT_CS (0x10) and __BOOT_DS (0x18) valid
+    //
+    // Our firmware already satisfies all of these: we're in long mode
+    // with identity-mapped 2 MiB pages over 4 GiB, interrupts are
+    // disabled (cli in _start16bit), and we have a valid GDT.
+    //
+    // SAFETY: all zero page fields have been populated above.
+    // kernel_addr points to a previously loaded bzImage.
+    unsafe {
+        core::arch::asm!(
+            "mov rsi, {zero_page}",
+            "jmp {entry}",
+            zero_page = in(reg) ZERO_PAGE,
+            entry = in(reg) entry64,
+            options(noreturn),
+        );
+    }
+}

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -444,37 +444,67 @@ pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) 
     let params = unsafe { &mut *(ZERO_PAGE as *mut [u8; 4096]) };
     params.fill(0);
 
-    // The loaded image is a raw bzImage: setup_header + protected-mode kernel.
-    // Read setup_sects (offset 0x1F1) from the setup header at kernel_addr
-    // to find where the protected-mode kernel starts within the image.
-    let setup_header = unsafe { core::slice::from_raw_parts(kernel_addr as *const u8, 0x4000) };
-    let setup_sects = setup_header[0x1F1] as u64;
-    let pm_kernel_offset = (setup_sects + 1) * 512;
+    // The loaded image is a raw bzImage: real-mode boot sector + setup
+    // header, followed by the protected-mode (compressed) kernel.
+    //
+    // The boot_params struct mirrors the bzImage layout: the setup_header
+    // lives at offset 0x1F1 within boot_params, exactly where it sits in
+    // the on-disk image. We must copy the ENTIRE setup header (not just
+    // the first 0x200 bytes) so the kernel can read critical fields like
+    // kernel_alignment (0x230), init_size (0x260), xloadflags (0x236),
+    // relocatable_kernel (0x234), etc.
+    let bzimage = unsafe { core::slice::from_raw_parts(kernel_addr as *const u8, 0x80_0000) };
 
-    // Copy the original setup header (first 0x200 bytes) into boot_params
-    // so Linux can read its own setup fields (protocol version, cmdline
-    // size, xloadflags, etc.). Then overlay our fields on top.
-    let hdr_len = 0x200usize.min(setup_header.len());
-    params[..hdr_len].copy_from_slice(&setup_header[..hdr_len]);
+    // Read setup_sects (offset 0x1F1) to determine the size of the
+    // real-mode portion of the bzImage.
+    let setup_sects = bzimage[0x1F1] as u64;
+    let setup_size = (setup_sects + 1) * 512; // bytes of real-mode code + header
+    let pm_kernel_offset = setup_size;
 
-    // Override fields that the bootloader must set
+    // Copy the entire real-mode setup area into boot_params.
+    // The setup area can be up to ~60 sectors (30 KiB) but boot_params
+    // is only 4 KiB. The setup_header fields that the kernel reads are
+    // all within the first 0x290 bytes (end of the header area, before
+    // the e820 table at 0x2D0). Copy up to 0x290 bytes from the bzImage
+    // to ensure ALL setup header fields are present.
+    let copy_end = (setup_size as usize).min(0x290).min(bzimage.len());
+    params[..copy_end].copy_from_slice(&bzimage[..copy_end]);
+
+    // Override fields that the bootloader must set.
     params[0x210] = 0xFF; // type_of_loader = unregistered
     params[0x211] |= 0x01; // loadflags |= LOADED_HIGH
 
-    // Relocate the protected-mode kernel to pref_address (from setup header
-    // offset 0x258), which is properly aligned to kernel_alignment. The PM
-    // kernel sits at kernel_addr + pm_kernel_offset within the loaded
-    // bzImage; move it to pref_address so the decompressor's alignment
-    // requirements are satisfied. Since pref_address (0x1000000) < source
-    // (0x1004000), a forward copy is safe (no overlap corruption).
-    let pref_address = u64::from_le_bytes(setup_header[0x258..0x260].try_into().unwrap_or([0; 8]));
+    // heap_end_ptr (offset 0x224): end of the setup heap relative to
+    // the start of the real-mode code. Set to end of boot_params.
+    // This is loadflags.CAN_USE_HEAP dependent; set it defensively.
+    params[0x211] |= 0x80; // loadflags |= CAN_USE_HEAP
+    params[0x224..0x226].copy_from_slice(&0xFE00u16.to_le_bytes());
+
+    // Relocate the protected-mode kernel to pref_address.
+    //
+    // pref_address (offset 0x258) is where the kernel prefers to be
+    // loaded, typically 0x1000000, aligned to kernel_alignment (2 MiB).
+    // The PM kernel sits at kernel_addr + pm_kernel_offset within the
+    // loaded bzImage. Move it to pref_address so the decompressor's
+    // alignment requirements are satisfied.
+    //
+    // startup_64 uses RIP-relative addressing (leaq startup_32(%rip))
+    // to discover its own address. The PM kernel must be at an aligned
+    // address so the kernel's relocation calculation works correctly.
+    let pref_address = u64::from_le_bytes(bzimage[0x258..0x260].try_into().unwrap_or([0; 8]));
     let pm_kernel_src = kernel_addr + pm_kernel_offset;
-    let pm_kernel_size = setup_header.len() as u64 * 512 - pm_kernel_offset; // approximate
-                                                                             // Use syssize (offset 0x1F4) for the actual protected-mode code size
+
+    // syssize (offset 0x1F4): protected-mode code size in 16-byte
+    // paragraphs. This is the exact amount to copy.
     let syssize =
-        u32::from_le_bytes(setup_header[0x1F4..0x1F8].try_into().unwrap_or([0; 4])) as u64 * 16; // syssize is in 16-byte paragraphs
+        u32::from_le_bytes(bzimage[0x1F4..0x1F8].try_into().unwrap_or([0; 4])) as u64 * 16;
     let copy_len = syssize;
+
     let pm_kernel_addr = if pref_address != 0 && pref_address != pm_kernel_src {
+        // SAFETY: pref_address (0x1000000) is below pm_kernel_src
+        // (kernel_load_addr + setup_size), so a forward copy is safe
+        // (no overlap corruption). Both addresses are in identity-mapped
+        // RAM covered by our page tables.
         unsafe {
             core::ptr::copy(
                 pm_kernel_src as *const u8,
@@ -487,13 +517,13 @@ pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) 
         pm_kernel_src
     };
 
-    // code32_start — set to where the protected-mode kernel now sits
+    // code32_start (offset 0x214): tell the kernel where the PM code is.
     params[0x214..0x218].copy_from_slice(&(pm_kernel_addr as u32).to_le_bytes());
 
     // vid_mode (offset 0x1FA) — 0xFFFF = "normal" (no video mode change)
     params[0x1FA..0x1FC].copy_from_slice(&0xFFFFu16.to_le_bytes());
 
-    // cmd_line_ptr (offset 0x228) — write the command line to CMD_LINE addr
+    // cmd_line_ptr (offset 0x228)
     let cmdline = unsafe { &mut *(CMD_LINE as *mut [u8; 4096]) };
     let bootargs = b"console=ttyS0 earlycon=uart8250,io,0x3f8,115200n8\0";
     cmdline[..bootargs.len()].copy_from_slice(bootargs);
@@ -516,31 +546,66 @@ pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) 
     let entry64 = pm_kernel_addr + 0x200;
 
     fstart_log::info!("  setup_sects: {}", setup_sects);
-    fstart_log::info!("  pm_kernel @ {:#x}", pm_kernel_addr);
+    fstart_log::info!(
+        "  pm_kernel @ {:#x} (syssize {:#x})",
+        pm_kernel_addr,
+        syssize
+    );
+    fstart_log::info!("  pref_address: {:#x}", pref_address);
     fstart_log::info!("  entry64 @ {:#x}", entry64);
     fstart_log::info!("  zero_page @ {:#x}", ZERO_PAGE);
     fstart_log::info!("  rsdp @ {:#x}", rsdp_addr);
     fstart_log::info!("  e820 count: {}", e820_entries.len());
 
+    // Log critical setup header fields for debugging.
+    let init_size = u32::from_le_bytes(params[0x260..0x264].try_into().unwrap_or([0; 4]));
+    let kernel_alignment = u32::from_le_bytes(params[0x230..0x234].try_into().unwrap_or([0; 4]));
+    let xloadflags = u16::from_le_bytes(params[0x236..0x238].try_into().unwrap_or([0; 2]));
+    fstart_log::info!("  init_size: {:#x}", init_size);
+    fstart_log::info!("  kernel_alignment: {:#x}", kernel_alignment);
+    fstart_log::info!("  xloadflags: {:#x}", xloadflags);
+
     // Jump to the kernel's 64-bit entry.
-    // The 64-bit boot protocol expects:
+    //
+    // The 64-bit boot protocol (boot protocol 2.12+, XLF_KERNEL_64) expects:
     //   - CPU in 64-bit long mode with paging enabled
     //   - Identity-mapped page tables covering all of physical memory
-    //     that the kernel might access during early boot
+    //     the kernel might access during early boot (we map 4 GiB)
     //   - %rsi = physical address of the boot_params (zero page)
-    //   - Interrupts disabled
+    //   - Interrupts disabled (cli)
     //   - GDT with __BOOT_CS (0x10) and __BOOT_DS (0x18) valid
     //
     // Our firmware already satisfies all of these: we're in long mode
     // with identity-mapped 2 MiB pages over 4 GiB, interrupts are
-    // disabled (cli in _start16bit), and we have a valid GDT.
+    // disabled (cli in _start16bit), and we have the correct GDT.
     //
     // SAFETY: all zero page fields have been populated above.
-    // kernel_addr points to a previously loaded bzImage.
+    // kernel_addr points to a previously loaded and relocated bzImage.
     unsafe {
         core::arch::asm!(
+            // Consume the input operands FIRST — the compiler may have
+            // placed them in any GPR, and the xor sequence below would
+            // destroy them if we zeroed first.
+            "cli",
             "mov rsi, {zero_page}",
-            "jmp {entry}",
+            "mov rdi, {entry}",
+            // Now zero all other GPRs to give the kernel a clean slate.
+            // rsi = boot_params, rdi = entry (consumed by jmp below).
+            // Leave rsp as-is — kernel sets its own stack.
+            "xor eax, eax",
+            "xor ebx, ebx",
+            "xor ecx, ecx",
+            "xor edx, edx",
+            "xor ebp, ebp",
+            "xor r8d, r8d",
+            "xor r9d, r9d",
+            "xor r10d, r10d",
+            "xor r11d, r11d",
+            "xor r12d, r12d",
+            "xor r13d, r13d",
+            "xor r14d, r14d",
+            "xor r15d, r15d",
+            "jmp rdi",
             zero_page = in(reg) ZERO_PAGE,
             entry = in(reg) entry64,
             options(noreturn),

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -433,7 +433,12 @@ pub fn jump_to(addr: u64) -> ! {
 /// - `kernel_addr`: physical address of the loaded kernel (typically `0x100000`)
 /// - `rsdp_addr`: physical address of the ACPI RSDP (from AcpiLoad)
 /// - `e820_entries`: slice of e820 memory map entries (from MemoryDetect)
-pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) -> ! {
+pub fn boot_linux(
+    kernel_addr: u64,
+    rsdp_addr: u64,
+    e820_entries: &[E820Entry],
+    bootargs: &str,
+) -> ! {
     // The zero page is at a well-known location in conventional memory.
     const ZERO_PAGE: u64 = 0x90000;
     const CMD_LINE: u64 = 0x91000;
@@ -525,8 +530,10 @@ pub fn boot_linux(kernel_addr: u64, rsdp_addr: u64, e820_entries: &[E820Entry]) 
 
     // cmd_line_ptr (offset 0x228)
     let cmdline = unsafe { &mut *(CMD_LINE as *mut [u8; 4096]) };
-    let bootargs = b"console=ttyS0 earlycon=uart8250,io,0x3f8,115200n8\0";
-    cmdline[..bootargs.len()].copy_from_slice(bootargs);
+    let args_bytes = bootargs.as_bytes();
+    let copy_len = args_bytes.len().min(4095); // leave room for NUL
+    cmdline[..copy_len].copy_from_slice(&args_bytes[..copy_len]);
+    cmdline[copy_len] = 0; // NUL terminator
     params[0x228..0x22C].copy_from_slice(&(CMD_LINE as u32).to_le_bytes());
 
     // ACPI RSDP address (offset 0x070, protocol 2.14+)

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -173,8 +173,17 @@ core::arch::global_asm!(
     "rep",
     "stosl",
     // Set up identity-mapped page tables for long mode.
-    // We use static page tables in the .page_tables section.
-    // PML4[0] → PDPT, PDPT[0..3] → PDT[0..3], each PDT has 512 2MB pages.
+    //
+    // Uses 1 GiB pages (PDPE1GB) for a compact 2-page layout:
+    //   PML4[0] → PDPT, PDPT[0..511] = 512 × 1 GiB identity pages.
+    // Covers 512 GiB — enough for any QEMU or real hardware config.
+    //
+    // 1 GiB pages (bit 7 = PS in PDPT entries) are supported by all
+    // x86_64 CPUs that QEMU can emulate (KVM host, TCG -cpu max).
+    //
+    // Layout: 2 pages total.
+    //   page_tables_start + 0x0000: PML4 (1 page)
+    //   page_tables_start + 0x1000: PDPT (1 page)
     //
     // Clear page table area first
     "movl $_page_tables_start, %edi",
@@ -188,25 +197,19 @@ core::arch::global_asm!(
     "movl $_page_tables_start, %edi",
     "leal 0x1003(%edi), %eax", // PDPT = page_tables + 0x1000, flags = 0x3
     "movl %eax, (%edi)",
-    // PDPT[0..3] = address of PDT[0..3] | Present | Writable
+    // Fill PDPT[0..511] with 1 GiB identity-mapped pages.
+    // Each entry: physical_addr | PageSize(1GB) | Writable | Present
+    // 1 GiB page flag = bit 7 (PS) in PDPT entry = 0x83.
     "leal 0x1000(%edi), %esi", // ESI = PDPT base
-    "leal 0x2003(%edi), %eax", // PDT0 = page_tables + 0x2000, flags = 0x3
-    "movl %eax, 0(%esi)",      // PDPT[0]
-    "addl $0x1000, %eax",
-    "movl %eax, 8(%esi)", // PDPT[1]
-    "addl $0x1000, %eax",
-    "movl %eax, 16(%esi)", // PDPT[2]
-    "addl $0x1000, %eax",
-    "movl %eax, 24(%esi)", // PDPT[3]
-    // Fill PDT entries: 4 PDTs × 512 entries = 2048 × 2MB = 4GB
-    // Each entry: physical_addr | Present | Writable | PageSize(2MB)
-    "leal 0x2000(%edi), %esi", // ESI = PDT0 base
-    "movl $0x00000083, %eax",  // Start: PA=0, PS=1, RW=1, P=1
-    "movl $2048, %ecx",        // 2048 entries
+    "xorl %edx, %edx",         // EDX = high 32 bits of PA (starts at 0)
+    "xorl %eax, %eax",         // EAX = low 32 bits of PA (starts at 0)
+    "orl $0x83, %eax",         // PS=1, RW=1, P=1
+    "movl $512, %ecx",         // 512 entries × 1 GiB = 512 GiB
     "1:",
-    "movl %eax, (%esi)",
-    "movl $0, 4(%esi)",     // high 32 bits = 0 (below 4GB)
-    "addl $0x200000, %eax", // next 2MB page
+    "movl %eax, (%esi)",      // low 32 bits
+    "movl %edx, 4(%esi)",     // high 32 bits
+    "addl $0x40000000, %eax", // next 1 GiB page (low 32 bits)
+    "adcl $0, %edx",          // carry into high 32 bits
     "addl $8, %esi",
     "decl %ecx",
     "jnz 1b",
@@ -218,10 +221,15 @@ core::arch::global_asm!(
     // Load PML4 base into CR3
     "movl $_page_tables_start, %eax",
     "movl %eax, %cr3",
-    // Enable long mode: set IA32_EFER.LME (bit 8)
+    // Enable long mode + NX support:
+    //   IA32_EFER.LME (bit 8) — Long Mode Enable
+    //   IA32_EFER.NXE (bit 11) — No-Execute Enable
+    // NXE is required by CrabEFI and the Linux kernel for marking
+    // data pages as non-executable. Without it, bit 63 in page
+    // table entries is reserved and triggers #PF.
     "movl $0xC0000080, %ecx", // IA32_EFER MSR
     "rdmsr",
-    "orl $0x100, %eax", // LME = 1
+    "orl $0x900, %eax", // LME | NXE
     "wrmsr",
     // Enable paging + SSE/AVX in one CR0 write:
     //   Set:   PG (bit 31), MP (bit 1)
@@ -342,14 +350,63 @@ core::arch::global_asm!(
 );
 
 // IDT table at a fixed low address (after page tables).
-// Page tables: 0x1000..0x7000 (6 pages).
-// IDT: 0x7000..0x8000 (1 page, 256 entries × 16 bytes).
+// Page tables: 0x1000..0x3000 (2 pages: PML4 + PDPT, 1 GiB pages).
+// IDT: placed after page tables (1 page, 256 entries × 16 bytes).
 core::arch::global_asm!(
     ".section .idt_table, \"aw\", @nobits",
     ".align 4096",
     ".global _idt_table",
     "_idt_table:",
     ".skip 4096",
+);
+
+// ---------------------------------------------------------------------------
+// RAM-stage entry (64-bit only — no 16-bit/32-bit transition)
+// ---------------------------------------------------------------------------
+
+/// Entry point for non-first x86_64 stages that run from RAM.
+///
+/// The bootblock already transitioned to 64-bit long mode with identity-
+/// mapped page tables. This entry zeros BSS, copies .data initializers
+/// (harmless no-op when src == dst), sets up the IDT and stack, then
+/// calls `fstart_main(0)`.
+///
+/// Placed in `.text.entry` so `KEEP(*(.text.entry))` in the linker script
+/// ensures it's at the start of the binary (= the load address that the
+/// bootblock's `jump_to()` targets).
+core::arch::global_asm!(
+    ".att_syntax prefix",
+    ".section .text.entry, \"ax\"",
+    ".code64",
+    ".global _start_ram",
+    "_start_ram:",
+    // Zero BSS (64-bit mode)
+    "movabs $_bss_start, %rdi",
+    "movabs $_bss_end, %rcx",
+    "subq %rdi, %rcx",
+    "shrq $3, %rcx", // count in qwords
+    "xorl %eax, %eax",
+    "rep stosq",
+    // Set up stack
+    "movabs $_stack_top, %rsp",
+    // Copy .data initializers (skip if src == dst, i.e., RAM-only)
+    "movabs $_data_load, %rsi",
+    "movabs $_data_start, %rdi",
+    "movabs $_data_end, %rcx",
+    "subq %rdi, %rcx",
+    "cmpq %rsi, %rdi",
+    "je 1f",
+    "rep movsb",
+    "1:",
+    // Set up IDT
+    "call _setup_idt",
+    // Call fstart_main(handoff_ptr=0)
+    "xorl %edi, %edi",
+    "call fstart_main",
+    // Should never return
+    "2:",
+    "hlt",
+    "jmp 2b",
 );
 
 // Make sure the linker pulls in the entry code

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -174,16 +174,15 @@ core::arch::global_asm!(
     "stosl",
     // Set up identity-mapped page tables for long mode.
     //
-    // Uses 1 GiB pages (PDPE1GB) for a compact 2-page layout:
-    //   PML4[0] → PDPT, PDPT[0..511] = 512 × 1 GiB identity pages.
-    // Covers 512 GiB — enough for any QEMU or real hardware config.
+    // Page size is selected at build time via the `x86-1g-pages` feature:
     //
-    // 1 GiB pages (bit 7 = PS in PDPT entries) are supported by all
-    // x86_64 CPUs that QEMU can emulate (KVM host, TCG -cpu max).
+    // x86-1g-pages (2 pages, 512 GiB):
+    //   PML4[0] -> PDPT, PDPT[0..511] = 512 x 1 GiB identity pages.
+    //   Requires PDPE1GB (CPUID 0x80000001 EDX[26]).
     //
-    // Layout: 2 pages total.
-    //   page_tables_start + 0x0000: PML4 (1 page)
-    //   page_tables_start + 0x1000: PDPT (1 page)
+    // Default / 2 MiB (6 pages, 4 GiB):
+    //   PML4[0] -> PDPT, PDPT[0..3] -> PD0..PD3, each PD has 512 x 2 MiB.
+    //   Universally supported. Matches coreboot pt.S layout.
     //
     // Clear page table area first
     "movl $_page_tables_start, %edi",
@@ -197,14 +196,21 @@ core::arch::global_asm!(
     "movl $_page_tables_start, %edi",
     "leal 0x1003(%edi), %eax", // PDPT = page_tables + 0x1000, flags = 0x3
     "movl %eax, (%edi)",
-    // Fill PDPT[0..511] with 1 GiB identity-mapped pages.
-    // Each entry: physical_addr | PageSize(1GB) | Writable | Present
-    // 1 GiB page flag = bit 7 (PS) in PDPT entry = 0x83.
+);
+
+// 1 GiB pages: PDPT[0..511] = 512 x 1 GiB identity-mapped pages.
+// Requires PDPE1GB. Covers 512 GiB. Compact: only 2 pages total.
+#[cfg(feature = "x86-1g-pages")]
+core::arch::global_asm!(
+    ".att_syntax prefix",
+    ".section .text, \"ax\"",
+    ".code32",
+    "movl $_page_tables_start, %edi",
     "leal 0x1000(%edi), %esi", // ESI = PDPT base
     "xorl %edx, %edx",         // EDX = high 32 bits of PA (starts at 0)
     "xorl %eax, %eax",         // EAX = low 32 bits of PA (starts at 0)
     "orl $0x83, %eax",         // PS=1, RW=1, P=1
-    "movl $512, %ecx",         // 512 entries × 1 GiB = 512 GiB
+    "movl $512, %ecx",         // 512 entries x 1 GiB = 512 GiB
     "1:",
     "movl %eax, (%esi)",      // low 32 bits
     "movl %edx, 4(%esi)",     // high 32 bits
@@ -213,6 +219,48 @@ core::arch::global_asm!(
     "addl $8, %esi",
     "decl %ecx",
     "jnz 1b",
+);
+
+// 2 MiB pages (default): PDPT[0..3] -> PD0..PD3, each PD 512 x 2 MiB.
+// Universally supported. Covers 4 GiB. Matches coreboot pt.S layout.
+#[cfg(not(feature = "x86-1g-pages"))]
+core::arch::global_asm!(
+    ".att_syntax prefix",
+    ".section .text, \"ax\"",
+    ".code32",
+    "movl $_page_tables_start, %edi",
+    // PDPT[0..3] = address of PD0..PD3 | Present | Writable
+    "leal 0x1000(%edi), %esi", // ESI = PDPT base
+    "leal 0x2003(%edi), %eax", // PD0 = page_tables + 0x2000, flags = 0x3
+    "movl %eax, 0(%esi)",
+    "addl $0x1000, %eax", // PD1 = page_tables + 0x3000
+    "movl %eax, 8(%esi)",
+    "addl $0x1000, %eax", // PD2 = page_tables + 0x4000
+    "movl %eax, 16(%esi)",
+    "addl $0x1000, %eax", // PD3 = page_tables + 0x5000
+    "movl %eax, 24(%esi)",
+    // Fill PD0..PD3 with 2048 x 2 MiB identity-mapped pages.
+    // Each entry: physical_addr | PageSize(2MB) | Writable | Present = 0x83.
+    "leal 0x2000(%edi), %esi", // ESI = PD0 base
+    "xorl %edx, %edx",         // EDX = high 32 bits of PA
+    "xorl %eax, %eax",         // EAX = low 32 bits of PA
+    "orl $0x83, %eax",         // PS=1, RW=1, P=1
+    "movl $2048, %ecx",        // 4 PDs x 512 entries = 2048
+    "2:",
+    "movl %eax, (%esi)",    // low 32 bits
+    "movl %edx, 4(%esi)",   // high 32 bits
+    "addl $0x200000, %eax", // next 2 MiB page
+    "adcl $0, %edx",        // carry into high 32 bits
+    "addl $8, %esi",
+    "decl %ecx",
+    "jnz 2b",
+);
+
+// Continue the entry sequence after page table setup.
+core::arch::global_asm!(
+    ".att_syntax prefix",
+    ".section .text, \"ax\"",
+    ".code32",
     // Enable PAE (bit 5), OSFXSR (bit 9), OSXMMEXCPT (bit 10).
     // OSFXSR + OSXMMEXCPT enable SSE/SSE2 (compiler_builtins memcpy).
     "movl %cr4, %eax",
@@ -479,31 +527,34 @@ pub fn jump_to(addr: u64) -> ! {
 ///
 /// Uses the 64-bit entry point at `code32_start + 0x200` (available since
 /// boot protocol 2.12 when `XLF_KERNEL_64` is set in `xload_flags`).
-/// This avoids the complex long-mode → protected-mode teardown needed
+/// This avoids the complex long-mode -> protected-mode teardown needed
 /// by the 32-bit protocol: we stay in long mode, set `%rsi` to the
 /// zero page, and jump directly to the kernel's `startup_64`.
 ///
-/// Constructs the zero page (boot_params) at `0x90000`, fills e820
-/// entries and ACPI RSDP address, then jumps to the kernel.
+/// Constructs the zero page (boot_params), fills e820 entries and ACPI
+/// RSDP address, then jumps to the kernel.
 ///
 /// # Arguments
 /// - `kernel_addr`: physical address of the loaded kernel (typically `0x100000`)
 /// - `rsdp_addr`: physical address of the ACPI RSDP (from AcpiLoad)
 /// - `e820_entries`: slice of e820 memory map entries (from MemoryDetect)
+/// - `bootargs`: kernel command line string
+/// - `zero_page_addr`: physical address for boot_params (0x90000 on QEMU,
+///   should be in e820-reported free conventional memory on real hardware)
 pub fn boot_linux(
     kernel_addr: u64,
     rsdp_addr: u64,
     e820_entries: &[E820Entry],
     bootargs: &str,
+    zero_page_addr: u64,
 ) -> ! {
-    // The zero page is at a well-known location in conventional memory.
-    const ZERO_PAGE: u64 = 0x90000;
-    const CMD_LINE: u64 = 0x91000;
+    let zero_page = zero_page_addr;
+    let cmd_line = zero_page + 0x1000; // command line follows zero page
 
-    // SAFETY: these addresses are in conventional memory below 640K,
-    // cleared by the entry code, and not used by any other code at
-    // this point.
-    let params = unsafe { &mut *(ZERO_PAGE as *mut [u8; 4096]) };
+    // SAFETY: zero_page_addr is in conventional memory (provided by
+    // the board config), cleared by the entry code, and not used by
+    // any other code at this point.
+    let params = unsafe { &mut *(zero_page as *mut [u8; 4096]) };
     params.fill(0);
 
     // The loaded image is a raw bzImage: real-mode boot sector + setup
@@ -586,12 +637,12 @@ pub fn boot_linux(
     params[0x1FA..0x1FC].copy_from_slice(&0xFFFFu16.to_le_bytes());
 
     // cmd_line_ptr (offset 0x228)
-    let cmdline = unsafe { &mut *(CMD_LINE as *mut [u8; 4096]) };
+    let cmdline = unsafe { &mut *(cmd_line as *mut [u8; 4096]) };
     let args_bytes = bootargs.as_bytes();
     let copy_len = args_bytes.len().min(4095); // leave room for NUL
     cmdline[..copy_len].copy_from_slice(&args_bytes[..copy_len]);
     cmdline[copy_len] = 0; // NUL terminator
-    params[0x228..0x22C].copy_from_slice(&(CMD_LINE as u32).to_le_bytes());
+    params[0x228..0x22C].copy_from_slice(&(cmd_line as u32).to_le_bytes());
 
     // ACPI RSDP address (offset 0x070, protocol 2.14+)
     params[0x070..0x078].copy_from_slice(&rsdp_addr.to_le_bytes());
@@ -617,7 +668,7 @@ pub fn boot_linux(
     );
     fstart_log::info!("  pref_address: {:#x}", pref_address);
     fstart_log::info!("  entry64 @ {:#x}", entry64);
-    fstart_log::info!("  zero_page @ {:#x}", ZERO_PAGE);
+    fstart_log::info!("  zero_page @ {:#x}", zero_page);
     fstart_log::info!("  rsdp @ {:#x}", rsdp_addr);
     fstart_log::info!("  e820 count: {}", e820_entries.len());
 
@@ -670,7 +721,7 @@ pub fn boot_linux(
             "xor r14d, r14d",
             "xor r15d, r15d",
             "jmp rdi",
-            zero_page = in(reg) ZERO_PAGE,
+            zero_page = in(reg) zero_page,
             entry = in(reg) entry64,
             options(noreturn),
         );

--- a/crates/fstart-services/src/acpi_provider.rs
+++ b/crates/fstart-services/src/acpi_provider.rs
@@ -1,0 +1,30 @@
+//! ACPI table provider service trait.
+//!
+//! Implemented by devices that can supply pre-built ACPI tables to firmware,
+//! such as QEMU's fw_cfg device. The firmware calls `load_acpi_tables()` to
+//! load the tables into a buffer, then passes the RSDP address to the OS
+//! via the boot protocol (e.g., x86 zero page, UEFI system table).
+//!
+//! For platforms that generate their own ACPI tables from the board RON,
+//! the `AcpiPrepare` capability is used instead — it does not go through
+//! this trait.
+
+use crate::ServiceError;
+
+/// A device that can provide pre-built ACPI tables.
+///
+/// The provider loads ACPI tables into the caller's buffer, processes
+/// any relocation or checksumming required, and returns the physical
+/// address of the RSDP (Root System Description Pointer).
+pub trait AcpiTableProvider {
+    /// Load ACPI tables into `buffer`.
+    ///
+    /// The implementation may use the buffer as scratch space for table
+    /// placement and patching (e.g., the QEMU table-loader protocol).
+    /// The buffer contents must remain valid after this call returns
+    /// (the caller will leak/forget the buffer so the OS can access
+    /// the tables).
+    ///
+    /// Returns the physical address of the RSDP within the buffer.
+    fn load_acpi_tables(&self, buffer: &mut [u8]) -> Result<u64, ServiceError>;
+}

--- a/crates/fstart-services/src/lib.rs
+++ b/crates/fstart-services/src/lib.rs
@@ -11,6 +11,7 @@
 
 #![no_std]
 
+pub mod acpi_provider;
 pub mod block;
 pub mod boot_media;
 pub mod clock;
@@ -20,6 +21,7 @@ pub mod framebuffer;
 pub mod gpio;
 pub mod i2c;
 pub mod memory_controller;
+pub mod memory_detect;
 pub mod pci;
 pub mod spi;
 pub mod timer;

--- a/crates/fstart-services/src/lib.rs
+++ b/crates/fstart-services/src/lib.rs
@@ -35,7 +35,7 @@ pub use framebuffer::{Framebuffer, FramebufferInfo};
 pub use gpio::GpioController;
 pub use i2c::I2c;
 pub use memory_controller::MemoryController;
-pub use pci::{PciAddr, PciRootBus};
+pub use pci::{PciAddr, PciRootBus, PciWindow, PciWindowKind};
 pub use spi::SpiBus;
 pub use timer::Timer;
 

--- a/crates/fstart-services/src/memory_detect.rs
+++ b/crates/fstart-services/src/memory_detect.rs
@@ -58,6 +58,94 @@ impl E820Entry {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Global e820 state — populated by MemoryDetect, read by PCI host bridges
+// ---------------------------------------------------------------------------
+
+/// Maximum number of e820 entries stored in the global state.
+pub const MAX_E820_ENTRIES: usize = 128;
+
+/// Shared e820 memory map state.
+///
+/// Populated by the `MemoryDetect` capability after calling
+/// `MemoryDetector::detect_memory()`.  Read by PCI host bridge drivers
+/// (e.g., Q35) to compute MMIO windows without requiring the codegen to
+/// pass e820 data explicitly.
+///
+/// This is firmware-level global state: single-threaded, set once during
+/// the capability pipeline, then read-only.
+pub struct E820State {
+    entries: [E820Entry; MAX_E820_ENTRIES],
+    count: usize,
+    total_ram: u64,
+}
+
+impl E820State {
+    const fn new() -> Self {
+        Self {
+            entries: [E820Entry::zeroed(); MAX_E820_ENTRIES],
+            count: 0,
+            total_ram: 0,
+        }
+    }
+
+    /// Store e820 entries and total RAM. Called once by MemoryDetect.
+    ///
+    /// # Safety
+    ///
+    /// Must be called from single-threaded firmware init context.
+    pub unsafe fn store(&mut self, entries: &[E820Entry], count: usize, total_ram: u64) {
+        let n = count.min(MAX_E820_ENTRIES);
+        self.entries[..n].copy_from_slice(&entries[..n]);
+        self.count = n;
+        self.total_ram = total_ram;
+    }
+
+    /// Get the stored e820 entries.
+    pub fn entries(&self) -> &[E820Entry] {
+        &self.entries[..self.count]
+    }
+
+    /// Get the stored entry count.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Get the total detected RAM in bytes.
+    pub fn total_ram(&self) -> u64 {
+        self.total_ram
+    }
+}
+
+/// Global e820 state instance.
+///
+/// # Safety
+///
+/// Access is safe in single-threaded firmware init. The `store()` method
+/// is called once during MemoryDetect; subsequent reads via `e820_state()`
+/// are safe because no concurrent mutation occurs.
+static mut E820_GLOBAL: E820State = E820State::new();
+
+/// Get a shared reference to the global e820 state.
+///
+/// # Safety
+///
+/// Safe to call after `MemoryDetect` has completed (which populates the
+/// state). Must not be called concurrently with `store()`.
+pub unsafe fn e820_state() -> &'static E820State {
+    unsafe { &*core::ptr::addr_of!(E820_GLOBAL) }
+}
+
+/// Get a mutable reference to the global e820 state for initial population.
+///
+/// # Safety
+///
+/// Must only be called once, from the MemoryDetect capability, in
+/// single-threaded firmware init context.
+pub unsafe fn e820_state_mut() -> &'static mut E820State {
+    unsafe { &mut *core::ptr::addr_of_mut!(E820_GLOBAL) }
+}
+
 /// A device that can detect the system memory layout at runtime.
 pub trait MemoryDetector {
     /// Discover memory regions and write them to `entries`.

--- a/crates/fstart-services/src/memory_detect.rs
+++ b/crates/fstart-services/src/memory_detect.rs
@@ -1,0 +1,75 @@
+//! Memory detection service trait.
+//!
+//! Implemented by devices that can discover the system memory layout
+//! at runtime, such as QEMU's fw_cfg device (which provides an e820 map)
+//! or future SPD/memory-training drivers.
+
+use crate::ServiceError;
+
+/// e820 memory region types.
+///
+/// These values match the x86 e820 / ACPI AddressRangeDescriptor types
+/// and are used regardless of architecture (the same enum can feed
+/// FDT `/memory` node updates on ARM/RISC-V).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum E820Kind {
+    /// Usable RAM.
+    Ram = 1,
+    /// Reserved by firmware / hardware.
+    Reserved = 2,
+    /// ACPI reclaimable memory (usable after ACPI tables are read).
+    Acpi = 3,
+    /// ACPI Non-Volatile Storage.
+    Nvs = 4,
+    /// Unusable / defective memory.
+    Unusable = 5,
+}
+
+/// A single memory region entry (matches the x86 e820 layout).
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct E820Entry {
+    /// Physical start address of the region.
+    pub addr: u64,
+    /// Size of the region in bytes.
+    pub size: u64,
+    /// Region type.
+    pub kind: u32,
+}
+
+impl E820Entry {
+    /// Create a zeroed (invalid) entry.
+    pub const fn zeroed() -> Self {
+        Self {
+            addr: 0,
+            size: 0,
+            kind: 0,
+        }
+    }
+
+    /// Create a new entry.
+    pub const fn new(addr: u64, size: u64, kind: E820Kind) -> Self {
+        Self {
+            addr,
+            size,
+            kind: kind as u32,
+        }
+    }
+}
+
+/// A device that can detect the system memory layout at runtime.
+pub trait MemoryDetector {
+    /// Discover memory regions and write them to `entries`.
+    ///
+    /// Returns the number of entries written. The caller provides a
+    /// buffer of at least 128 entries (the x86 e820 protocol maximum).
+    fn detect_memory(&self, entries: &mut [E820Entry]) -> Result<usize, ServiceError>;
+
+    /// Return the total usable RAM in bytes.
+    ///
+    /// This is the sum of all `E820Kind::Ram` regions. Implementations
+    /// may compute this from `detect_memory()` results or from a
+    /// separate query (e.g., fw_cfg `FW_CFG_RAM_SIZE`).
+    fn total_ram_bytes(&self) -> Result<u64, ServiceError>;
+}

--- a/crates/fstart-services/src/pci.rs
+++ b/crates/fstart-services/src/pci.rs
@@ -24,6 +24,74 @@
 
 use crate::ServiceError;
 
+// -----------------------------------------------------------------------
+// Standard PCI configuration register offsets (PCI Local Bus Spec 3.0)
+// -----------------------------------------------------------------------
+
+/// Vendor ID register (16-bit, offset 0x00).  Returns 0xFFFF when no
+/// device is present.
+pub const PCI_VENDOR_ID: u16 = 0x00;
+/// Device ID register (16-bit, offset 0x02).
+pub const PCI_DEVICE_ID: u16 = 0x02;
+/// Command register (16-bit, offset 0x04).
+pub const PCI_COMMAND: u16 = 0x04;
+/// Status register (16-bit, offset 0x06).
+pub const PCI_STATUS: u16 = 0x06;
+/// Revision ID + Class Code (32-bit, offset 0x08).
+pub const PCI_CLASS_REVISION: u16 = 0x08;
+/// Header Type (8-bit, offset 0x0E).  Bit 7 = multi-function.
+pub const PCI_HEADER_TYPE: u16 = 0x0E;
+
+// -- Type 0 (endpoint) header --
+/// Base Address Register 0 (offset 0x10).
+pub const PCI_BAR0: u16 = 0x10;
+/// Base Address Register 1 (offset 0x14).
+pub const PCI_BAR1: u16 = 0x14;
+/// Base Address Register 2 (offset 0x18).
+pub const PCI_BAR2: u16 = 0x18;
+/// Base Address Register 3 (offset 0x1C).
+pub const PCI_BAR3: u16 = 0x1C;
+/// Base Address Register 4 (offset 0x20).
+pub const PCI_BAR4: u16 = 0x20;
+/// Base Address Register 5 (offset 0x24).
+pub const PCI_BAR5: u16 = 0x24;
+/// Interrupt Line — IRQ number written by firmware (offset 0x3C).
+pub const PCI_INTERRUPT_LINE: u16 = 0x3C;
+/// Interrupt Pin — 1=INTA, 2=INTB, 3=INTC, 4=INTD (offset 0x3D).
+pub const PCI_INTERRUPT_PIN: u16 = 0x3D;
+
+// -- Type 1 (bridge) header --
+/// Primary Bus Number (offset 0x18, type 1 header).
+pub const PCI_PRIMARY_BUS: u16 = 0x18;
+/// I/O Base (offset 0x1C, type 1 header).
+pub const PCI_IO_BASE: u16 = 0x1C;
+/// Memory Base (offset 0x20, type 1 header).
+pub const PCI_MEMORY_BASE: u16 = 0x20;
+/// Prefetchable Memory Base (offset 0x24, type 1 header).
+pub const PCI_PREF_MEMORY_BASE: u16 = 0x24;
+/// Prefetchable Base Upper 32 bits (offset 0x28, type 1 header).
+pub const PCI_PREF_BASE_UPPER32: u16 = 0x28;
+/// Prefetchable Limit Upper 32 bits (offset 0x2C, type 1 header).
+pub const PCI_PREF_LIMIT_UPPER32: u16 = 0x2C;
+
+// -- Command register bits --
+/// I/O Space Enable (bit 0).
+pub const PCI_CMD_IO: u16 = 0x0001;
+/// Memory Space Enable (bit 1).
+pub const PCI_CMD_MEMORY: u16 = 0x0002;
+/// Bus Master Enable (bit 2).
+pub const PCI_CMD_BUS_MASTER: u16 = 0x0004;
+
+// -- Header type field values --
+/// Type 1 (PCI-to-PCI bridge).
+pub const PCI_HEADER_TYPE_BRIDGE: u8 = 0x01;
+/// Multi-function device flag (bit 7 of header type).
+pub const PCI_HEADER_TYPE_MULTI_FUNC: u8 = 0x80;
+
+// -- Sentinel values --
+/// Value read from PCI_VENDOR_ID when no device is present.
+pub const PCI_VENDOR_INVALID: u32 = 0xFFFF_FFFF;
+
 /// PCI address: bus / device / function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PciAddr {

--- a/crates/fstart-services/src/pci.rs
+++ b/crates/fstart-services/src/pci.rs
@@ -8,6 +8,19 @@
 //! After `init()` returns, all BARs on the bus tree are programmed and the
 //! devices are ready for use by downstream consumers (e.g., CrabEFI's own
 //! PCI driver model which *reads* pre-allocated BARs).
+//!
+//! # Resource windows
+//!
+//! A root bridge decodes one or more address windows on behalf of its
+//! children.  Each window is either memory-mapped (MMIO) or I/O port
+//! space, described by [`PciWindow`].  Whether a memory window is
+//! reachable via 32-bit or 64-bit BARs is derived from its base and
+//! size — no separate "32-bit" vs "64-bit" distinction is needed.
+//!
+//! The [`PciRootBus::windows`] method returns all windows as a slice,
+//! so platforms with multiple MMIO ranges (e.g., separate prefetchable
+//! and non-prefetchable regions, or below- and above-4 GiB ranges) can
+//! describe their topology faithfully.
 
 use crate::ServiceError;
 
@@ -22,6 +35,56 @@ pub struct PciAddr {
 impl PciAddr {
     pub const fn new(bus: u8, dev: u8, func: u8) -> Self {
         Self { bus, dev, func }
+    }
+}
+
+/// Kind of address space a [`PciWindow`] decodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PciWindowKind {
+    /// Memory-mapped I/O.  Whether 32-bit or 64-bit BARs can target this
+    /// window is determined by the address range: if `base + size <= 4 GiB`,
+    /// 32-bit BARs fit; otherwise only 64-bit BARs can reach it.
+    Mmio,
+    /// I/O port space.  On architectures without native I/O ports
+    /// (AArch64, RISC-V), the host bridge maps PCI I/O into a memory
+    /// window — `base` is that MMIO address.  On x86, `base` is the
+    /// first I/O port number.
+    Io,
+}
+
+/// One address window decoded by a PCI root bridge.
+///
+/// A root bridge may decode several windows: low MMIO (below 4 GiB),
+/// high MMIO (above 4 GiB), I/O ports, etc.  The allocator assigns
+/// BARs from these windows during enumeration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PciWindow {
+    /// Kind of address space (memory or I/O).
+    pub kind: PciWindowKind,
+    /// Base physical address (MMIO) or I/O port address.
+    pub base: u64,
+    /// Size of the window in bytes.
+    pub size: u64,
+    /// Whether this memory window supports prefetchable transactions.
+    ///
+    /// Only meaningful for [`PciWindowKind::Mmio`] windows.  ACPI `_CRS`
+    /// resource descriptors and PCI bridge forwarding registers
+    /// distinguish prefetchable from non-prefetchable memory.
+    pub prefetchable: bool,
+}
+
+impl PciWindow {
+    /// Exclusive end address (`base + size`), saturating at `u64::MAX`.
+    pub const fn end(&self) -> u64 {
+        self.base.saturating_add(self.size)
+    }
+
+    /// Whether a 32-bit BAR can target this window.
+    ///
+    /// True when the entire window fits within the low 4 GiB.
+    pub const fn is_below_4g(&self) -> bool {
+        self.base.saturating_add(self.size) <= 0x1_0000_0000
     }
 }
 
@@ -91,4 +154,15 @@ pub trait PciRootBus: Send + Sync {
 
     /// Number of discovered devices after `init()`.
     fn device_count(&self) -> usize;
+
+    /// Address windows decoded by this root bridge.
+    ///
+    /// Returns all MMIO and I/O windows that the root bridge forwards to
+    /// PCI devices.  The allocator assigns BARs from these windows during
+    /// enumeration.  Consumers (ACPI table generators, downstream PCI
+    /// stacks) use these to learn the platform topology.
+    ///
+    /// A typical ECAM host bridge returns 2–3 windows: low MMIO
+    /// (below 4 GiB), high MMIO (above 4 GiB), and I/O ports.
+    fn windows(&self) -> &[PciWindow];
 }

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 riscv64 = ["dep:fstart-platform-riscv64"]
 aarch64 = ["dep:fstart-platform-aarch64"]
 armv7 = ["dep:fstart-platform-armv7"]
+x86_64 = ["dep:fstart-platform-x86_64"]
 # Allwinner sunxi support — adds fstart-soc-sunxi and enables the sunxi
 # entry point on platforms that support it (AArch64 RMR switch for H5/A64,
 # ARMv7 eGON boot for A20/H3, RISC-V eGON boot for D1).  Driven by
@@ -40,6 +41,15 @@ fu740-prci = ["dep:fstart-driver-fu740-prci"]
 fu740-ddr = ["dep:fstart-driver-fu740-ddr"]
 pci-ecam = ["dep:fstart-driver-pci-ecam", "dep:fstart-alloc"]
 bochs-display = ["dep:fstart-driver-bochs-display"]
+qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
+# NS16550 with x86 port I/O support
+ns16550-pio = ["ns16550", "fstart-driver-ns16550?/pio"]
+# x86 boot protocol support (zero page construction in platform crate)
+x86-boot = []
+# AcpiLoad capability (load ACPI tables from external provider)
+acpi-load = []
+# MemoryDetect capability (runtime memory detection)
+memory-detect = []
 # FFS / crypto features (forwarded to fstart-capabilities)
 ffs = ["fstart-capabilities/ffs", "dep:fstart-ffs"]
 ed25519 = ["ffs", "fstart-capabilities/ed25519", "fstart-ffs/ed25519"]
@@ -79,6 +89,7 @@ heapless = { workspace = true }
 fstart-platform-riscv64 = { workspace = true, optional = true }
 fstart-platform-aarch64 = { workspace = true, optional = true }
 fstart-platform-armv7 = { workspace = true, optional = true }
+fstart-platform-x86_64 = { workspace = true, optional = true }
 fstart-soc-sunxi = { workspace = true, optional = true }
 
 # Individual driver crates (enabled via features matching board.ron driver names)
@@ -98,6 +109,7 @@ fstart-driver-fu740-prci = { workspace = true, optional = true }
 fstart-driver-fu740-ddr = { workspace = true, optional = true }
 fstart-driver-pci-ecam = { workspace = true, optional = true }
 fstart-driver-bochs-display = { workspace = true, optional = true }
+fstart-driver-qemu-fw-cfg = { workspace = true, optional = true }
 
 # FFS (optional, behind ffs feature)
 fstart-ffs = { workspace = true, optional = true }

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -48,6 +48,8 @@ qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
 ns16550-pio = ["ns16550", "fstart-driver-ns16550?/pio"]
 # x86 boot protocol support (zero page construction in platform crate)
 x86-boot = []
+# x86_64: use 1 GiB pages (requires PDPE1GB). Default is 2 MiB pages.
+x86-1g-pages = ["fstart-platform-x86_64?/x86-1g-pages"]
 # AcpiLoad capability (load ACPI tables from external provider)
 acpi-load = []
 # MemoryDetect capability (runtime memory detection)

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -40,8 +40,8 @@ sifive-uart = ["dep:fstart-driver-sifive-uart"]
 fu740-prci = ["dep:fstart-driver-fu740-prci"]
 fu740-ddr = ["dep:fstart-driver-fu740-ddr"]
 pci-ecam = ["dep:fstart-driver-pci-ecam", "dep:fstart-alloc"]
-# PCI ECAM with x86 CF8/CFC PCIEXBAR bootstrap
-pci-ecam-pio = ["pci-ecam", "fstart-driver-pci-ecam?/pio"]
+
+q35-hostbridge = ["dep:fstart-driver-q35-hostbridge", "dep:fstart-alloc"]
 bochs-display = ["dep:fstart-driver-bochs-display"]
 qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
 # NS16550 with x86 port I/O support
@@ -112,6 +112,7 @@ fstart-driver-fu740-ddr = { workspace = true, optional = true }
 fstart-driver-pci-ecam = { workspace = true, optional = true }
 fstart-driver-bochs-display = { workspace = true, optional = true }
 fstart-driver-qemu-fw-cfg = { workspace = true, optional = true }
+fstart-driver-q35-hostbridge = { workspace = true, optional = true }
 
 # FFS (optional, behind ffs feature)
 fstart-ffs = { workspace = true, optional = true }

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -40,6 +40,8 @@ sifive-uart = ["dep:fstart-driver-sifive-uart"]
 fu740-prci = ["dep:fstart-driver-fu740-prci"]
 fu740-ddr = ["dep:fstart-driver-fu740-ddr"]
 pci-ecam = ["dep:fstart-driver-pci-ecam", "dep:fstart-alloc"]
+# PCI ECAM with x86 CF8/CFC PCIEXBAR bootstrap
+pci-ecam-pio = ["pci-ecam", "fstart-driver-pci-ecam?/pio"]
 bochs-display = ["dep:fstart-driver-bochs-display"]
 qemu-fw-cfg = ["dep:fstart-driver-qemu-fw-cfg"]
 # NS16550 with x86 port I/O support

--- a/crates/fstart-stage/src/main.rs
+++ b/crates/fstart-stage/src/main.rs
@@ -16,7 +16,12 @@
 // to register the global allocator.  Without this explicit extern crate,
 // the linker would not include it (nothing else references the crate by
 // symbol).
-#[cfg(any(feature = "acpi", feature = "pci-ecam", feature = "crabefi"))]
+#[cfg(any(
+    feature = "acpi",
+    feature = "pci-ecam",
+    feature = "q35-hostbridge",
+    feature = "crabefi"
+))]
 extern crate fstart_alloc;
 
 // Include the generated stage code (fstart_main, driver instances, etc.)

--- a/crates/fstart-types/src/board.rs
+++ b/crates/fstart-types/src/board.rs
@@ -22,6 +22,8 @@ pub enum Platform {
     Aarch64,
     /// ARMv7-A (armv7a-none-eabi)
     Armv7,
+    /// x86-64 / AMD64 (x86_64-unknown-none)
+    X86_64,
 }
 
 impl Platform {
@@ -31,6 +33,7 @@ impl Platform {
             Platform::Riscv64 => "riscv64gc-unknown-none-elf",
             Platform::Aarch64 => "aarch64-unknown-none",
             Platform::Armv7 => "armv7a-none-eabi",
+            Platform::X86_64 => "x86_64-unknown-none",
         }
     }
 
@@ -40,6 +43,7 @@ impl Platform {
             Platform::Riscv64 => "riscv",
             Platform::Aarch64 => "aarch64",
             Platform::Armv7 => "arm",
+            Platform::X86_64 => "i386:x86-64",
         }
     }
 
@@ -49,6 +53,7 @@ impl Platform {
             Platform::Riscv64 => "riscv64",
             Platform::Aarch64 => "aarch64",
             Platform::Armv7 => "armv7",
+            Platform::X86_64 => "x86_64",
         }
     }
 }

--- a/crates/fstart-types/src/ffs.rs
+++ b/crates/fstart-types/src/ffs.rs
@@ -418,8 +418,9 @@ pub enum EntryContent {
     File {
         /// Type of file — influences how the loader treats it.
         file_type: FileType,
-        /// Segments that make up this file (max 4: text, rodata, data, bss).
-        segments: heapless::Vec<Segment, 4>,
+        /// Segments that make up this file (max 8: text, rodata, data, bss,
+        /// plus additional sections for x86 boot code and reset vector).
+        segments: heapless::Vec<Segment, 8>,
         /// Integrity digests over concatenated uncompressed segment data.
         digests: DigestSet,
     },

--- a/crates/fstart-types/src/stage.rs
+++ b/crates/fstart-types/src/stage.rs
@@ -178,6 +178,35 @@ pub enum Capability {
     /// 4/16/17/19/32/127) from the board RON's `smbios` config section.
     /// Does not require a heap — writes directly to the target address.
     SmBiosPrepare,
+    /// Load ACPI tables from an external provider device.
+    ///
+    /// Calls the referenced device's `AcpiTableProvider` implementation
+    /// to load pre-built ACPI tables into memory. Used when the platform
+    /// provides ACPI tables externally (e.g., QEMU's fw_cfg device)
+    /// rather than generating them from the board RON.
+    ///
+    /// The loaded RSDP address is stored for the payload boot protocol
+    /// (e.g., x86 zero page, or UEFI system table).
+    ///
+    /// For platforms that generate their own ACPI tables, use
+    /// `AcpiPrepare` instead.
+    AcpiLoad {
+        /// Device name implementing `AcpiTableProvider` (e.g., "fw_cfg0")
+        device: HString<32>,
+    },
+    /// Detect system memory layout at runtime.
+    ///
+    /// Calls the referenced device's `MemoryDetector` implementation
+    /// to discover the memory map. On QEMU this reads e820 entries from
+    /// the fw_cfg device. On real hardware, a future implementation
+    /// might read SPD data and perform memory training.
+    ///
+    /// Results are stored for later use by the boot protocol (e.g.,
+    /// x86 zero page e820 table, or FDT `/memory` node updates).
+    MemoryDetect {
+        /// Device name implementing `MemoryDetector` (e.g., "fw_cfg0")
+        device: HString<32>,
+    },
     /// Return to the BROM's FEL (USB recovery) mode.
     ///
     /// Restores the saved BROM state (SP, LR, CPSR, SCTLR, VBAR) from

--- a/crates/fstart-types/src/stage.rs
+++ b/crates/fstart-types/src/stage.rs
@@ -42,6 +42,16 @@ pub struct MonolithicConfig {
     /// (e.g., QEMU places the DTB at the base of RAM on AArch64).
     #[serde(default)]
     pub data_addr: Option<u64>,
+    /// Separate low-memory region for page tables and IDT (x86_64).
+    ///
+    /// On x86_64, page tables and the IDT must be in writable RAM at
+    /// addresses below the main data region. When set, the linker
+    /// creates a separate LOW memory region at `(addr, size)` for
+    /// `.pagetables` and `.idt` sections. When unset, these sections
+    /// go in the normal RAM region (or in ROM for platforms that
+    /// support ROM-resident page tables).
+    #[serde(default)]
+    pub page_table_addr: Option<(u64, u64)>,
 }
 
 /// Configuration for one stage in a multi-stage build.
@@ -70,6 +80,11 @@ pub struct StageConfig {
     /// the base of RAM.
     #[serde(default)]
     pub data_addr: Option<u64>,
+    /// Separate low-memory region for page tables and IDT (x86_64).
+    ///
+    /// Same semantics as [`MonolithicConfig::page_table_addr`].
+    #[serde(default)]
+    pub page_table_addr: Option<(u64, u64)>,
 }
 
 /// Where a stage executes from.
@@ -295,6 +310,18 @@ pub enum BootMedium {
         base: u64,
         /// Size of the mapped flash region in bytes.
         size: u64,
+        /// Optional RAM address to copy FFS data before accessing it.
+        ///
+        /// On x86_64 with code-model=large, FFS operations (postcard
+        /// deserialization, LZ4 decompression) are significantly faster
+        /// when operating on RAM rather than flash-mapped MMIO. When
+        /// set, generated code copies `size` bytes from `base` to this
+        /// address before constructing the `MemoryMapped` accessor.
+        ///
+        /// On platforms with true XIP (ARM, RISC-V), this should be
+        /// `None` — the flash is accessed directly.
+        #[serde(default)]
+        ram_copy_addr: Option<u64>,
     },
     /// A named device that implements `BlockDevice`.
     ///

--- a/crates/fstart-types/src/stage.rs
+++ b/crates/fstart-types/src/stage.rs
@@ -52,6 +52,12 @@ pub struct MonolithicConfig {
     /// support ROM-resident page tables).
     #[serde(default)]
     pub page_table_addr: Option<(u64, u64)>,
+    /// x86_64 identity-map page size (default: 2 MiB).
+    ///
+    /// Controls page table layout and total memory used. Use `Size1GiB`
+    /// only on CPUs known to support PDPE1GB.
+    #[serde(default)]
+    pub page_size: PageSize,
 }
 
 /// Configuration for one stage in a multi-stage build.
@@ -85,6 +91,11 @@ pub struct StageConfig {
     /// Same semantics as [`MonolithicConfig::page_table_addr`].
     #[serde(default)]
     pub page_table_addr: Option<(u64, u64)>,
+    /// x86_64 identity-map page size (default: 2 MiB).
+    ///
+    /// Same semantics as [`MonolithicConfig::page_size`].
+    #[serde(default)]
+    pub page_size: PageSize,
 }
 
 /// Where a stage executes from.
@@ -94,6 +105,31 @@ pub enum RunsFrom {
     Rom,
     /// Execute from RAM after being loaded
     Ram,
+}
+
+/// x86_64 identity-map page size for page table construction.
+///
+/// Controls the page table depth and total size:
+/// - `Size2MiB`: 4-level (PML4 + PDPT + PD tables), 6 pages for 4 GiB.
+///   Compatible with all x86_64 CPUs.
+/// - `Size1GiB`: 3-level (PML4 + PDPT with PS=1), 2 pages for 512 GiB.
+///   Requires CPUID 0x80000001 EDX bit 26 (PDPE1GB).  Not supported on
+///   early Atom, some Xeon E3, and Goldmont-class CPUs.
+///
+/// Real boards should set this based on the target CPU's known capabilities.
+/// QEMU boards can use `Size1GiB` since QEMU always supports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PageSize {
+    /// 2 MiB pages — universally supported on all x86_64 CPUs.
+    Size2MiB,
+    /// 1 GiB pages — requires PDPE1GB (CPUID 0x80000001 EDX[26]).
+    Size1GiB,
+}
+
+impl Default for PageSize {
+    fn default() -> Self {
+        Self::Size2MiB
+    }
 }
 
 /// A capability is a composable unit of firmware functionality.

--- a/xtask/src/assemble.rs
+++ b/xtask/src/assemble.rs
@@ -530,10 +530,9 @@ fn assemble_linux_payload(
                     data: kernel_data,
                     mem_size: None,
                     load_addr: kernel_load_addr,
-                    // TODO: make compression configurable per-board via RON
-                    // (e.g. payload.compression field). For now LZ4 is always
-                    // used — the runtime decompressor is enabled whenever FFS
-                    // is active, and smaller images benefit all targets.
+                    // LZ4 compression — the x86 FFS-to-RAM copy ensures
+                    // decompression runs on fast RAM, not flash XIP.
+                    // TODO: make compression configurable per-board via RON.
                     compression: Compression::Lz4,
                     flags: SegmentFlags::CODE,
                 }],

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -596,12 +596,17 @@ fn capability_features(
         features.push("fdt".to_string());
     }
 
+    // PCI features are determined by the actual driver, not the platform.
+    // The Q35 host bridge handles CF8/CFC bootstrap internally.
     if stage_uses_pci(capabilities) {
-        if config.platform == Platform::X86_64 {
-            // x86: use CF8/CFC to program PCIEXBAR before ECAM access.
-            features.push("pci-ecam-pio".to_string());
-        } else {
-            features.push("pci-ecam".to_string());
+        // Find the PCI root bus device to determine which driver is used.
+        let pci_driver = config
+            .devices
+            .iter()
+            .find(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
+        match pci_driver.map(|d| d.driver.as_str()) {
+            Some("q35-hostbridge") => features.push("q35-hostbridge".to_string()),
+            _ => features.push("pci-ecam".to_string()),
         }
     }
 

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -113,6 +113,9 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
             let mut features = base_features.clone();
             let cap_features = capability_features(&mono.capabilities, &config.security, &config);
             features.extend(cap_features);
+            if mono.page_size == fstart_types::stage::PageSize::Size1GiB {
+                features.push("x86-1g-pages".to_string());
+            }
             let features_str = features.join(",");
             let needs_alloc = stage_uses_fdt(&mono.capabilities)
                 || stage_uses_acpi(&mono.capabilities)
@@ -156,6 +159,9 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
                 let cap_features =
                     capability_features(&stage.capabilities, &config.security, &config);
                 features.extend(cap_features);
+                if stage.page_size == fstart_types::stage::PageSize::Size1GiB {
+                    features.push("x86-1g-pages".to_string());
+                }
                 let features_str = features.join(",");
 
                 let stage_has_crabefi = stage

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -102,7 +102,7 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
     // boot ROM loads raw binary from SD/SPI/eMMC.
     let needs_flat_binary = matches!(
         config.platform,
-        Platform::Aarch64 | Platform::Riscv64 | Platform::Armv7
+        Platform::Aarch64 | Platform::Riscv64 | Platform::Armv7 | Platform::X86_64
     );
 
     let soc_format = config.soc_image_format;
@@ -231,11 +231,33 @@ fn build_one_stage(
     // adds alignment/null checks on read_volatile/write_volatile that are
     // incompatible with MMIO register access in firmware debug builds).
     //
-    // Force strict-align: the armv7a-none-eabi target spec already sets
-    // +strict-align, but we re-assert it here to ensure LLVM never emits
-    // unaligned loads/stores to MMIO addresses (device memory faults on
-    // unaligned access even when the core supports it for normal memory).
-    cmd.env("RUSTFLAGS", "-Zub-checks=no -Ctarget-feature=+strict-align");
+    // Force strict-align on ARM/RISC-V: the armv7a-none-eabi target spec
+    // already sets +strict-align, but we re-assert it here to ensure LLVM
+    // never emits unaligned loads/stores to MMIO addresses (device memory
+    // faults on unaligned access even when the core supports it for normal
+    // memory).  Not applicable to x86_64 (unaligned access is always allowed).
+    let rustflags = if target.starts_with("x86_64") {
+        // x86_64 firmware: static relocation, large code model.
+        // Large model is needed because ROM at 0xFF800000 and RAM/BSS at
+        // 0x10000 are ~4 GiB apart, exceeding small/medium/kernel model
+        // ±2 GiB limits. LTO (enabled in release profile) mitigates the
+        // indirect-call overhead by inlining across crate boundaries.
+        // Future: move BSS/stack to addresses within 2 GiB of ROM to
+        // allow kernel code model with fast PC-relative calls.
+        //
+        // Force curve25519-dalek to use the scalar ("serial") backend.
+        // The auto-detected "simd" backend (AVX2) causes LLVM crashes
+        // when compiling for x86_64-unknown-none: adding +avx2 globally
+        // breaks compiler_builtins (f16/f128 getCopyFromParts mismatch),
+        // and without it LLVM can't lower AVX2 intrinsics. The scalar
+        // backend is correct and sufficient for firmware signature verify.
+        "-Zub-checks=no -Crelocation-model=static -Ccode-model=large \
+         --cfg curve25519_dalek_backend=\"serial\""
+            .to_string()
+    } else {
+        "-Zub-checks=no -Ctarget-feature=+strict-align".to_string()
+    };
+    cmd.env("RUSTFLAGS", &rustflags);
 
     // Pass board RON path to build.rs
     cmd.env("FSTART_BOARD_RON", board_ron.to_str().unwrap());
@@ -585,6 +607,28 @@ fn capability_features(
         features.push("smbios".to_string());
     }
 
+    // AcpiLoad needs the fw_cfg driver and x86-boot support
+    if capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::AcpiLoad { .. }))
+    {
+        features.push("acpi-load".to_string());
+    }
+
+    // MemoryDetect needs the memory-detect feature
+    if capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::MemoryDetect { .. }))
+    {
+        features.push("memory-detect".to_string());
+    }
+
+    // NS16550 PIO mode needs the pio feature propagated
+    if config.platform == Platform::X86_64 {
+        features.push("ns16550-pio".to_string());
+        features.push("x86-boot".to_string());
+    }
+
     features
 }
 
@@ -606,7 +650,7 @@ fn stage_uses_pci(capabilities: &[Capability]) -> bool {
 fn stage_uses_acpi(capabilities: &[Capability]) -> bool {
     capabilities
         .iter()
-        .any(|c| matches!(c, Capability::AcpiPrepare))
+        .any(|c| matches!(c, Capability::AcpiPrepare | Capability::AcpiLoad { .. }))
 }
 
 /// Check if the board uses CrabEFI as a UEFI payload.

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -597,7 +597,12 @@ fn capability_features(
     }
 
     if stage_uses_pci(capabilities) {
-        features.push("pci-ecam".to_string());
+        if config.platform == Platform::X86_64 {
+            // x86: use CF8/CFC to program PCIEXBAR before ECAM access.
+            features.push("pci-ecam-pio".to_string());
+        } else {
+            features.push("pci-ecam".to_string());
+        }
     }
 
     if stage_uses_crabefi(config) {

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -158,9 +158,23 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
                 features.extend(cap_features);
                 let features_str = features.join(",");
 
+                let stage_has_crabefi = stage
+                    .capabilities
+                    .iter()
+                    .any(|c| matches!(c, Capability::PayloadLoad))
+                    && stage_uses_crabefi(&config);
+                // PCI and Q35 driver features pull in fstart-alloc, which
+                // needs alloc in build-std even for stages that don't
+                // directly use PCI. Driver features are global.
+                let has_pci_driver = config
+                    .devices
+                    .iter()
+                    .any(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
                 let needs_alloc = stage_uses_fdt(&stage.capabilities)
                     || stage_uses_acpi(&stage.capabilities)
-                    || stage.heap_size.is_some();
+                    || stage_has_crabefi
+                    || stage.heap_size.is_some()
+                    || has_pci_driver;
                 let build_std = if needs_alloc { "core,alloc" } else { "core" };
 
                 eprintln!("[fstart] features: {features_str}");
@@ -610,7 +624,12 @@ fn capability_features(
         }
     }
 
-    if stage_uses_crabefi(config) {
+    // CrabEFI is only needed by stages that actually have PayloadLoad.
+    // For multi-stage boards, the bootblock doesn't need CrabEFI.
+    let has_payload_load = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::PayloadLoad));
+    if has_payload_load && stage_uses_crabefi(config) {
         features.push("crabefi".to_string());
     }
 

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -246,6 +246,11 @@ fn build_one_stage(
         // allow kernel code model with fast PC-relative calls.
         //
         // Force curve25519-dalek to use the scalar ("serial") backend.
+        // This must be in RUSTFLAGS (not Cargo.toml) because:
+        // 1. Cargo features can't set --cfg on transitive dependencies
+        // 2. .cargo/config.toml would affect host builds too
+        // 3. This only applies to x86_64-unknown-none (firmware target)
+        //
         // The auto-detected "simd" backend (AVX2) causes LLVM crashes
         // when compiling for x86_64-unknown-none: adding +avx2 globally
         // breaks compiler_builtins (f16/f128 getCopyFromParts mismatch),

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -168,6 +168,75 @@ pub fn run(
                 ];
                 (find_qemu("qemu-system-arm"), args)
             }
+            Platform::X86_64 => {
+                // x86 Q35: load firmware as pflash (flash ROM at top of 4GB).
+                // QEMU Q35 maps pflash0 at the top of the 32-bit address space
+                // with the reset vector at 0xFFFFFFF0.
+                let pflash_size = 8 * 1024 * 1024; // 8 MiB flash
+                                                   // x86: the raw stage .bin has boot code at the correct
+                                                   // offsets within 8MB (reset vector at end, code at start).
+                                                   // The FFS image has the stage segments + kernel payload.
+                                                   // We overlay the FFS onto the raw binary so both the boot
+                                                   // code (end of flash) and FFS data (start of flash) are
+                                                   // present.
+                                                   //
+                                                   // binary = target/ffs/qemu-q35.ffs
+                                                   // stage_bin = target/x86_64-unknown-none/{debug,release}/fstart-stage.bin
+                let workspace = binary.parent().unwrap().parent().unwrap();
+                let profile = if binary.to_str().unwrap_or("").contains("release")
+                    || std::env::args().any(|a| a == "--release")
+                {
+                    "release"
+                } else {
+                    "debug"
+                };
+                let stage_bin = workspace
+                    .join("x86_64-unknown-none")
+                    .join(profile)
+                    .join("fstart-stage.bin");
+                let pflash_path = if stage_bin.exists() {
+                    create_x86_pflash(binary, &stage_bin, pflash_size)?
+                } else {
+                    eprintln!(
+                        "[fstart] warning: stage .bin not found at {}, using FFS directly",
+                        stage_bin.display()
+                    );
+                    create_pflash_image_aligned(binary, pflash_size, true)?
+                };
+
+                // Try KVM first, fall back to TCG if /dev/kvm is absent.
+                // -cpu max: under KVM exposes host features; under TCG
+                // enables all emulated features.
+                // KVM requires -bios (ROM mapping via EPT). pflash is backed
+                // by a block device whose MMIO semantics prevent KVM from
+                // fetching instructions — the ljmpl from the boot block to
+                // stage code at 0xFF800000 hangs. TCG software-emulates
+                // everything so pflash works fine there.
+                let use_kvm = std::fs::File::open("/dev/kvm").is_ok();
+                let mut args = vec![
+                    "-machine".to_string(),
+                    "q35".to_string(),
+                    "-accel".to_string(),
+                    if use_kvm { "kvm" } else { "tcg" }.to_string(),
+                    "-cpu".to_string(),
+                    if use_kvm { "host" } else { "max" }.to_string(),
+                    "-m".to_string(),
+                    "1G".to_string(),
+                    "-nographic".to_string(),
+                    if use_kvm { "-bios" } else { "-drive" }.to_string(),
+                    if use_kvm {
+                        pflash_path.display().to_string()
+                    } else {
+                        format!("if=pflash,format=raw,file={}", pflash_path.display())
+                    },
+                    // ISA debugcon for early debug output
+                    "-device".to_string(),
+                    "isa-debugcon,iobase=0x402,chardev=debugout".to_string(),
+                    "-chardev".to_string(),
+                    "file,id=debugout,path=/dev/stderr".to_string(),
+                ];
+                (find_qemu("qemu-system-x86_64"), args)
+            }
         }
     };
 
@@ -357,7 +426,18 @@ fn find_board_dir(binary: &Path) -> Result<PathBuf, String> {
 
 /// Create a QEMU pflash image by padding a firmware binary to the exact
 /// flash bank size. Padding uses 0xFF (the erased state of NOR flash).
-fn create_pflash_image(binary: &Path, flash_size: usize) -> Result<PathBuf, String> {
+///
+/// The `align_end` parameter controls placement within the pflash:
+/// - `false` (default, RISC-V/ARM): firmware at offset 0, padding after.
+/// - `true` (x86): firmware at end of flash, padding before. This is
+///   required because QEMU maps pflash so the LAST byte is at the top
+///   of the address space (0xFFFFFFFF on x86), and the reset vector
+///   must be at the last 16 bytes.
+fn create_pflash_image_aligned(
+    binary: &Path,
+    flash_size: usize,
+    align_end: bool,
+) -> Result<PathBuf, String> {
     let data = std::fs::read(binary).map_err(|e| format!("failed to read firmware binary: {e}"))?;
 
     if data.len() > flash_size {
@@ -369,17 +449,146 @@ fn create_pflash_image(binary: &Path, flash_size: usize) -> Result<PathBuf, Stri
     }
 
     let mut pflash = vec![0xFFu8; flash_size];
-    pflash[..data.len()].copy_from_slice(&data);
+    if align_end {
+        // x86: firmware at the END of flash (reset vector at last 16 bytes)
+        let offset = flash_size - data.len();
+        pflash[offset..].copy_from_slice(&data);
+    } else {
+        // ARM/RISC-V: firmware at the START of flash
+        pflash[..data.len()].copy_from_slice(&data);
+    }
 
     let pflash_path = binary.with_extension("pflash");
     std::fs::write(&pflash_path, &pflash)
         .map_err(|e| format!("failed to write pflash image: {e}"))?;
 
     eprintln!(
-        "[fstart] pflash image: {} ({} bytes, firmware {} bytes)",
+        "[fstart] pflash image: {} ({} bytes, firmware {} bytes{})",
         pflash_path.display(),
         flash_size,
-        data.len()
+        data.len(),
+        if align_end { ", aligned to end" } else { "" },
+    );
+
+    Ok(pflash_path)
+}
+
+/// Convenience wrapper: firmware at start of flash (ARM/RISC-V).
+fn create_pflash_image(binary: &Path, flash_size: usize) -> Result<PathBuf, String> {
+    create_pflash_image_aligned(binary, flash_size, false)
+}
+
+/// Create an x86 pflash image by overlaying the FFS image onto the raw
+/// stage binary.
+///
+/// The raw stage `.bin` (from objcopy) is a full flash-sized image with
+/// boot code at the correct offsets (reset vector at end, 16/32/64-bit
+/// entry code near end, main code at start). The FFS image contains the
+/// stage segments + kernel payload at offset 0 (mapped to flash base).
+///
+/// We start with the raw binary as the base (preserving boot code at the
+/// end) and overlay the FFS content at offset 0 (so the FFS anchor and
+/// payload are accessible via memory-mapped flash reads).
+fn create_x86_pflash(
+    ffs_image: &Path,
+    stage_bin: &Path,
+    flash_size: usize,
+) -> Result<PathBuf, String> {
+    let mut pflash =
+        std::fs::read(stage_bin).map_err(|e| format!("failed to read stage binary: {e}"))?;
+
+    if pflash.len() != flash_size {
+        // Pad or truncate to flash size
+        pflash.resize(flash_size, 0xFF);
+    }
+
+    let ffs_data =
+        std::fs::read(ffs_image).map_err(|e| format!("failed to read FFS image: {e}"))?;
+
+    if ffs_data.len() > flash_size {
+        return Err(format!(
+            "FFS image ({} bytes) exceeds flash size ({} bytes)",
+            ffs_data.len(),
+            flash_size,
+        ));
+    }
+
+    // Place FFS at offset 0x100000 (1 MiB) to avoid overwriting stage code.
+    // Stage code (.text + .rodata + .ltext with code-model=large) occupies
+    // ~640 KiB at the start of flash; 1 MiB gives headroom for growth.
+    //
+    // Flash layout (8 MiB pflash at 0xFF800000):
+    //   [0x000000..0x0FFFFF] stage code XIP (.text, .rodata, .ltext)
+    //   [0x100000..0x7FEFFF] FFS image (kernel payload, manifest, etc.)
+    //   [0x7FF000..0x7FFFFF] boot block (.x86boot + .reset)
+    //
+    // Must match the board RON BootMedia base:
+    //   flash_base + FFS_FLASH_OFFSET = 0xFF800000 + 0x100000 = 0xFF900000
+    const FFS_FLASH_OFFSET: usize = 0x100000;
+    let ffs_end = FFS_FLASH_OFFSET + ffs_data.len();
+    let bootblock_start = flash_size - 0x1000; // last 4K
+
+    if ffs_end > bootblock_start {
+        return Err(format!(
+            "FFS image ({} bytes) at offset {:#x} overlaps boot block at {:#x}",
+            ffs_data.len(),
+            FFS_FLASH_OFFSET,
+            bootblock_start,
+        ));
+    }
+
+    pflash[FFS_FLASH_OFFSET..ffs_end].copy_from_slice(&ffs_data);
+
+    // Patch the FSTART_ANCHOR in the stage code region.
+    //
+    // The assembler patches the anchor within the FFS image (at the anchor
+    // offset within the FFS). But the stage binary has its own copy of the
+    // anchor in the `.fstart.anchor` section (at a fixed flash offset).
+    // On x86, these are at different flash offsets, so we must copy the
+    // patched anchor from the FFS to the stage's anchor location.
+    //
+    // This mechanism is reusable: any x86 platform with the boot block
+    // architecture needs this anchor patching step.
+    //
+    // Find the anchor in the FFS by scanning for the FSTART01 magic.
+    let anchor_magic = b"FSTART01";
+    if let Some(ffs_anchor_off) = ffs_data
+        .windows(anchor_magic.len())
+        .position(|w| w == anchor_magic)
+    {
+        // Find the anchor in the stage binary (pflash offset 0..FFS_FLASH_OFFSET)
+        if let Some(stage_anchor_off) = pflash[..FFS_FLASH_OFFSET]
+            .windows(anchor_magic.len())
+            .position(|w| w == anchor_magic)
+        {
+            // The anchor block is 300 bytes (AnchorBlock size).
+            // Copy from FFS anchor to stage anchor.
+            let anchor_size = 300;
+            let ffs_src = ffs_anchor_off;
+            let stage_dst = stage_anchor_off;
+            if ffs_src + anchor_size <= ffs_data.len()
+                && stage_dst + anchor_size <= FFS_FLASH_OFFSET
+            {
+                pflash[stage_dst..stage_dst + anchor_size]
+                    .copy_from_slice(&ffs_data[ffs_src..ffs_src + anchor_size]);
+                eprintln!(
+                    "[fstart] x86 pflash: patched anchor at flash offset {:#x} (from FFS offset {:#x})",
+                    stage_dst, ffs_src,
+                );
+            }
+        }
+    }
+
+    let pflash_path = ffs_image.with_extension("pflash");
+    std::fs::write(&pflash_path, &pflash)
+        .map_err(|e| format!("failed to write pflash image: {e}"))?;
+
+    eprintln!(
+        "[fstart] x86 pflash: {} ({} bytes, FFS {} bytes at offset {:#x})",
+        pflash_path.display(),
+        flash_size,
+        ffs_data.len(),
+        FFS_FLASH_OFFSET,
     );
 
     Ok(pflash_path)

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -173,15 +173,21 @@ pub fn run(
                 // QEMU Q35 maps pflash0 at the top of the 32-bit address space
                 // with the reset vector at 0xFFFFFFF0.
                 let pflash_size = 8 * 1024 * 1024; // 8 MiB flash
-                                                   // x86: the raw stage .bin has boot code at the correct
-                                                   // offsets within 8MB (reset vector at end, code at start).
-                                                   // The FFS image has the stage segments + kernel payload.
-                                                   // We overlay the FFS onto the raw binary so both the boot
-                                                   // code (end of flash) and FFS data (start of flash) are
-                                                   // present.
-                                                   //
-                                                   // binary = target/ffs/qemu-q35.ffs
-                                                   // stage_bin = target/x86_64-unknown-none/{debug,release}/fstart-stage.bin
+                let is_uefi = board_name.contains("uefi");
+
+                // x86: the raw stage .bin has boot code at the correct
+                // offsets within 8MB (reset vector at end, code at start).
+                // The FFS image has the stage segments + kernel payload.
+                // We overlay the FFS onto the raw binary so both the boot
+                // code (end of flash) and FFS data (start of flash) are
+                // present.
+                //
+                // For multi-stage boards (e.g., qemu-q35-uefi), the
+                // bootblock .bin provides the reset vector; FFS contains
+                // the main stage + payload data.
+                //
+                // binary = target/ffs/<board>.ffs
+                // stage_bin = target/x86_64-unknown-none/{debug,release}/fstart-{stage}.bin
                 let workspace = binary.parent().unwrap().parent().unwrap();
                 let profile = if binary.to_str().unwrap_or("").contains("release")
                     || std::env::args().any(|a| a == "--release")
@@ -190,10 +196,18 @@ pub fn run(
                 } else {
                     "debug"
                 };
+
+                // For multi-stage, the bootblock binary has the reset vector.
+                // For monolithic, it's fstart-stage.bin.
+                let stage_bin_name = if is_uefi {
+                    "fstart-bootblock.bin"
+                } else {
+                    "fstart-stage.bin"
+                };
                 let stage_bin = workspace
                     .join("x86_64-unknown-none")
                     .join(profile)
-                    .join("fstart-stage.bin");
+                    .join(stage_bin_name);
                 let pflash_path = if stage_bin.exists() {
                     create_x86_pflash(binary, &stage_bin, pflash_size)?
                 } else {
@@ -213,6 +227,7 @@ pub fn run(
                 // stage code at 0xFF800000 hangs. TCG software-emulates
                 // everything so pflash works fine there.
                 let use_kvm = std::fs::File::open("/dev/kvm").is_ok();
+                let default_mem = if is_uefi { "4G" } else { "1G" };
                 let mut args = vec![
                     "-machine".to_string(),
                     "q35".to_string(),
@@ -221,7 +236,7 @@ pub fn run(
                     "-cpu".to_string(),
                     if use_kvm { "host" } else { "max" }.to_string(),
                     "-m".to_string(),
-                    "1G".to_string(),
+                    default_mem.to_string(),
                     "-nographic".to_string(),
                     if use_kvm { "-bios" } else { "-drive" }.to_string(),
                     if use_kvm {
@@ -235,18 +250,34 @@ pub fn run(
                     "-chardev".to_string(),
                     "file,id=debugout,path=/dev/stderr".to_string(),
                     // Bochs VBE display — non-VGA PCI device (class 0x0380)
-                    // with MMIO registers in BAR2. Only added when the
-                    // board RON declares a BochsDisplay child device.
-                    // Q35 has a built-in VGA; use -vga none to avoid
-                    // conflicts, then add bochs-display explicitly.
-                    //
-                    // TODO: conditionally add based on board RON devices.
-                    // For now, always add it.
+                    // with MMIO registers in BAR2. Q35 has a built-in VGA;
+                    // use -vga none to avoid conflicts.
                     "-vga".to_string(),
                     "none".to_string(),
                     "-device".to_string(),
                     "bochs-display".to_string(),
                 ];
+
+                // UEFI boards: attach AHCI disk via ICH9-AHCI.
+                // QEMU Q35 already provides an ICH9-AHCI controller on
+                // the southbridge, but adding an explicit one ensures
+                // SATA device detection in CrabEFI's PCI scan.
+                if is_uefi && disk.is_none() {
+                    // Check for a default disk image in the board directory
+                    let board_dir = find_board_dir_by_name(binary, board_name)?;
+                    let default_disk = board_dir.join("disk.img");
+                    if default_disk.exists() {
+                        let disk_str = default_disk.display().to_string();
+                        args.extend([
+                            "-drive".to_string(),
+                            format!("file={disk_str},id=hd0,if=none,format=raw"),
+                            "-device".to_string(),
+                            "ide-hd,drive=hd0".to_string(),
+                        ]);
+                        eprintln!("[fstart] disk: {disk_str} (AHCI/SATA, default)");
+                    }
+                }
+
                 (find_qemu("qemu-system-x86_64"), args)
             }
         }
@@ -257,20 +288,37 @@ pub fn run(
         args.extend(["-m".to_string(), mem.to_string()]);
     }
 
-    // Attach disk image as NVMe (CrabEFI has an NVMe driver)
+    // Attach disk image.
+    // x86 Q35 UEFI: AHCI (ICH9-SATA) via ide-hd on the built-in controller.
+    // AArch64/RISC-V: NVMe (CrabEFI has an NVMe driver).
     if let Some(disk_path) = disk {
         let fmt = if disk_path.ends_with(".qcow2") {
             "qcow2"
         } else {
             "raw"
         };
-        args.extend([
-            "-drive".to_string(),
-            format!("file={disk_path},id=hd0,if=none,format={fmt}"),
-            "-device".to_string(),
-            "nvme,serial=fstartdisk0,drive=hd0".to_string(),
-        ]);
-        eprintln!("[fstart] disk: {disk_path} (NVMe, format={fmt})");
+        if platform == Platform::X86_64 {
+            let is_iso = disk_path.ends_with(".iso");
+            let device_type = if is_iso { "ide-cd" } else { "ide-hd" };
+            args.extend([
+                "-drive".to_string(),
+                format!(
+                    "file={disk_path},id=hd0,if=none,format={fmt},readonly={}",
+                    if is_iso { "on" } else { "off" }
+                ),
+                "-device".to_string(),
+                format!("{device_type},drive=hd0"),
+            ]);
+            eprintln!("[fstart] disk: {disk_path} (AHCI/{device_type}, format={fmt})");
+        } else {
+            args.extend([
+                "-drive".to_string(),
+                format!("file={disk_path},id=hd0,if=none,format={fmt}"),
+                "-device".to_string(),
+                "nvme,serial=fstartdisk0,drive=hd0".to_string(),
+            ]);
+            eprintln!("[fstart] disk: {disk_path} (NVMe, format={fmt})");
+        }
     }
 
     eprintln!("[fstart] launching: {qemu_bin} {}", args.join(" "));
@@ -434,6 +482,35 @@ fn find_board_dir(binary: &Path) -> Result<PathBuf, String> {
     }
 
     Err("could not find SBSA board directory".to_string())
+}
+
+/// Find a board directory by board name, starting from a binary's location.
+fn find_board_dir_by_name(binary: &Path, board_name: &str) -> Result<PathBuf, String> {
+    let mut dir = binary
+        .parent()
+        .ok_or_else(|| "no parent directory for binary".to_string())?
+        .to_path_buf();
+
+    loop {
+        let cargo_toml = dir.join("Cargo.toml");
+        if cargo_toml.exists() {
+            let contents =
+                std::fs::read_to_string(&cargo_toml).map_err(|e| format!("read error: {e}"))?;
+            if contents.contains("[workspace]") {
+                let board_dir = dir.join("boards").join(board_name);
+                if board_dir.is_dir() {
+                    return Ok(board_dir);
+                }
+                return Err(format!(
+                    "board directory not found: {}",
+                    board_dir.display()
+                ));
+            }
+        }
+        if !dir.pop() {
+            return Err("could not find workspace root from binary path".to_string());
+        }
+    }
 }
 
 /// Create a QEMU pflash image by padding a firmware binary to the exact

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -234,6 +234,18 @@ pub fn run(
                     "isa-debugcon,iobase=0x402,chardev=debugout".to_string(),
                     "-chardev".to_string(),
                     "file,id=debugout,path=/dev/stderr".to_string(),
+                    // Bochs VBE display — non-VGA PCI device (class 0x0380)
+                    // with MMIO registers in BAR2. Only added when the
+                    // board RON declares a BochsDisplay child device.
+                    // Q35 has a built-in VGA; use -vga none to avoid
+                    // conflicts, then add bochs-display explicitly.
+                    //
+                    // TODO: conditionally add based on board RON devices.
+                    // For now, always add it.
+                    "-vga".to_string(),
+                    "none".to_string(),
+                    "-device".to_string(),
+                    "bochs-display".to_string(),
                 ];
                 (find_qemu("qemu-system-x86_64"), args)
             }


### PR DESCRIPTION
Introduces end-to-end x86_64 firmware support targeting the QEMU Q35 machine, including a new board definition, platform crate, port I/O library, and QEMU fw_cfg driver.

## New crates

- **`fstart-pio`**: Inline-asm wrappers for x86 `in`/`out` instructions (`inb`, `outb`, `inw`, `outw`, `inl`, `outl`, `io_delay`) used by legacy x86 devices
- **`fstart-platform-x86_64`**: Full entry sequence (reset vector → 16-bit real mode → 32-bit protected mode → 64-bit long mode), GDT setup, identity-mapped 2 MiB page tables over 4 GiB, IDT with exception handler, and Linux 64-bit boot protocol handoff via zero page construction
- **`fstart-driver-qemu-fw-cfg`**: QEMU fw_cfg driver implementing `AcpiTableProvider` (table-loader protocol) and `MemoryDetector` (e820 from `etc/e820`)

## New board

- **`boards/qemu-q35/board.ron`**: QEMU Q35 (ICH9) board config with 8 MiB pflash at 0xFF800000, NS16550 COM1 at port 0x3F8 (PIO mode), fw_cfg at 0x510/0x511, ECAM PCI at 0xB0000000, and a monolithic stage with `ConsoleInit → MemoryDetect → MemoryInit → AcpiLoad → BootMedia → SigVerify → DriverInit → PayloadLoad`

## New capabilities

- **`AcpiLoad { device }`**: Calls a device's `AcpiTableProvider::load_acpi_tables()` to load QEMU-supplied ACPI tables; stores the RSDP address for the boot protocol
- **`MemoryDetect { device }`**: Calls a device's `MemoryDetector::detect_memory()` to read the e820 map at runtime; stores entries and total RAM for the x86 zero page

## Key changes

- **`fstart-driver-ns16550`**: Added `AccessMode` enum (`Mmio`/`Pio`) and optional `pio` feature; `read_reg`/`write_reg` dispatch on access mode; PIO path uses `fstart-pio` `inb`/`outb`
- **`fstart-codegen` (linker)**: x86_64-aware linker script generation — `LOW` region for page tables/IDT at fixed low addresses, `.lrodata`/`.ldata`/`.lbss` sections for large code model, `.x86boot` + `.reset` sections for boot block, ROM-to-RAM copy for FFS
- **`fstart-codegen` (stage gen)**: Platform extern routing for `fstart_platform_x86_64`, x86_64 boot protocol invocation in `PayloadLoad`, pre-phase state variables (`_acpi_rsdp_addr`, `_e820_entries`, `_e820_count`)
- **`xtask/build_board`**: x86_64 RUSTFLAGS (`-Crelocation-model=static -Ccode-model=large`, curve25519-dalek serial backend workaround), `ns16550-pio`/`x86-boot` features, flat binary output enabled for x86_64
- **`xtask/qemu`**: x86 QEMU runner using TCG/KVM autodetection, pflash overlay (`create_x86_pflash`) that merges FFS at offset 1 MiB into the stage binary while preserving the boot block at the end, anchor patching between FFS and stage regions
- **`fstart-services`**: New `acpi_provider` and `memory_detect` modules with `AcpiTableProvider`, `MemoryDetector`, `E820Entry`, and `E820Kind` types
- **`fstart-mmio`**: Added `mfence` I/O barrier for x86_64
- **`fstart-arch`**: Added `x86_64` feature with `halt()`, `udelay()`, `mdelay()`
- **`fstart-ffs`**: Increased segment vector capacity from 4 to 8 to accommodate x86 `.x86boot`/`.reset` extra sections
- **`fstart-types`**: Added `Platform::X86_64` with target triple `x86_64-unknown-none`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added x86_64 architecture support with QEMU Q35 machine board configuration
  * Introduced QEMU fw_cfg device driver enabling runtime memory detection and ACPI table loading
  * Implemented x86_64 Linux kernel boot protocol support
  * Added PCI address window tracking for improved resource allocation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->