### PR TITLE
Refactor xtask build planning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,30 +69,45 @@ jobs:
           cargo xtask build --board qemu-aarch64 --release
 
   # -----------------------------------------------------------------------
-  # Build every board image (cross-compile via -Z build-std=core)
+  # Discover every board directory so future boards are automatically covered.
+  # -----------------------------------------------------------------------
+  discover-boards:
+    runs-on: ubuntu-latest
+    outputs:
+      boards: ${{ steps.boards.outputs.boards }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Discover boards
+        id: boards
+        run: |
+          boards=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          names = sorted(path.parent.name for path in Path("boards").glob("*/board.ron"))
+          if not names:
+              raise SystemExit("no boards/*/board.ron files found")
+          print(json.dumps(names))
+          PY
+          )
+          echo "boards=${boards}" >> "$GITHUB_OUTPUT"
+          echo "Discovered boards: ${boards}"
+
+  # -----------------------------------------------------------------------
+  # Assemble every board image (cross-compile + FFS/full-flash packaging).
   # -----------------------------------------------------------------------
   build-boards:
+    needs: [discover-boards]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        board:
-          - qemu-riscv64
-          - qemu-aarch64
-          - qemu-armv7
-          - bananapi-m1
-          - qemu-riscv64-multi
-          - qemu-aarch64-multi
-          - qemu-aarch64-uefi
-          - qemu-sbsa
-          - orangepi-pc2
-          - sifive-unmatched
-          - sifive-unmatched-hw
-          - licheerv-dock
-          - orangepi-r1
+        board: ${{ fromJson(needs.discover-boards.outputs.boards) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
+        with:
+          submodules: true
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -109,8 +124,25 @@ jobs:
         with:
           shared-key: release-${{ matrix.board }}
 
-      - name: Build ${{ matrix.board }}
-        run: cargo xtask build --board ${{ matrix.board }} --release
+      - name: Assemble ${{ matrix.board }}
+        env:
+          BOARD: ${{ matrix.board }}
+        run: |
+          mkdir -p target/ci
+          printf 'fstart CI placeholder payload\n' > target/ci/payload.bin
+
+          if grep -q 'kind: FitImage' "boards/$BOARD/board.ron"; then
+            # FIT images are structured payloads; if a board uses FIT, test the
+            # board-declared FIT path rather than replacing it with a raw blob.
+            cargo xtask assemble --board "$BOARD" --release
+          else
+            # LinuxBoot/raw payload boards only require opaque bytes for assembly.
+            # Supplying placeholders keeps this job focused on firmware assembly
+            # and ensures newly added boards are covered without adding CI payloads.
+            cargo xtask assemble --board "$BOARD" --release \
+              --kernel target/ci/payload.bin \
+              --firmware target/ci/payload.bin
+          fi
 
   # -----------------------------------------------------------------------
   # Build external payloads: OpenSBI, TF-A BL31, Linux kernels
@@ -162,7 +194,6 @@ jobs:
             expect: "console ready"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -245,7 +276,6 @@ jobs:
             memory: 1G
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "intel-microcode"]
+	path = intel-microcode
+	url = https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git

--- a/boards/foxconn-d41s-uefi/board.ron
+++ b/boards/foxconn-d41s-uefi/board.ron
@@ -351,8 +351,8 @@
         // Intel Atom Pineview / model_106cx microcode. Match coreboot's
         // cpu/intel/model_106cx selection: intel-ucode/06-1c-*.
         files: [
-            "../../../intel-microcode/intel-ucode/06-1c-02",
-            "../../../intel-microcode/intel-ucode/06-1c-0a",
+            "../../intel-microcode/intel-ucode/06-1c-02",
+            "../../intel-microcode/intel-ucode/06-1c-0a",
         ],
         early: true,
         mp: true,

--- a/boards/foxconn-d41s/board.ron
+++ b/boards/foxconn-d41s/board.ron
@@ -349,8 +349,8 @@
         // Intel Atom Pineview / model_106cx microcode. Match coreboot's
         // cpu/intel/model_106cx selection: intel-ucode/06-1c-*.
         files: [
-            "../../../intel-microcode/intel-ucode/06-1c-02",
-            "../../../intel-microcode/intel-ucode/06-1c-0a",
+            "../../intel-microcode/intel-ucode/06-1c-02",
+            "../../intel-microcode/intel-ucode/06-1c-0a",
         ],
         early: true,
         mp: true,

--- a/boards/lenovo-x61/board.ron
+++ b/boards/lenovo-x61/board.ron
@@ -333,13 +333,13 @@
 
     microcode: Some(Intel((
         files: [
-            "../../../intel-microcode/intel-ucode/06-0f-02",
-            "../../../intel-microcode/intel-ucode/06-0f-06",
-            "../../../intel-microcode/intel-ucode/06-0f-07",
-            "../../../intel-microcode/intel-ucode/06-0f-0a",
-            "../../../intel-microcode/intel-ucode/06-0f-0b",
-            "../../../intel-microcode/intel-ucode/06-0f-0d",
-            "../../../intel-microcode/intel-ucode/06-16-01",
+            "../../intel-microcode/intel-ucode/06-0f-02",
+            "../../intel-microcode/intel-ucode/06-0f-06",
+            "../../intel-microcode/intel-ucode/06-0f-07",
+            "../../intel-microcode/intel-ucode/06-0f-0a",
+            "../../intel-microcode/intel-ucode/06-0f-0b",
+            "../../intel-microcode/intel-ucode/06-0f-0d",
+            "../../intel-microcode/intel-ucode/06-16-01",
         ],
         early: true,
         mp: true,

--- a/crates/fstart-device-registry/src/lib.rs
+++ b/crates/fstart-device-registry/src/lib.rs
@@ -771,6 +771,11 @@ impl DriverInstance {
         matches!(self, Self::Structural(_))
     }
 
+    /// Returns `true` if this driver provides the runtime PCI root-bus service.
+    pub fn provides_pci_root(&self) -> bool {
+        self.meta().services.contains(&"PciRootBus")
+    }
+
     /// Return the SoC boot-source register values that select this device.
     ///
     /// Used by `plan_gen` and `board_gen` to emit match arms for runtime

--- a/xtask/src/assemble.rs
+++ b/xtask/src/assemble.rs
@@ -350,7 +350,7 @@ fn assemble_impl(
             );
         }
 
-        crate::build_board::patch_allwinner_egon_ffs(&mut image_bytes, bootblock_size)?;
+        crate::image::egon::patch_ffs(&mut image_bytes, bootblock_size)?;
     }
 
     // Write the FFS image

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -6,9 +6,7 @@
 //! 4. Return the path(s) to the built binary(ies)
 
 use fstart_codegen::ron_loader;
-use fstart_types::{
-    effective_stage_load_addr, Capability, Platform, SecurityConfig, SocImageFormat, StageLayout,
-};
+use fstart_types::{Capability, SocImageFormat, StageLayout};
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -58,204 +56,48 @@ pub fn build(board_name: &str, release: bool) -> Result<BuildResult, String> {
     }
 
     eprintln!("[fstart] loading board config: {}", board_ron.display());
-    let config = ron_loader::load_board_config(&board_ron)?;
+    let parsed = ron_loader::load_parsed_board(&board_ron)?;
+    let config = &parsed.config;
 
     eprintln!("[fstart] board: {}", config.name);
     eprintln!("[fstart] platform: {}", config.platform);
     eprintln!("[fstart] mode: {:?}", config.mode);
 
-    let smm_artifacts = build_smm_artifacts(&workspace_root, board_name, release, &config)?;
+    let smm_artifacts = build_smm_artifacts(&workspace_root, board_name, release, config)?;
+    let plan = crate::build_plan::plan(&parsed);
 
-    // Determine target triple from the Platform enum.
-    let target = config.platform.target_triple();
+    eprintln!("[fstart] target: {}", plan.target.triple);
 
-    // Base features: platform + all driver features (every stage constructs
-    // all devices, so driver features are always needed globally).
-    //
-    // Structural (driverless) nodes use the sentinel driver name
-    // `_structural` and must be skipped here — there is no cargo
-    // feature by that name. Similarly, ACPI-only devices (ahci,
-    // xhci, pcie-root) contribute only build-time ACPI table entries
-    // and have no runtime driver crate / no corresponding feature in
-    // fstart-stage's Cargo.toml.
-    const ACPI_ONLY_DRIVERS: &[&str] = &["ahci", "xhci", "pcie-root"];
-    let mut base_features = Vec::new();
-    base_features.push(config.platform.as_str().to_string());
-    for device in &config.devices {
-        let drv = device.driver.as_str();
-        if drv == "_structural" || ACPI_ONLY_DRIVERS.contains(&drv) {
-            continue;
+    let mut result = Vec::new();
+    for stage in &plan.stages {
+        if stage.stage_name.is_some() {
+            eprintln!("[fstart] building stage: {}", stage.display_name);
         }
-        base_features.push(drv.to_string());
+        let features = stage.features_arg();
+        eprintln!("[fstart] features: {features}");
+
+        let (elf_path, run_path) = build_one_stage(
+            &workspace_root,
+            &board_ron,
+            stage.stage_name.as_deref(),
+            plan.target.triple,
+            &features,
+            release,
+            stage.needs_flat_binary,
+            stage.build_std,
+            stage.soc_format,
+            smm_artifacts.as_ref(),
+        )?;
+        result.push(StageBinary {
+            name: stage.display_name.clone(),
+            path: elf_path,
+            run_path,
+            load_addr: stage.load_addr,
+        });
     }
 
-    // Multi-stage boards need the handoff feature for inter-stage data passing.
-    let is_multi_stage = matches!(&config.stages, StageLayout::MultiStage(_));
-    if is_multi_stage {
-        base_features.push("handoff".to_string());
-    }
-
-    // Check if the board uses a FIT image with runtime parsing (board-level feature)
-    let uses_fit_runtime = config.payload.as_ref().is_some_and(|p| {
-        p.kind == fstart_types::PayloadKind::FitImage
-            && p.fit_parse.unwrap_or(fstart_types::FitParseMode::Buildtime)
-                == fstart_types::FitParseMode::Runtime
-    });
-    if uses_fit_runtime {
-        base_features.push("fit".to_string());
-    }
-
-    // Allwinner sunxi SoCs use the eGON boot format and need
-    // fstart-soc-sunxi for the eGON header, boot media detection,
-    // and FEL support.  This is driven by `soc_image_format`, not by
-    // the platform — sunxi boards exist on both ARMv7 and AArch64.
-    if config.soc_image_format == SocImageFormat::AllwinnerEgon {
-        base_features.push("sunxi".to_string());
-    }
-
-    // SBSA boards use a special entry point that copies firmware from
-    // flash to DRAM before executing (the flash→DRAM gap exceeds the
-    // AArch64 ADRP relocation range).
-    if config.name.as_str().contains("sbsa") {
-        base_features.push("sbsa".to_string());
-    }
-
-    eprintln!("[fstart] target: {target}");
-
-    // All bare-metal platforms need flat binaries: AArch64 uses -bios
-    // which expects raw binary, RISC-V uses pflash, and ARMv7 Allwinner
-    // boot ROM loads raw binary from SD/SPI/eMMC.
-    let needs_flat_binary = matches!(
-        config.platform,
-        Platform::Aarch64 | Platform::Riscv64 | Platform::Armv7 | Platform::X86_64
-    );
-
-    let soc_format = config.soc_image_format;
-
-    match &config.stages {
-        StageLayout::Monolithic(mono) => {
-            // Single build — compute features from this stage's capabilities.
-            let mut features = base_features.clone();
-            let cap_features = capability_features(&mono.capabilities, &config.security, &config);
-            features.extend(cap_features);
-            if mono.page_size == fstart_types::stage::PageSize::Size1GiB {
-                features.push("x86-1g-pages".to_string());
-            }
-            if config.platform == Platform::X86_64 {
-                if mono.page_table_addr.is_some() {
-                    features.push("x86-writable-page-tables".to_string());
-                } else {
-                    features.push("x86-static-page-tables".to_string());
-                }
-            }
-            let features_str = features.join(",");
-            let needs_alloc = stage_uses_fdt(&mono.capabilities)
-                || stage_uses_acpi(&mono.capabilities)
-                || stage_uses_crabefi(&config)
-                || mono.heap_size.is_some();
-            let build_std = if needs_alloc { "core,alloc" } else { "core" };
-
-            eprintln!("[fstart] features: {features_str}");
-
-            let (elf_path, run_path) = build_one_stage(
-                &workspace_root,
-                &board_ron,
-                None,
-                target,
-                &features_str,
-                release,
-                needs_flat_binary,
-                build_std,
-                soc_format,
-                smm_artifacts.as_ref(),
-            )?;
-            Ok(BuildResult {
-                stages: vec![StageBinary {
-                    name: "stage".to_string(),
-                    path: elf_path,
-                    run_path,
-                    load_addr: mono.load_addr,
-                }],
-            })
-        }
-        StageLayout::MultiStage(stages) => {
-            let mut result = Vec::new();
-            for (i, stage) in stages.iter().enumerate() {
-                let stage_name = stage.name.to_string();
-                eprintln!("[fstart] building stage: {stage_name}");
-
-                // Compute per-stage features: base (platform + drivers) +
-                // capability-driven features (FFS, crypto, FDT) for THIS
-                // stage only. The bootblock doesn't need FFS/crypto/FDT
-                // even if the main stage does.
-                let mut features = base_features.clone();
-                let cap_features =
-                    capability_features(&stage.capabilities, &config.security, &config);
-                features.extend(cap_features);
-                if stage.page_size == fstart_types::stage::PageSize::Size1GiB {
-                    features.push("x86-1g-pages".to_string());
-                }
-                if config.platform == Platform::X86_64 {
-                    if stage.page_table_addr.is_some() {
-                        features.push("x86-writable-page-tables".to_string());
-                    } else if i == 0 {
-                        features.push("x86-static-page-tables".to_string());
-                    }
-                }
-                let features_str = features.join(",");
-
-                let stage_has_crabefi = stage
-                    .capabilities
-                    .iter()
-                    .any(|c| matches!(c, Capability::PayloadLoad))
-                    && stage_uses_crabefi(&config);
-                // PCI and Q35 driver features pull in fstart-alloc, which
-                // needs alloc in build-std even for stages that don't
-                // directly use PCI. Driver features are global.
-                let has_pci_driver = config
-                    .devices
-                    .iter()
-                    .any(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
-                let needs_alloc = stage_uses_fdt(&stage.capabilities)
-                    || stage_uses_acpi(&stage.capabilities)
-                    || stage_has_crabefi
-                    || stage.heap_size.is_some()
-                    || has_pci_driver;
-                let build_std = if needs_alloc { "core,alloc" } else { "core" };
-
-                eprintln!("[fstart] features: {features_str}");
-
-                // Allwinner eGON only applies to the first stage (the one
-                // the BROM loads).  Later stages are loaded by fstart.
-                let stage_format = if i == 0 {
-                    soc_format
-                } else {
-                    SocImageFormat::None
-                };
-                let (elf_path, run_path) = build_one_stage(
-                    &workspace_root,
-                    &board_ron,
-                    Some(&stage_name),
-                    target,
-                    &features_str,
-                    release,
-                    needs_flat_binary,
-                    build_std,
-                    stage_format,
-                    smm_artifacts.as_ref(),
-                )?;
-                result.push(StageBinary {
-                    name: stage_name,
-                    path: elf_path,
-                    run_path,
-                    load_addr: effective_stage_load_addr(&config, i, stage),
-                });
-            }
-            Ok(BuildResult { stages: result })
-        }
-    }
+    Ok(BuildResult { stages: result })
 }
-
 /// Build the standalone SMM image artifacts requested by the board.
 fn build_smm_artifacts(
     workspace_root: &std::path::Path,
@@ -386,37 +228,7 @@ fn build_one_stage(
         cmd.arg("--release");
     }
 
-    // Disable UB precondition checks on volatile ops (nightly core library
-    // adds alignment/null checks on read_volatile/write_volatile that are
-    // incompatible with MMIO register access in firmware debug builds).
-    //
-    // Note: +strict-align is NOT set here — the ARM target specs
-    // (armv7a-none-eabi, aarch64-unknown-none) already include it by
-    // default. Passing it via -Ctarget-feature triggers an "unknown and
-    // unstable feature" warning from rustc even though LLVM accepts it.
-    let mut rustflags = if target.starts_with("x86_64") {
-        // x86_64 firmware: static relocation, large code model.
-        // Large model is needed because ROM at the top of 4 GiB and RAM/BSS
-        // can be ~4 GiB apart, exceeding small/medium/kernel model ±2 GiB
-        // limits.
-        //
-        // Force curve25519-dalek to use the scalar ("serial") backend.
-        // This must be in RUSTFLAGS (not Cargo.toml) because:
-        // 1. Cargo features can't set --cfg on transitive dependencies
-        // 2. .cargo/config.toml would affect host builds too
-        // 3. This only applies to x86_64-unknown-none (firmware target)
-        //
-        // The auto-detected "simd" backend (AVX2) causes LLVM crashes
-        // when compiling for x86_64-unknown-none: adding +avx2 globally
-        // breaks compiler_builtins (f16/f128 getCopyFromParts mismatch),
-        // and without it LLVM can't lower AVX2 intrinsics. The scalar
-        // backend is correct and sufficient for firmware signature verify.
-        "-Zub-checks=no -Crelocation-model=static -Ccode-model=large \
-         --cfg curve25519_dalek_backend=\"serial\""
-            .to_string()
-    } else {
-        "-Zub-checks=no".to_string()
-    };
+    let mut rustflags = crate::toolchain::rustflags_for_triple(target);
     // FSTART_EXTRA_RUSTFLAGS (if set) is appended — CI uses this for
     // -Dwarnings to catch generated-code regressions.
     if let Ok(extra) = std::env::var("FSTART_EXTRA_RUSTFLAGS") {
@@ -504,7 +316,7 @@ fn build_one_stage(
         // Allwinner eGON: compute the actual binary size, pad to
         // 512-byte alignment, and patch both length and checksum.
         if let SocImageFormat::AllwinnerEgon = soc_format {
-            patch_allwinner_egon(&bin_path)?;
+            crate::image::egon::patch_file(&bin_path)?;
         }
 
         bin_path
@@ -519,356 +331,6 @@ fn build_one_stage(
 /// Public wrapper for workspace root (used by other xtask modules).
 pub fn workspace_root_pub() -> Result<PathBuf, String> {
     workspace_root()
-}
-
-/// Patch an Allwinner eGON binary: compute size, pad, write length + checksum.
-///
-/// Like U-Boot's `mksunxiboot` / `sunxi_egon.c`, this computes the
-/// image size from the actual binary content (rounded up to 8K block
-/// alignment, matching U-Boot's `PAD_SIZE = 8192`), then:
-/// 1. Verifies the eGON magic and checksum sentinel
-/// 2. Pads the binary to the 8K-aligned size
-/// 3. Writes the length at offset 0x10
-/// 4. Computes the word-add checksum and writes it at offset 0x0C
-/// 5. Self-verifies using U-Boot's `egon_verify_header` algorithm
-fn patch_allwinner_egon(bin_path: &std::path::Path) -> Result<(), String> {
-    let mut data = std::fs::read(bin_path).map_err(|e| format!("failed to read binary: {e}"))?;
-
-    if data.len() < 96 {
-        return Err("binary too small for Allwinner eGON header (< 96 bytes)".to_string());
-    }
-    if &data[4..12] != b"eGON.BT0" {
-        return Err("eGON.BT0 magic not found at offset 0x04".to_string());
-    }
-
-    let stamp = u32::from_le_bytes([data[0x0C], data[0x0D], data[0x0E], data[0x0F]]);
-    if stamp != 0x5F0A6C39 {
-        return Err(format!(
-            "eGON checksum sentinel not found (got {stamp:#010x}, expected 0x5F0A6C39)"
-        ));
-    }
-
-    // Compute the image size: round up to 8K (0x2000) block alignment.
-    // U-Boot's sunxi_egon.c uses PAD_SIZE = 8192; the BROM reads this
-    // many bytes from the SD card.  512-byte alignment is the minimum
-    // the hardware accepts, but U-Boot always pads to 8K blocks.
-    let raw_size = data.len();
-    let image_size = ((raw_size + 0x1FFF) & !0x1FFF) as u32;
-
-    // Pad to the aligned size.
-    data.resize(image_size as usize, 0);
-
-    // Write the length field at offset 0x10.
-    data[0x10..0x14].copy_from_slice(&image_size.to_le_bytes());
-
-    // Write the SPL signature at offset 0x14 — "SPL\x02".
-    // U-Boot's sunxi SPL includes this so that sunxi-fel and other tools
-    // recognise the binary as a version-2 SPL header.
-    data[0x14..0x18].copy_from_slice(b"SPL\x02");
-
-    // Compute checksum per U-Boot's gen_check_sum() / egon_set_header():
-    //   1. Stamp value (0x5F0A6C39) is already in the checksum field
-    //   2. Sum all u32 words (stamp participates in the sum)
-    //   3. Write the sum as the checksum
-    let mut checksum: u32 = 0;
-    for chunk in data.chunks_exact(4) {
-        let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        checksum = checksum.wrapping_add(word);
-    }
-
-    // Write the checksum at offset 0x0C.
-    data[0x0C..0x10].copy_from_slice(&checksum.to_le_bytes());
-
-    // Self-verify using U-Boot's egon_verify_header() algorithm:
-    //   1. Save the checksum from the header
-    //   2. Put the stamp value back into the checksum field
-    //   3. Sum all words up to length/4
-    //   4. The sum must equal the saved checksum
-    allwinner_egon_verify(&data)?;
-
-    std::fs::write(bin_path, &data).map_err(|e| format!("failed to write patched binary: {e}"))?;
-
-    eprintln!(
-        "[fstart] Allwinner eGON patched: raw_size={raw_size:#x}, \
-         image_size={image_size:#x}, checksum={checksum:#010x}"
-    );
-    Ok(())
-}
-
-/// Verify an Allwinner eGON binary using U-Boot's verification algorithm.
-///
-/// Mirrors `egon_verify_header()` from `tools/sunxi_egon.c`:
-///   1. Check branch instruction: ARM (`0xEA` at byte 3) or RISC-V JAL (`0x6F` at byte 0)
-///   2. Check "eGON.BT0" magic at offset 0x04
-///   3. Check length is 512-byte aligned and within buffer
-///   4. Save checksum, put stamp back, re-sum, compare
-pub(crate) fn allwinner_egon_verify(data: &[u8]) -> Result<(), String> {
-    if data.len() < 96 {
-        return Err("verify: binary too small".to_string());
-    }
-
-    // Branch instruction check:
-    // - ARM: byte 3 == 0xEA (ARM `b` opcode)
-    // - RISC-V: byte 0 == 0x6F (RISC-V JAL opcode, `j _start`)
-    let is_arm_branch = data[3] == 0xEA;
-    let is_riscv_jal = (data[0] & 0x7F) == 0x6F; // JAL opcode = 0x6F (bits [6:0])
-    if !is_arm_branch && !is_riscv_jal {
-        return Err(format!(
-            "verify: unrecognized branch instruction (bytes: {:#04x} {:#04x} {:#04x} {:#04x})",
-            data[0], data[1], data[2], data[3]
-        ));
-    }
-
-    // Magic check.
-    if &data[4..12] != b"eGON.BT0" {
-        return Err("verify: eGON.BT0 magic mismatch".to_string());
-    }
-
-    // Read length and checksum from header.
-    let length = u32::from_le_bytes([data[0x10], data[0x11], data[0x12], data[0x13]]);
-    let saved_checksum = u32::from_le_bytes([data[0x0C], data[0x0D], data[0x0E], data[0x0F]]);
-
-    if length == 0 || (length & 0x1FF) != 0 {
-        return Err(format!(
-            "verify: length {length:#x} is not a positive multiple of 512"
-        ));
-    }
-    if length as usize > data.len() {
-        return Err(format!(
-            "verify: length {length:#x} exceeds buffer size {:#x}",
-            data.len()
-        ));
-    }
-
-    // Re-compute: put stamp back in checksum field, sum length/4 words.
-    let num_words = length as usize / 4;
-    let mut verify_sum: u32 = 0;
-    for i in 0..num_words {
-        let off = i * 4;
-        let word = if i == 3 {
-            // Checksum field (offset 0x0C) — use stamp value, not stored checksum.
-            0x5F0A6C39_u32
-        } else {
-            u32::from_le_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]])
-        };
-        verify_sum = verify_sum.wrapping_add(word);
-    }
-
-    if verify_sum != saved_checksum {
-        return Err(format!(
-            "verify: checksum mismatch — stored {saved_checksum:#010x}, \
-             computed {verify_sum:#010x}"
-        ));
-    }
-
-    Ok(())
-}
-
-/// Patch the Allwinner eGON header at the start of an FFS image.
-///
-/// The FFS assembler reads stage ELFs directly, so the eGON header fields
-/// (length, SPL signature, checksum) are left at their unpatched defaults.
-/// This function patches them in-place using the bootblock size from the
-/// standalone build.
-///
-/// `bootblock_size` is the eGON image size (8K-aligned) from the patched
-/// standalone `.bin`. The BROM loads exactly this many bytes into SRAM;
-/// the rest of the FFS stays on SD card for later loading.
-pub(crate) fn patch_allwinner_egon_ffs(
-    ffs_image: &mut [u8],
-    bootblock_size: u32,
-) -> Result<(), String> {
-    if (ffs_image.len() as u32) < bootblock_size {
-        return Err(format!(
-            "FFS image ({:#x} bytes) is smaller than bootblock size ({:#x})",
-            ffs_image.len(),
-            bootblock_size
-        ));
-    }
-    if ffs_image.len() < 96 {
-        return Err("FFS image too small for eGON header".to_string());
-    }
-    if &ffs_image[4..12] != b"eGON.BT0" {
-        return Err("eGON.BT0 magic not found at start of FFS image".to_string());
-    }
-
-    // Write the bootblock length at offset 0x10.
-    ffs_image[0x10..0x14].copy_from_slice(&bootblock_size.to_le_bytes());
-
-    // Write the SPL signature at offset 0x14.
-    ffs_image[0x14..0x18].copy_from_slice(b"SPL\x02");
-
-    // Put the stamp value back in the checksum field before computing.
-    ffs_image[0x0C..0x10].copy_from_slice(&0x5F0A6C39_u32.to_le_bytes());
-
-    // Compute checksum over the bootblock area only (what the BROM loads).
-    let bb = &ffs_image[..bootblock_size as usize];
-    let mut checksum: u32 = 0;
-    for chunk in bb.chunks_exact(4) {
-        let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        checksum = checksum.wrapping_add(word);
-    }
-
-    // Write the checksum at offset 0x0C.
-    ffs_image[0x0C..0x10].copy_from_slice(&checksum.to_le_bytes());
-
-    // Self-verify.
-    allwinner_egon_verify(&ffs_image[..bootblock_size as usize])?;
-
-    eprintln!(
-        "[fstart] eGON patched in FFS: bootblock_size={bootblock_size:#x}, \
-         checksum={checksum:#010x}"
-    );
-    Ok(())
-}
-
-/// Compute the capability-driven feature flags for a single stage.
-///
-/// Examines the stage's capabilities to determine which FFS, crypto,
-/// and FDT features are needed. Driver features are NOT included here
-/// (they are always global since every stage constructs all devices).
-fn capability_features(
-    capabilities: &[Capability],
-    security: &SecurityConfig,
-    config: &fstart_types::BoardConfig,
-) -> Vec<String> {
-    let mut features = Vec::new();
-
-    let uses_ffs = capabilities.iter().any(|c| {
-        matches!(
-            c,
-            Capability::SigVerify | Capability::StageLoad { .. } | Capability::PayloadLoad
-        )
-    });
-
-    if uses_ffs {
-        features.push("ffs".to_string());
-        // LZ4 decompression support — always enabled when FFS is active
-        // so the runtime can handle compressed stage/payload segments.
-        features.push("lz4".to_string());
-        // Enable crypto features based on board security config
-        match security.signing_algorithm {
-            fstart_types::SignatureAlgorithm::Ed25519 => features.push("ed25519".to_string()),
-            fstart_types::SignatureAlgorithm::EcdsaP256 => {} // future: add ecdsa feature
-        }
-        for digest in &security.required_digests {
-            match digest {
-                fstart_types::DigestAlgorithm::Sha256 => {
-                    features.push("sha2-digest".to_string());
-                }
-                fstart_types::DigestAlgorithm::Sha3_256 => {
-                    features.push("sha3-digest".to_string());
-                }
-            }
-        }
-    }
-
-    if stage_uses_fdt(capabilities) {
-        features.push("fdt".to_string());
-    }
-
-    // PCI features are determined by the actual driver, not the platform.
-    // The Q35 host bridge handles CF8/CFC bootstrap internally.
-    if stage_uses_pci(capabilities) {
-        // Find the PCI root bus device to determine which driver is used.
-        let pci_driver = config
-            .devices
-            .iter()
-            .find(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
-        match pci_driver.map(|d| d.driver.as_str()) {
-            Some("q35-hostbridge") => features.push("q35-hostbridge".to_string()),
-            _ => features.push("pci-ecam".to_string()),
-        }
-    }
-
-    // CrabEFI is only needed by stages that actually have PayloadLoad.
-    // For multi-stage boards, the bootblock doesn't need CrabEFI.
-    let has_payload_load = capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::PayloadLoad));
-    if has_payload_load && stage_uses_crabefi(config) {
-        features.push("crabefi".to_string());
-    }
-
-    if stage_uses_acpi(capabilities) {
-        features.push("acpi".to_string());
-    }
-
-    if stage_uses_smbios(capabilities) {
-        features.push("smbios".to_string());
-    }
-
-    for cap in capabilities {
-        if let Capability::MpInit { cpu_model, .. } = cap {
-            features.push("mp".to_string());
-            if cpu_model.as_str().contains("pineview") || cpu_model.as_str().contains("106cx") {
-                features.push("pineview-cpu".to_string());
-            }
-            if cpu_model.as_str().contains("core2") || cpu_model.as_str().contains("6fx") {
-                features.push("core2-cpu".to_string());
-            }
-        }
-    }
-
-    // AcpiLoad needs the fw_cfg driver and x86-boot support
-    if capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::AcpiLoad { .. }))
-    {
-        features.push("acpi-load".to_string());
-    }
-
-    // MemoryDetect needs the memory-detect feature
-    if capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::MemoryDetect { .. }))
-    {
-        features.push("memory-detect".to_string());
-    }
-
-    // NS16550 PIO mode needs the pio feature propagated
-    if config.platform == Platform::X86_64 {
-        features.push("ns16550-pio".to_string());
-        features.push("x86-boot".to_string());
-    }
-
-    features
-}
-
-/// Check if a stage's capabilities require the FDT feature.
-fn stage_uses_fdt(capabilities: &[Capability]) -> bool {
-    capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::FdtPrepare))
-}
-
-/// Check if a stage's capabilities require the PCI ECAM feature.
-fn stage_uses_pci(capabilities: &[Capability]) -> bool {
-    capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::PciInit { .. }))
-}
-
-/// Check if a stage's capabilities require the ACPI feature.
-fn stage_uses_acpi(capabilities: &[Capability]) -> bool {
-    capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::AcpiPrepare | Capability::AcpiLoad { .. }))
-}
-
-/// Check if the board uses CrabEFI as a UEFI payload.
-fn stage_uses_crabefi(config: &fstart_types::BoardConfig) -> bool {
-    config
-        .payload
-        .as_ref()
-        .is_some_and(|p| p.kind == fstart_types::PayloadKind::UefiPayload)
-}
-
-/// Check if a stage's capabilities require the SMBIOS feature.
-fn stage_uses_smbios(capabilities: &[Capability]) -> bool {
-    capabilities
-        .iter()
-        .any(|c| matches!(c, Capability::SmBiosPrepare))
 }
 
 fn workspace_root() -> Result<PathBuf, String> {

--- a/xtask/src/build_plan.rs
+++ b/xtask/src/build_plan.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeSet;
 
 use fstart_codegen::ron_loader::ParsedBoard;
+use fstart_device_registry::DriverInstance;
 use fstart_types::stage::PageSize;
 use fstart_types::{
     effective_stage_load_addr, BoardConfig, Capability, Platform, SecurityConfig, SocImageFormat,
@@ -92,27 +93,28 @@ pub fn plan(parsed: &ParsedBoard) -> BuildPlan {
     let target = TargetSpec::for_platform(config.platform);
     let base_features = base_features(parsed, target);
     let is_multi_stage = matches!(&config.stages, StageLayout::MultiStage(_));
-    let has_pci_driver = config
-        .devices
-        .iter()
-        .any(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
+    let pci_root_backend = pci_root_backend(&parsed.driver_instances);
+    let has_pci_driver = pci_root_backend.is_some();
 
     let stages = match &config.stages {
         StageLayout::Monolithic(stage) => {
             vec![stage_plan(
                 config,
-                &stage.capabilities,
-                stage.heap_size,
-                stage.page_size,
-                stage.page_table_addr,
-                None,
-                "stage".to_string(),
-                0,
+                &StageContext {
+                    capabilities: &stage.capabilities,
+                    heap_size: stage.heap_size,
+                    page_size: stage.page_size,
+                    page_table_addr: stage.page_table_addr,
+                    stage_name: None,
+                    display_name: "stage".to_string(),
+                    stage_idx: 0,
+                    load_addr: stage.load_addr,
+                },
                 &base_features,
                 target.needs_flat_binary,
                 config.soc_image_format,
                 false,
-                stage.load_addr,
+                pci_root_backend,
             )]
         }
         StageLayout::MultiStage(stages) => stages
@@ -126,18 +128,21 @@ pub fn plan(parsed: &ParsedBoard) -> BuildPlan {
                 };
                 stage_plan(
                     config,
-                    &stage.capabilities,
-                    stage.heap_size,
-                    stage.page_size,
-                    stage.page_table_addr,
-                    Some(stage.name.to_string()),
-                    stage.name.to_string(),
-                    idx,
+                    &StageContext {
+                        capabilities: &stage.capabilities,
+                        heap_size: stage.heap_size,
+                        page_size: stage.page_size,
+                        page_table_addr: stage.page_table_addr,
+                        stage_name: Some(stage.name.to_string()),
+                        display_name: stage.name.to_string(),
+                        stage_idx: idx,
+                        load_addr: effective_stage_load_addr(config, idx, stage),
+                    },
                     &base_features,
                     target.needs_flat_binary,
                     soc_format,
                     has_pci_driver,
-                    effective_stage_load_addr(config, idx, stage),
+                    pci_root_backend,
                 )
             })
             .collect(),
@@ -185,55 +190,83 @@ fn base_features(parsed: &ParsedBoard, target: TargetSpec) -> FeatureSet {
     features
 }
 
-#[allow(clippy::too_many_arguments)]
-fn stage_plan(
-    config: &BoardConfig,
-    capabilities: &[Capability],
+#[derive(Debug)]
+struct StageContext<'a> {
+    capabilities: &'a [Capability],
     heap_size: Option<u32>,
     page_size: PageSize,
     page_table_addr: Option<(u64, u64)>,
     stage_name: Option<String>,
     display_name: String,
     stage_idx: usize,
+    load_addr: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PciRootBackend {
+    GenericEcam,
+    Q35HostBridge,
+}
+
+fn pci_root_backend(driver_instances: &[DriverInstance]) -> Option<PciRootBackend> {
+    let pci_root = driver_instances
+        .iter()
+        .find(|inst| inst.provides_pci_root())?;
+    if pci_root.driver_name() == "q35-hostbridge" {
+        Some(PciRootBackend::Q35HostBridge)
+    } else {
+        Some(PciRootBackend::GenericEcam)
+    }
+}
+
+fn stage_plan(
+    config: &BoardConfig,
+    stage: &StageContext<'_>,
     base_features: &FeatureSet,
     needs_flat_binary: bool,
     soc_format: SocImageFormat,
     include_global_pci_alloc: bool,
-    load_addr: u64,
+    pci_root_backend: Option<PciRootBackend>,
 ) -> StageBuildPlan {
     let mut features = base_features.clone();
-    features.extend(capability_features(capabilities, &config.security, config));
+    features.extend(capability_features(
+        stage.capabilities,
+        &config.security,
+        config,
+        pci_root_backend,
+    ));
 
-    if page_size == PageSize::Size1GiB {
+    if stage.page_size == PageSize::Size1GiB {
         features.insert("x86-1g-pages");
     }
     if config.platform == Platform::X86_64 {
-        if page_table_addr.is_some() {
+        if stage.page_table_addr.is_some() {
             features.insert("x86-writable-page-tables");
-        } else if stage_name.is_none() || stage_idx == 0 {
+        } else if stage.stage_name.is_none() || stage.stage_idx == 0 {
             features.insert("x86-static-page-tables");
         }
     }
 
-    let stage_has_crabefi = capabilities
+    let stage_has_crabefi = stage
+        .capabilities
         .iter()
         .any(|c| matches!(c, Capability::PayloadLoad))
         && stage_uses_crabefi(config);
-    let needs_alloc = stage_uses_fdt(capabilities)
-        || stage_uses_acpi(capabilities)
+    let needs_alloc = stage_uses_fdt(stage.capabilities)
+        || stage_uses_acpi(stage.capabilities)
         || stage_has_crabefi
-        || heap_size.is_some()
+        || stage.heap_size.is_some()
         || include_global_pci_alloc;
     let build_std = if needs_alloc { "core,alloc" } else { "core" };
 
     StageBuildPlan {
-        stage_name,
-        display_name,
+        stage_name: stage.stage_name.clone(),
+        display_name: stage.display_name.clone(),
         features,
         needs_flat_binary,
         build_std,
         soc_format,
-        load_addr,
+        load_addr: stage.load_addr,
     }
 }
 
@@ -242,6 +275,7 @@ fn capability_features(
     capabilities: &[Capability],
     security: &SecurityConfig,
     config: &BoardConfig,
+    pci_root_backend: Option<PciRootBackend>,
 ) -> Vec<&'static str> {
     let mut features = Vec::new();
 
@@ -272,13 +306,9 @@ fn capability_features(
     }
 
     if stage_uses_pci(capabilities) {
-        let pci_driver = config
-            .devices
-            .iter()
-            .find(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
-        match pci_driver.map(|d| d.driver.as_str()) {
-            Some("q35-hostbridge") => features.push("q35-hostbridge"),
-            _ => features.push("pci-ecam"),
+        match pci_root_backend {
+            Some(PciRootBackend::Q35HostBridge) => features.push("q35-hostbridge"),
+            Some(PciRootBackend::GenericEcam) | None => features.push("pci-ecam"),
         }
     }
 

--- a/xtask/src/build_plan.rs
+++ b/xtask/src/build_plan.rs
@@ -1,0 +1,438 @@
+//! Build planning for board firmware images.
+//!
+//! This module turns a parsed board description into stage build plans: target
+//! triple, cargo features, build-std selection, and stage image post-processing
+//! requirements.  It intentionally keeps driver classification in the typed
+//! device registry instead of duplicating string lists in xtask.
+
+use std::collections::BTreeSet;
+
+use fstart_codegen::ron_loader::ParsedBoard;
+use fstart_types::stage::PageSize;
+use fstart_types::{
+    effective_stage_load_addr, BoardConfig, Capability, Platform, SecurityConfig, SocImageFormat,
+    StageLayout,
+};
+
+use crate::toolchain::TargetSpec;
+
+/// Deterministic cargo feature collection.
+#[derive(Debug, Clone, Default)]
+pub struct FeatureSet {
+    features: BTreeSet<String>,
+}
+
+impl FeatureSet {
+    /// Insert a feature name.
+    pub fn insert(&mut self, feature: impl Into<String>) {
+        self.features.insert(feature.into());
+    }
+
+    /// Insert all features from an iterator.
+    pub fn extend<I, S>(&mut self, features: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for feature in features {
+            self.insert(feature);
+        }
+    }
+
+    /// Whether the set contains a feature.
+    #[cfg(test)]
+    pub fn contains(&self, feature: &str) -> bool {
+        self.features.contains(feature)
+    }
+
+    /// Return a comma-separated feature list for Cargo.
+    pub fn to_cargo_arg(&self) -> String {
+        self.features.iter().cloned().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Complete build plan for a board.
+#[derive(Debug, Clone)]
+pub struct BuildPlan {
+    /// Target/toolchain policy.
+    pub target: TargetSpec,
+    /// Per-stage builds to execute.
+    pub stages: Vec<StageBuildPlan>,
+}
+
+/// Build plan for one `fstart-stage` invocation.
+#[derive(Debug, Clone)]
+pub struct StageBuildPlan {
+    /// Stage name passed to build.rs. `None` means monolithic.
+    pub stage_name: Option<String>,
+    /// Human-readable label for logging/artifact names.
+    pub display_name: String,
+    /// Cargo feature set.
+    pub features: FeatureSet,
+    /// Whether this stage needs a flat `.bin` produced by objcopy.
+    pub needs_flat_binary: bool,
+    /// `-Z build-std=...` value.
+    pub build_std: &'static str,
+    /// SoC image format to post-process for this stage.
+    pub soc_format: SocImageFormat,
+    /// Effective load address for packaging.
+    pub load_addr: u64,
+}
+
+impl StageBuildPlan {
+    /// Comma-separated Cargo feature argument.
+    pub fn features_arg(&self) -> String {
+        self.features.to_cargo_arg()
+    }
+}
+
+/// Produce a complete build plan for a parsed board.
+pub fn plan(parsed: &ParsedBoard) -> BuildPlan {
+    let config = &parsed.config;
+    let target = TargetSpec::for_platform(config.platform);
+    let base_features = base_features(parsed, target);
+    let is_multi_stage = matches!(&config.stages, StageLayout::MultiStage(_));
+    let has_pci_driver = config
+        .devices
+        .iter()
+        .any(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
+
+    let stages = match &config.stages {
+        StageLayout::Monolithic(stage) => {
+            vec![stage_plan(
+                config,
+                &stage.capabilities,
+                stage.heap_size,
+                stage.page_size,
+                stage.page_table_addr,
+                None,
+                "stage".to_string(),
+                0,
+                &base_features,
+                target.needs_flat_binary,
+                config.soc_image_format,
+                false,
+                stage.load_addr,
+            )]
+        }
+        StageLayout::MultiStage(stages) => stages
+            .iter()
+            .enumerate()
+            .map(|(idx, stage)| {
+                let soc_format = if idx == 0 {
+                    config.soc_image_format
+                } else {
+                    SocImageFormat::None
+                };
+                stage_plan(
+                    config,
+                    &stage.capabilities,
+                    stage.heap_size,
+                    stage.page_size,
+                    stage.page_table_addr,
+                    Some(stage.name.to_string()),
+                    stage.name.to_string(),
+                    idx,
+                    &base_features,
+                    target.needs_flat_binary,
+                    soc_format,
+                    has_pci_driver,
+                    effective_stage_load_addr(config, idx, stage),
+                )
+            })
+            .collect(),
+    };
+
+    debug_assert_eq!(is_multi_stage, stages.len() > 1);
+    BuildPlan { target, stages }
+}
+
+fn base_features(parsed: &ParsedBoard, target: TargetSpec) -> FeatureSet {
+    let config = &parsed.config;
+    let mut features = FeatureSet::default();
+    features.insert(target.platform_feature);
+
+    for inst in &parsed.driver_instances {
+        if inst.is_structural() || inst.is_acpi_only() {
+            continue;
+        }
+        features.insert(inst.driver_name());
+    }
+
+    if matches!(&config.stages, StageLayout::MultiStage(_)) {
+        features.insert("handoff");
+    }
+
+    let uses_fit_runtime = config.payload.as_ref().is_some_and(|p| {
+        p.kind == fstart_types::PayloadKind::FitImage
+            && p.fit_parse.unwrap_or(fstart_types::FitParseMode::Buildtime)
+                == fstart_types::FitParseMode::Runtime
+    });
+    if uses_fit_runtime {
+        features.insert("fit");
+    }
+
+    if config.soc_image_format == SocImageFormat::AllwinnerEgon {
+        features.insert("sunxi");
+    }
+
+    // TODO: replace this board-name heuristic with an explicit board/emulation
+    // profile.  Kept here temporarily so the policy is isolated from build IO.
+    if config.name.as_str().contains("sbsa") {
+        features.insert("sbsa");
+    }
+
+    features
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stage_plan(
+    config: &BoardConfig,
+    capabilities: &[Capability],
+    heap_size: Option<u32>,
+    page_size: PageSize,
+    page_table_addr: Option<(u64, u64)>,
+    stage_name: Option<String>,
+    display_name: String,
+    stage_idx: usize,
+    base_features: &FeatureSet,
+    needs_flat_binary: bool,
+    soc_format: SocImageFormat,
+    include_global_pci_alloc: bool,
+    load_addr: u64,
+) -> StageBuildPlan {
+    let mut features = base_features.clone();
+    features.extend(capability_features(capabilities, &config.security, config));
+
+    if page_size == PageSize::Size1GiB {
+        features.insert("x86-1g-pages");
+    }
+    if config.platform == Platform::X86_64 {
+        if page_table_addr.is_some() {
+            features.insert("x86-writable-page-tables");
+        } else if stage_name.is_none() || stage_idx == 0 {
+            features.insert("x86-static-page-tables");
+        }
+    }
+
+    let stage_has_crabefi = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::PayloadLoad))
+        && stage_uses_crabefi(config);
+    let needs_alloc = stage_uses_fdt(capabilities)
+        || stage_uses_acpi(capabilities)
+        || stage_has_crabefi
+        || heap_size.is_some()
+        || include_global_pci_alloc;
+    let build_std = if needs_alloc { "core,alloc" } else { "core" };
+
+    StageBuildPlan {
+        stage_name,
+        display_name,
+        features,
+        needs_flat_binary,
+        build_std,
+        soc_format,
+        load_addr,
+    }
+}
+
+/// Compute the capability-driven feature flags for a single stage.
+fn capability_features(
+    capabilities: &[Capability],
+    security: &SecurityConfig,
+    config: &BoardConfig,
+) -> Vec<&'static str> {
+    let mut features = Vec::new();
+
+    let uses_ffs = capabilities.iter().any(|c| {
+        matches!(
+            c,
+            Capability::SigVerify | Capability::StageLoad { .. } | Capability::PayloadLoad
+        )
+    });
+
+    if uses_ffs {
+        features.push("ffs");
+        features.push("lz4");
+        match security.signing_algorithm {
+            fstart_types::SignatureAlgorithm::Ed25519 => features.push("ed25519"),
+            fstart_types::SignatureAlgorithm::EcdsaP256 => {}
+        }
+        for digest in &security.required_digests {
+            match digest {
+                fstart_types::DigestAlgorithm::Sha256 => features.push("sha2-digest"),
+                fstart_types::DigestAlgorithm::Sha3_256 => features.push("sha3-digest"),
+            }
+        }
+    }
+
+    if stage_uses_fdt(capabilities) {
+        features.push("fdt");
+    }
+
+    if stage_uses_pci(capabilities) {
+        let pci_driver = config
+            .devices
+            .iter()
+            .find(|d| d.services.iter().any(|s| s.as_str() == "PciRootBus"));
+        match pci_driver.map(|d| d.driver.as_str()) {
+            Some("q35-hostbridge") => features.push("q35-hostbridge"),
+            _ => features.push("pci-ecam"),
+        }
+    }
+
+    let has_payload_load = capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::PayloadLoad));
+    if has_payload_load && stage_uses_crabefi(config) {
+        features.push("crabefi");
+    }
+
+    if stage_uses_acpi(capabilities) {
+        features.push("acpi");
+    }
+
+    if stage_uses_smbios(capabilities) {
+        features.push("smbios");
+    }
+
+    for cap in capabilities {
+        if let Capability::MpInit { cpu_model, .. } = cap {
+            features.push("mp");
+            if cpu_model.as_str().contains("pineview") || cpu_model.as_str().contains("106cx") {
+                features.push("pineview-cpu");
+            }
+            if cpu_model.as_str().contains("core2") || cpu_model.as_str().contains("6fx") {
+                features.push("core2-cpu");
+            }
+        }
+    }
+
+    if capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::AcpiLoad { .. }))
+    {
+        features.push("acpi-load");
+    }
+
+    if capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::MemoryDetect { .. }))
+    {
+        features.push("memory-detect");
+    }
+
+    if config.platform == Platform::X86_64 {
+        features.push("ns16550-pio");
+        features.push("x86-boot");
+    }
+
+    features
+}
+
+fn stage_uses_fdt(capabilities: &[Capability]) -> bool {
+    capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::FdtPrepare))
+}
+
+fn stage_uses_pci(capabilities: &[Capability]) -> bool {
+    capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::PciInit { .. }))
+}
+
+fn stage_uses_acpi(capabilities: &[Capability]) -> bool {
+    capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::AcpiPrepare | Capability::AcpiLoad { .. }))
+}
+
+fn stage_uses_crabefi(config: &BoardConfig) -> bool {
+    config
+        .payload
+        .as_ref()
+        .is_some_and(|p| p.kind == fstart_types::PayloadKind::UefiPayload)
+}
+
+fn stage_uses_smbios(capabilities: &[Capability]) -> bool {
+    capabilities
+        .iter()
+        .any(|c| matches!(c, Capability::SmBiosPrepare))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use fstart_codegen::ron_loader;
+
+    fn load_plan(board: &'static str) -> super::BuildPlan {
+        // The all-drivers registry has large enum/config values; parse on a
+        // larger stack so x86 boards with nested chipset configs are reliable
+        // under `cargo test`'s default test-thread stack.
+        std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || {
+                let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                let board_ron = manifest
+                    .join("..")
+                    .join("boards")
+                    .join(board)
+                    .join("board.ron");
+                let parsed = ron_loader::load_parsed_board(&board_ron)
+                    .unwrap_or_else(|e| panic!("failed to load {}: {e}", board_ron.display()));
+                super::plan(&parsed)
+            })
+            .expect("spawn build-plan test loader")
+            .join()
+            .expect("build-plan test loader panicked")
+    }
+
+    #[test]
+    fn acpi_only_devices_do_not_become_cargo_features() {
+        let plan = load_plan("qemu-sbsa");
+        let features = &plan.stages[0].features;
+
+        assert!(!features.contains("ahci"));
+        assert!(!features.contains("xhci"));
+        assert!(!features.contains("pcie-root"));
+        assert!(features.contains("pci-ecam"));
+        assert!(features.contains("acpi"));
+    }
+
+    #[test]
+    fn structural_nodes_do_not_become_cargo_features() {
+        let plan = load_plan("foxconn-d41s");
+        for stage in &plan.stages {
+            assert!(!stage.features.contains("_structural"));
+            assert!(stage.features.contains("intel-pineview"));
+            assert!(stage.features.contains("intel-ich7"));
+        }
+    }
+
+    #[test]
+    fn q35_multi_stage_keeps_x86_boot_policy() {
+        let plan = load_plan("qemu-q35-uefi");
+        assert_eq!(plan.stages.len(), 2);
+
+        let bootblock = &plan.stages[0];
+        assert!(bootblock.features.contains("x86-boot"));
+        assert!(bootblock.features.contains("x86-writable-page-tables"));
+        assert_eq!(bootblock.build_std, "core,alloc");
+
+        let main = &plan.stages[1];
+        assert!(main.features.contains("x86-boot"));
+        assert!(!main.features.contains("x86-static-page-tables"));
+        assert!(main.features.contains("crabefi"));
+    }
+
+    #[test]
+    fn allwinner_boards_enable_sunxi_feature() {
+        let plan = load_plan("bananapi-m1");
+        for stage in &plan.stages {
+            assert!(stage.features.contains("sunxi"));
+        }
+    }
+}

--- a/xtask/src/image/egon.rs
+++ b/xtask/src/image/egon.rs
@@ -1,0 +1,140 @@
+//! Allwinner eGON image post-processing.
+
+use std::path::Path;
+
+const EGON_MAGIC: &[u8; 8] = b"eGON.BT0";
+const CHECKSUM_STAMP: u32 = 0x5F0A6C39;
+const HEADER_LEN: usize = 96;
+const SPL_SIGNATURE: &[u8; 4] = b"SPL\x02";
+
+/// Patch an Allwinner eGON binary: compute size, pad, write length + checksum.
+pub fn patch_file(bin_path: &Path) -> Result<(), String> {
+    let mut data = std::fs::read(bin_path).map_err(|e| format!("failed to read binary: {e}"))?;
+
+    if data.len() < HEADER_LEN {
+        return Err("binary too small for Allwinner eGON header (< 96 bytes)".to_string());
+    }
+    if &data[4..12] != EGON_MAGIC {
+        return Err("eGON.BT0 magic not found at offset 0x04".to_string());
+    }
+
+    let stamp = u32::from_le_bytes([data[0x0C], data[0x0D], data[0x0E], data[0x0F]]);
+    if stamp != CHECKSUM_STAMP {
+        return Err(format!(
+            "eGON checksum sentinel not found (got {stamp:#010x}, expected {CHECKSUM_STAMP:#010x})"
+        ));
+    }
+
+    // U-Boot's sunxi_egon.c uses PAD_SIZE = 8192; the BROM reads this many
+    // bytes from the boot medium.
+    let raw_size = data.len();
+    let image_size = ((raw_size + 0x1FFF) & !0x1FFF) as u32;
+    data.resize(image_size as usize, 0);
+    data[0x10..0x14].copy_from_slice(&image_size.to_le_bytes());
+    data[0x14..0x18].copy_from_slice(SPL_SIGNATURE);
+
+    let checksum = word_sum(&data);
+    data[0x0C..0x10].copy_from_slice(&checksum.to_le_bytes());
+    verify(&data)?;
+
+    std::fs::write(bin_path, &data).map_err(|e| format!("failed to write patched binary: {e}"))?;
+
+    eprintln!(
+        "[fstart] Allwinner eGON patched: raw_size={raw_size:#x}, \
+         image_size={image_size:#x}, checksum={checksum:#010x}"
+    );
+    Ok(())
+}
+
+/// Verify an Allwinner eGON binary using U-Boot's `egon_verify_header()` algorithm.
+pub fn verify(data: &[u8]) -> Result<(), String> {
+    if data.len() < HEADER_LEN {
+        return Err("verify: binary too small".to_string());
+    }
+
+    let is_arm_branch = data[3] == 0xEA;
+    let is_riscv_jal = (data[0] & 0x7F) == 0x6F;
+    if !is_arm_branch && !is_riscv_jal {
+        return Err(format!(
+            "verify: unrecognized branch instruction (bytes: {:#04x} {:#04x} {:#04x} {:#04x})",
+            data[0], data[1], data[2], data[3]
+        ));
+    }
+
+    if &data[4..12] != EGON_MAGIC {
+        return Err("verify: eGON.BT0 magic mismatch".to_string());
+    }
+
+    let length = u32::from_le_bytes([data[0x10], data[0x11], data[0x12], data[0x13]]);
+    let saved_checksum = u32::from_le_bytes([data[0x0C], data[0x0D], data[0x0E], data[0x0F]]);
+
+    if length == 0 || (length & 0x1FF) != 0 {
+        return Err(format!(
+            "verify: length {length:#x} is not a positive multiple of 512"
+        ));
+    }
+    if length as usize > data.len() {
+        return Err(format!(
+            "verify: length {length:#x} exceeds buffer size {:#x}",
+            data.len()
+        ));
+    }
+
+    let mut verify_sum: u32 = 0;
+    for i in 0..(length as usize / 4) {
+        let off = i * 4;
+        let word = if i == 3 {
+            CHECKSUM_STAMP
+        } else {
+            u32::from_le_bytes([data[off], data[off + 1], data[off + 2], data[off + 3]])
+        };
+        verify_sum = verify_sum.wrapping_add(word);
+    }
+
+    if verify_sum != saved_checksum {
+        return Err(format!(
+            "verify: checksum mismatch — stored {saved_checksum:#010x}, \
+             computed {verify_sum:#010x}"
+        ));
+    }
+
+    Ok(())
+}
+
+/// Patch the Allwinner eGON header at the start of an FFS image.
+pub fn patch_ffs(ffs_image: &mut [u8], bootblock_size: u32) -> Result<(), String> {
+    if (ffs_image.len() as u32) < bootblock_size {
+        return Err(format!(
+            "FFS image ({:#x} bytes) is smaller than bootblock size ({:#x})",
+            ffs_image.len(),
+            bootblock_size
+        ));
+    }
+    if ffs_image.len() < HEADER_LEN {
+        return Err("FFS image too small for eGON header".to_string());
+    }
+    if &ffs_image[4..12] != EGON_MAGIC {
+        return Err("eGON.BT0 magic not found at start of FFS image".to_string());
+    }
+
+    ffs_image[0x10..0x14].copy_from_slice(&bootblock_size.to_le_bytes());
+    ffs_image[0x14..0x18].copy_from_slice(SPL_SIGNATURE);
+    ffs_image[0x0C..0x10].copy_from_slice(&CHECKSUM_STAMP.to_le_bytes());
+
+    let checksum = word_sum(&ffs_image[..bootblock_size as usize]);
+    ffs_image[0x0C..0x10].copy_from_slice(&checksum.to_le_bytes());
+    verify(&ffs_image[..bootblock_size as usize])?;
+
+    eprintln!(
+        "[fstart] eGON patched in FFS: bootblock_size={bootblock_size:#x}, \
+         checksum={checksum:#010x}"
+    );
+    Ok(())
+}
+
+fn word_sum(data: &[u8]) -> u32 {
+    data.chunks_exact(4).fold(0u32, |checksum, chunk| {
+        let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        checksum.wrapping_add(word)
+    })
+}

--- a/xtask/src/image/mod.rs
+++ b/xtask/src/image/mod.rs
@@ -1,0 +1,3 @@
+//! Firmware image construction and post-processing helpers.
+
+pub mod egon;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,8 +15,11 @@ use std::process;
 
 pub mod assemble;
 pub mod build_board;
+mod build_plan;
+mod image;
 mod inspect;
 mod qemu;
+mod toolchain;
 
 #[derive(Parser)]
 #[command(name = "xtask", about = "fstart firmware build orchestrator")]

--- a/xtask/src/toolchain.rs
+++ b/xtask/src/toolchain.rs
@@ -1,0 +1,47 @@
+//! Toolchain policy for firmware builds.
+
+use fstart_types::Platform;
+
+/// Build-time target information derived from a board platform.
+#[derive(Debug, Clone, Copy)]
+pub struct TargetSpec {
+    /// Rust target triple used by Cargo.
+    pub triple: &'static str,
+    /// Cargo feature selecting the platform crate.
+    pub platform_feature: &'static str,
+    /// Whether the ELF must be converted to a flat binary for booting/packaging.
+    pub needs_flat_binary: bool,
+}
+
+impl TargetSpec {
+    /// Construct target build policy for a platform.
+    pub fn for_platform(platform: Platform) -> Self {
+        Self {
+            triple: platform.target_triple(),
+            platform_feature: platform.as_str(),
+            needs_flat_binary: matches!(
+                platform,
+                Platform::Aarch64 | Platform::Riscv64 | Platform::Armv7 | Platform::X86_64
+            ),
+        }
+    }
+}
+
+/// Base rustflags for a firmware target triple.
+pub fn rustflags_for_triple(triple: &str) -> String {
+    if triple.starts_with("x86_64") {
+        // x86_64 firmware: static relocation, large code model.
+        // Large model is needed because ROM at the top of 4 GiB and RAM/BSS
+        // can be ~4 GiB apart, exceeding small/medium/kernel model ±2 GiB
+        // limits.
+        //
+        // Force curve25519-dalek to use the scalar backend.  This must be in
+        // RUSTFLAGS because Cargo features cannot set --cfg on transitive
+        // dependencies and a global .cargo/config.toml would affect host builds.
+        "-Zub-checks=no -Crelocation-model=static -Ccode-model=large \
+         --cfg curve25519_dalek_backend=\"serial\""
+            .to_string()
+    } else {
+        "-Zub-checks=no".to_string()
+    }
+}


### PR DESCRIPTION
## Summary
- move xtask feature and stage build resolution into a typed build plan
- derive runtime driver features from typed DriverInstance metadata instead of ad hoc string lists
- move toolchain rustflags policy and Allwinner eGON image patching into focused modules
- make CI discover boards dynamically and assemble every board so future boards are covered automatically
- add Intel microcode as a pinned submodule and point x86 board configs at the in-tree submodule
- add build-plan tests for ACPI-only devices, structural nodes, x86 Q35 policy, and sunxi features

## Test plan
- cargo fmt --all
- cargo check --workspace --exclude fstart-stage --exclude fstart-platform-riscv64 --exclude fstart-platform-aarch64 --exclude fstart-platform-armv7 --exclude fstart-runtime
- cargo test --package xtask build_plan
- cargo clippy --workspace --exclude fstart-stage --exclude fstart-platform-riscv64 --exclude fstart-platform-aarch64 --exclude fstart-platform-armv7 --exclude fstart-runtime -- -D warnings
- cargo xtask assemble --board foxconn-d41s --release --kernel target/ci/payload.bin --firmware target/ci/payload.bin
- cargo xtask assemble --board foxconn-d41s-uefi --release --kernel target/ci/payload.bin --firmware target/ci/payload.bin
- cargo xtask assemble --board lenovo-x61 --release --kernel target/ci/payload.bin --firmware target/ci/payload.bin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized firmware build system with dedicated build planning for consistent feature composition across board stages.
  * Consolidated SoC image post-processing logic into specialized modules.
  * Enhanced CI workflow to dynamically discover board targets.

* **Chores**
  * Updated Intel microcode file paths for supported boards.
  * Added Intel microcode repository as a git submodule dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fstart-io/fstart/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->