### PR TITLE
Use object crate for ELF extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "fstart-log",
  "fstart-microcode-intel",
  "fstart-smm",
+ "object",
  "ufmt",
 ]
 
@@ -1177,6 +1178,7 @@ dependencies = [
  "clap",
  "fstart-smm",
  "fstart-types",
+ "object",
 ]
 
 [[package]]
@@ -1342,17 +1344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
-dependencies = [
- "log",
- "plain",
- "scroll",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "noto-sans-mono-bitmap"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,12 +1576,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "postcard"
@@ -1741,26 +1741,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scroll"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
 
 [[package]]
 name = "sec1"
@@ -2081,7 +2061,7 @@ dependencies = [
  "fstart-services",
  "fstart-smm-image",
  "fstart-types",
- "goblin",
+ "object",
  "rand_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,11 +106,10 @@ dtoolkit = { version = "0.1", default-features = false }
 # Compression
 lz4_flex = { version = "0.11", default-features = false }
 
-# ELF parsing (host-side only)
-goblin = { version = "0.10", default-features = false, features = [
-  "elf32",
-  "elf64",
-  "endian_fd",
+# Object/ELF parsing and flat-binary extraction (host-side only)
+object = { version = "0.37", default-features = false, features = [
+  "elf",
+  "read",
 ] }
 
 # xtask / host-side

--- a/crates/fstart-mp/Cargo.toml
+++ b/crates/fstart-mp/Cargo.toml
@@ -12,3 +12,6 @@ fstart-log = { workspace = true }
 fstart-microcode-intel = { workspace = true }
 fstart-smm = { workspace = true }
 ufmt = { workspace = true }
+
+[build-dependencies]
+object = { workspace = true }

--- a/crates/fstart-mp/build.rs
+++ b/crates/fstart-mp/build.rs
@@ -1,3 +1,4 @@
+use object::{Object, ObjectSection};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -29,13 +30,7 @@ fn main() {
         .arg("-o")
         .arg(&elf)
         .arg(&object));
-    run(Command::new("objcopy")
-        .arg("-O")
-        .arg("binary")
-        .arg("-j")
-        .arg(".text")
-        .arg(&elf)
-        .arg(&bin));
+    write_text_section(&elf, &bin);
 
     fs::write(
         out_dir.join("sipi_trampoline.rs"),
@@ -55,6 +50,19 @@ fn main() {
         ),
     )
     .unwrap();
+}
+
+fn write_text_section(elf: &Path, bin: &Path) {
+    let data = fs::read(elf).unwrap_or_else(|e| panic!("failed to read {}: {e}", elf.display()));
+    let file = object::File::parse(data.as_slice())
+        .unwrap_or_else(|e| panic!("failed to parse ELF {}: {e}", elf.display()));
+    let section = file
+        .section_by_name(".text")
+        .unwrap_or_else(|| panic!(".text section not found in {}", elf.display()));
+    let text = section
+        .data()
+        .unwrap_or_else(|e| panic!("failed to read .text from {}: {e}", elf.display()));
+    fs::write(bin, text).unwrap_or_else(|e| panic!("failed to write {}: {e}", bin.display()));
 }
 
 fn find_symbol_offset(elf: &Path, symbol: &str) -> usize {

--- a/crates/fstart-smm-image/Cargo.toml
+++ b/crates/fstart-smm-image/Cargo.toml
@@ -8,3 +8,7 @@ license.workspace = true
 clap = { workspace = true }
 fstart-smm = { workspace = true, features = ["std", "coreboot"] }
 fstart-types = { workspace = true }
+object = { workspace = true }
+
+[build-dependencies]
+object = { workspace = true }

--- a/crates/fstart-smm-image/build.rs
+++ b/crates/fstart-smm-image/build.rs
@@ -1,3 +1,4 @@
+use object::{Object, ObjectSection};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -61,17 +62,20 @@ fn link_text_blob(object: &Path, elf: &Path, bin: &Path) {
         .arg("-o")
         .arg(elf)
         .arg(object));
-    objcopy_text(elf, bin);
+    write_text_section(elf, bin);
 }
 
-fn objcopy_text(elf: &Path, bin: &Path) {
-    run(Command::new("objcopy")
-        .arg("-O")
-        .arg("binary")
-        .arg("-j")
-        .arg(".text")
-        .arg(elf)
-        .arg(bin));
+fn write_text_section(elf: &Path, bin: &Path) {
+    let data = fs::read(elf).unwrap_or_else(|e| panic!("failed to read {}: {e}", elf.display()));
+    let file = object::File::parse(data.as_slice())
+        .unwrap_or_else(|e| panic!("failed to parse ELF {}: {e}", elf.display()));
+    let section = file
+        .section_by_name(".text")
+        .unwrap_or_else(|| panic!(".text section not found in {}", elf.display()));
+    let text = section
+        .data()
+        .unwrap_or_else(|e| panic!("failed to read .text from {}: {e}", elf.display()));
+    fs::write(bin, text).unwrap_or_else(|e| panic!("failed to write {}: {e}", bin.display()));
 }
 
 fn find_symbol_offset(elf: &Path, symbol: &str) -> usize {

--- a/crates/fstart-smm-image/src/lib.rs
+++ b/crates/fstart-smm-image/src/lib.rs
@@ -7,6 +7,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use object::{Object, ObjectSection};
+
 use fstart_smm::header::{
     render_coreboot_header, CorebootOffsets, EntryDescriptor, SmmImageHeader, FLAG_COREBOOT_HEADER,
     FLAG_COREBOOT_MODULE_ARGS,
@@ -297,20 +299,26 @@ fn build_smm_stage(platform: SmmPlatform) -> Result<BuiltHandler, BuildError> {
             .arg(&archive)
             .arg("--no-whole-archive"),
     )?;
-    run_tool(
-        Command::new("objcopy")
-            .arg("-O")
-            .arg("binary")
-            .arg("-j")
-            .arg(".text")
-            .arg(&elf)
-            .arg(&bin),
-    )?;
+    write_text_section(&elf, &bin)?;
 
     Ok(BuiltHandler {
         code: std::fs::read(&bin)?,
         entry_offset: find_symbol_offset(&elf, "fstart_smm_handler")?,
     })
+}
+
+fn write_text_section(elf: &Path, bin: &Path) -> Result<(), BuildError> {
+    let data = std::fs::read(elf)?;
+    let file = object::File::parse(data.as_slice())
+        .map_err(|e| BuildError::Tool(format!("failed to parse ELF {}: {e}", elf.display())))?;
+    let section = file
+        .section_by_name(".text")
+        .ok_or_else(|| BuildError::Tool(format!(".text section not found in {}", elf.display())))?;
+    let text = section.data().map_err(|e| {
+        BuildError::Tool(format!("failed to read .text from {}: {e}", elf.display()))
+    })?;
+    std::fs::write(bin, text)?;
+    Ok(())
 }
 
 fn platform_env(platform: SmmPlatform) -> &'static str {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ boards/my-board/board.ron
        v
   ELF binary
        |
-       |  10. llvm-objcopy -O binary (flat binary for all platforms)
+       |  10. object-crate ELF PT_LOAD extraction (flat binary for all platforms)
        |  11. (armv7/sunxi) patch eGON header: length + checksum
        |
        v
@@ -102,11 +102,12 @@ include!(concat!(env!("OUT_DIR"), "/generated_stage.rs"));
 Everything else comes from codegen. The platform crate provides `_start`
 (the entry point), and `fstart-runtime` provides the `#[panic_handler]`.
 
-**Steps 10-11: post-processing.** All platforms produce flat binaries via
-`llvm-objcopy -O binary`. The `.bss` section is stripped to avoid a
-multi-gigabyte file spanning the ROM-to-RAM address gap. For Allwinner SoCs,
-the binary is further patched with an eGON boot header (magic bytes, length,
-checksum) that the SoC's BROM expects.
+**Steps 10-11: post-processing.** All platforms produce flat binaries by
+reading ELF `PT_LOAD` segments with the Rust `object` crate and laying out
+file-backed segment contents by physical address. Pure BSS segments are not
+written, avoiding a multi-gigabyte file spanning the ROM-to-RAM address gap.
+For Allwinner SoCs, the binary is further patched with an eGON boot header
+(magic bytes, length, checksum) that the SoC's BROM expects.
 
 **Steps 12-13: assembly and launch.** For multi-stage boards or boards with
 payload blobs (kernel, OpenSBI, ATF), xtask runs the assembly step: it
@@ -125,7 +126,7 @@ fstart has 26 crates in three groups: host-only, shared, and target-only.
 xtask
   reads board RON, invokes cargo, assembles FFS, launches QEMU
   depends on: fstart-types, fstart-ffs, fstart-fit, fstart-crypto,
-              fstart-device-registry, goblin (ELF parsing),
+              fstart-device-registry, object (ELF parsing/extraction),
               ed25519-dalek (signing)
 
 fstart-codegen
@@ -335,7 +336,7 @@ the eGON magic appears at offset 0 of the binary.
 
 ## Runtime boot flow
 
-### Platform entry (_start)
+### Platform entry (\_start)
 
 Each platform crate (`fstart-platform-riscv64`, etc.) provides a `_start`
 in a `global_asm!` block placed in `.text.entry`. The assembly does four

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-goblin = { workspace = true }
+object = { workspace = true }
 fstart-types = { workspace = true, features = ["std"] }
 fstart-codegen = { workspace = true }
 fstart-device-registry = { workspace = true, features = ["all-drivers"] }

--- a/xtask/src/assemble.rs
+++ b/xtask/src/assemble.rs
@@ -3,7 +3,7 @@
 //! Reads a board config, collects built binaries, and assembles them into
 //! a signed FFS firmware image using the fstart-ffs builder.
 //!
-//! Stage flat binaries (`.bin` files produced by `llvm-objcopy`) are
+//! Stage flat binaries (`.bin` files produced from ELF PT_LOAD data) are
 //! embedded as single FFS segments. This preserves alignment gaps between
 //! sections (e.g., `.text` → `.fstart.anchor` → `.rodata`) which is
 //! critical for XIP boards that read the anchor at its link-time VMA.
@@ -23,7 +23,8 @@ use fstart_types::ffs::{
 };
 use fstart_types::memory::{FlashLayout, IntelIfdFlashLayout, IntelIfdRegion};
 use fstart_types::{BoardConfig, FdtSource, Platform, RunsFrom, SocImageFormat, StageLayout};
-use goblin::elf::{program_header, Elf};
+use object::elf;
+use object::read::elf::{ElfFile, FileHeader, ProgramHeader};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -97,7 +98,7 @@ fn assemble_impl(
 
     // Build the list of input files from the built stages.
     //
-    // Each stage is packaged as a flat binary (.bin from objcopy) to
+    // Each stage is packaged as a flat binary (.bin extracted from ELF PT_LOAD data) to
     // preserve alignment gaps between sections.  ELF parsing is
     // retained only for diagnostic logging.
     let mut ro_files = Vec::new();
@@ -175,7 +176,7 @@ fn assemble_impl(
                     });
                 } else {
                     // Subsequent stages are stored as flat binaries (the
-                    // objcopy .bin). The StageLoad path loads the FFS segment
+                    // ELF-derived .bin). The StageLoad path loads the FFS segment
                     // to load_addr and supports LZ4 in-place decompression, so
                     // ramstages loaded via StageLoad can be stored compressed.
                     // LoadNextStage users (e.g. tiny SoC bootblocks) copy raw
@@ -705,24 +706,19 @@ fn create_full_flash_image(
             bootblock_elf.display()
         )
     })?;
-    let elf = Elf::parse(&elf_data).map_err(|e| {
-        format!(
-            "failed to parse bootblock ELF {}: {e}",
-            bootblock_elf.display()
-        )
-    })?;
+    let load_segments = elf_load_segments(&elf_data, bootblock_elf)?;
 
     let mut first_flash_load: Option<usize> = None;
-    for phdr in &elf.program_headers {
-        if phdr.p_type != program_header::PT_LOAD || phdr.p_filesz == 0 {
+    for segment in load_segments {
+        if segment.filesz == 0 {
             continue;
         }
-        let paddr = phdr.p_paddr;
+        let paddr = segment.paddr;
         if paddr < flash_base {
             continue;
         }
         let off = (paddr - flash_base) as usize;
-        let size = phdr.p_filesz as usize;
+        let size = segment.filesz as usize;
         if off + size > flash_size {
             return Err(format!(
                 "bootblock segment paddr={paddr:#x} size={size:#x} outside flash image"
@@ -903,24 +899,19 @@ fn create_intel_ifd_flash_image(
             bootblock_elf.display()
         )
     })?;
-    let elf = Elf::parse(&elf_data).map_err(|e| {
-        format!(
-            "failed to parse bootblock ELF {}: {e}",
-            bootblock_elf.display()
-        )
-    })?;
+    let load_segments = elf_load_segments(&elf_data, bootblock_elf)?;
 
     let mut first_flash_load: Option<usize> = None;
-    for phdr in &elf.program_headers {
-        if phdr.p_type != program_header::PT_LOAD || phdr.p_filesz == 0 {
+    for segment in load_segments {
+        if segment.filesz == 0 {
             continue;
         }
-        let paddr = phdr.p_paddr;
+        let paddr = segment.paddr;
         if paddr < layout.base || paddr >= layout.end() {
             continue;
         }
         let off = (paddr - layout.base) as usize;
-        let size = phdr.p_filesz as usize;
+        let size = segment.filesz as usize;
         if off + size > image.len() {
             return Err(format!(
                 "bootblock segment paddr={paddr:#x} size={size:#x} outside Intel IFD flash image"
@@ -1601,8 +1592,55 @@ fn add_firmware_blob(
 }
 
 // ============================================================================
-// ELF parsing — replaces llvm-objcopy
+// ELF parsing via the object crate
 // ============================================================================
+
+#[derive(Debug, Clone, Copy)]
+struct ElfLoadSegment {
+    offset: u64,
+    paddr: u64,
+    filesz: u64,
+    memsz: u64,
+    flags: u32,
+}
+
+fn elf_load_segments(elf_data: &[u8], elf_path: &Path) -> Result<Vec<ElfLoadSegment>, String> {
+    if elf_data.len() < 16 {
+        return Err(format!("ELF {} is too short", elf_path.display()));
+    }
+
+    match elf_data[4] {
+        elf::ELFCLASS32 => elf_load_segments_for::<elf::FileHeader32<object::Endianness>>(elf_data),
+        elf::ELFCLASS64 => elf_load_segments_for::<elf::FileHeader64<object::Endianness>>(elf_data),
+        class => {
+            return Err(format!(
+                "unsupported ELF class {class} in {}",
+                elf_path.display()
+            ));
+        }
+    }
+    .map_err(|e| format!("failed to parse ELF {}: {e}", elf_path.display()))
+}
+
+fn elf_load_segments_for<Elf>(elf_data: &[u8]) -> Result<Vec<ElfLoadSegment>, object::Error>
+where
+    Elf: FileHeader,
+{
+    let elf = ElfFile::<Elf>::parse(elf_data)?;
+    let endian = elf.elf_header().endian()?;
+    Ok(elf
+        .elf_program_headers()
+        .iter()
+        .filter(|phdr| phdr.p_type(endian) == elf::PT_LOAD)
+        .map(|phdr| ElfLoadSegment {
+            offset: phdr.p_offset(endian).into(),
+            paddr: phdr.p_paddr(endian).into(),
+            filesz: phdr.p_filesz(endian).into(),
+            memsz: phdr.p_memsz(endian).into(),
+            flags: phdr.p_flags(endian),
+        })
+        .collect())
+}
 
 /// Parse an ELF file into FFS input segments, one per PT_LOAD.
 ///
@@ -1622,27 +1660,21 @@ fn parse_elf_segments(
     let elf_data =
         fs::read(elf_path).map_err(|e| format!("failed to read {}: {e}", elf_path.display()))?;
 
-    let elf = Elf::parse(&elf_data)
-        .map_err(|e| format!("failed to parse ELF {}: {e}", elf_path.display()))?;
-
     let mut segments = Vec::new();
 
-    for phdr in &elf.program_headers {
+    for phdr in elf_load_segments(&elf_data, elf_path)? {
         // Only process PT_LOAD segments with nonzero memory footprint
-        if phdr.p_type != program_header::PT_LOAD {
-            continue;
-        }
-        if phdr.p_memsz == 0 {
+        if phdr.memsz == 0 {
             continue;
         }
 
-        let p_flags = phdr.p_flags;
-        let is_exec = p_flags & program_header::PF_X != 0;
-        let is_write = p_flags & program_header::PF_W != 0;
+        let p_flags = phdr.flags;
+        let is_exec = p_flags & elf::PF_X != 0;
+        let is_write = p_flags & elf::PF_W != 0;
 
         // Determine segment kind and name from ELF flags, matching
         // the coreboot PAYLOAD_SEGMENT_CODE / DATA / BSS classification.
-        let (kind, name, flags) = if phdr.p_filesz == 0 {
+        let (kind, name, flags) = if phdr.filesz == 0 {
             // Pure BSS — no file content, just zero-fill
             (SegmentKind::Bss, ".bss", SegmentFlags::DATA)
         } else if is_exec {
@@ -1654,13 +1686,13 @@ fn parse_elf_segments(
         };
 
         // Extract file data (p_filesz bytes at p_offset)
-        let data = if phdr.p_filesz > 0 {
-            let start = phdr.p_offset as usize;
-            let end = start + phdr.p_filesz as usize;
+        let data = if phdr.filesz > 0 {
+            let start = phdr.offset as usize;
+            let end = start + phdr.filesz as usize;
             if end > elf_data.len() {
                 return Err(format!(
                     "PT_LOAD at {:#x} extends past EOF in {}",
-                    phdr.p_paddr,
+                    phdr.paddr,
                     elf_path.display(),
                 ));
             }
@@ -1671,15 +1703,15 @@ fn parse_elf_segments(
 
         // mem_size tracks the BSS tail: when p_memsz > p_filesz the
         // loader must zero-fill the remaining bytes after the file data.
-        let mem_size = if phdr.p_memsz != phdr.p_filesz {
-            Some(phdr.p_memsz)
+        let mem_size = if phdr.memsz != phdr.filesz {
+            Some(phdr.memsz)
         } else {
             None
         };
 
         // BSS segments have no stored content — never compress them.
         // Other segments use the caller's requested compression.
-        let seg_compression = if phdr.p_filesz == 0 {
+        let seg_compression = if phdr.filesz == 0 {
             Compression::None
         } else {
             compression
@@ -1690,7 +1722,7 @@ fn parse_elf_segments(
             kind,
             data,
             mem_size,
-            load_addr: phdr.p_paddr,
+            load_addr: phdr.paddr,
             compression: seg_compression,
             flags,
         });

--- a/xtask/src/build_board.rs
+++ b/xtask/src/build_board.rs
@@ -7,7 +7,10 @@
 
 use fstart_codegen::ron_loader;
 use fstart_types::{Capability, SocImageFormat, StageLayout};
-use std::path::PathBuf;
+use object::elf;
+use object::read::elf::{ElfFile, FileHeader, ProgramHeader};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Result of building a board — one or more stage binaries.
@@ -21,7 +24,7 @@ pub struct BuildResult {
 pub struct StageBinary {
     /// Stage name (e.g., "bootblock", "main", or "stage" for monolithic).
     pub name: String,
-    /// Path to the ELF binary on disk (used by assembler for objcopy).
+    /// Path to the ELF binary on disk (used by assembler diagnostics/packaging).
     pub path: PathBuf,
     /// Path to run in QEMU (flat binary for AArch64, same as `path` otherwise).
     pub run_path: PathBuf,
@@ -291,27 +294,17 @@ fn build_one_stage(
     // section's LMA is in ROM (via `AT > ROM` in the linker script) so it
     // is contiguous with .text/.rodata and must NOT be removed — the _start
     // assembly copies those initializers to RAM. Only .bss is removed: it
-    // is NOLOAD and its VMA is in RAM, which would cause objcopy to span
+    // is NOLOAD and its VMA is in RAM, which would cause naive flat extraction to span
     // the ROM→RAM gap (producing a multi-GiB file of mostly zeros). The
     // entry code clears BSS at runtime.
     let run_path = if needs_flat_binary {
         let bin_path = final_elf.with_extension("bin");
         eprintln!(
-            "[fstart] objcopy: {} -> {}",
+            "[fstart] elf-to-bin: {} -> {}",
             final_elf.display(),
             bin_path.display()
         );
-        let objcopy_status = Command::new("llvm-objcopy")
-            .arg("-O")
-            .arg("binary")
-            .arg("--remove-section=.bss")
-            .arg(&final_elf)
-            .arg(&bin_path)
-            .status()
-            .map_err(|e| format!("failed to run llvm-objcopy: {e}"))?;
-        if !objcopy_status.success() {
-            return Err("llvm-objcopy failed".to_string());
-        }
+        write_flat_binary(&final_elf, &bin_path)?;
 
         // Allwinner eGON: compute the actual binary size, pad to
         // 512-byte alignment, and patch both length and checksum.
@@ -331,6 +324,101 @@ fn build_one_stage(
 /// Public wrapper for workspace root (used by other xtask modules).
 pub fn workspace_root_pub() -> Result<PathBuf, String> {
     workspace_root()
+}
+
+fn write_flat_binary(elf_path: &Path, bin_path: &Path) -> Result<(), String> {
+    let elf_data = fs::read(elf_path)
+        .map_err(|e| format!("failed to read ELF {}: {e}", elf_path.display()))?;
+    let load_segments = elf_load_segments(&elf_data, elf_path)?;
+
+    let min_paddr = load_segments
+        .iter()
+        .filter(|segment| segment.filesz != 0)
+        .map(|segment| segment.paddr)
+        .min()
+        .ok_or_else(|| format!("no loadable file-backed segments in {}", elf_path.display()))?;
+    let max_paddr = load_segments
+        .iter()
+        .filter(|segment| segment.filesz != 0)
+        .map(|segment| segment.paddr.saturating_add(segment.filesz))
+        .max()
+        .unwrap_or(min_paddr);
+    let len = max_paddr
+        .checked_sub(min_paddr)
+        .and_then(|len| usize::try_from(len).ok())
+        .ok_or_else(|| {
+            format!(
+                "flat binary address range is too large in {}",
+                elf_path.display()
+            )
+        })?;
+
+    let mut flat = vec![0u8; len];
+    for segment in load_segments.iter().filter(|segment| segment.filesz != 0) {
+        let start = usize::try_from(segment.paddr - min_paddr)
+            .map_err(|_| format!("segment offset is too large in {}", elf_path.display()))?;
+        let size = usize::try_from(segment.filesz)
+            .map_err(|_| format!("segment size is too large in {}", elf_path.display()))?;
+        let file_start = usize::try_from(segment.offset)
+            .map_err(|_| format!("segment file offset is too large in {}", elf_path.display()))?;
+        let file_end = file_start
+            .checked_add(size)
+            .ok_or_else(|| format!("segment file range overflows in {}", elf_path.display()))?;
+        if file_end > elf_data.len() {
+            return Err(format!(
+                "PT_LOAD at {:#x} extends past EOF in {}",
+                segment.paddr,
+                elf_path.display()
+            ));
+        }
+        flat[start..start + size].copy_from_slice(&elf_data[file_start..file_end]);
+    }
+
+    fs::write(bin_path, flat)
+        .map_err(|e| format!("failed to write flat binary {}: {e}", bin_path.display()))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ElfLoadSegment {
+    offset: u64,
+    paddr: u64,
+    filesz: u64,
+}
+
+fn elf_load_segments(elf_data: &[u8], elf_path: &Path) -> Result<Vec<ElfLoadSegment>, String> {
+    if elf_data.len() < 16 {
+        return Err(format!("ELF {} is too short", elf_path.display()));
+    }
+
+    match elf_data[4] {
+        elf::ELFCLASS32 => elf_load_segments_for::<elf::FileHeader32<object::Endianness>>(elf_data),
+        elf::ELFCLASS64 => elf_load_segments_for::<elf::FileHeader64<object::Endianness>>(elf_data),
+        class => {
+            return Err(format!(
+                "unsupported ELF class {class} in {}",
+                elf_path.display()
+            ));
+        }
+    }
+    .map_err(|e| format!("failed to parse ELF {}: {e}", elf_path.display()))
+}
+
+fn elf_load_segments_for<Elf>(elf_data: &[u8]) -> Result<Vec<ElfLoadSegment>, object::Error>
+where
+    Elf: FileHeader,
+{
+    let elf = ElfFile::<Elf>::parse(elf_data)?;
+    let endian = elf.elf_header().endian()?;
+    Ok(elf
+        .elf_program_headers()
+        .iter()
+        .filter(|phdr| phdr.p_type(endian) == elf::PT_LOAD)
+        .map(|phdr| ElfLoadSegment {
+            offset: phdr.p_offset(endian).into(),
+            paddr: phdr.p_paddr(endian).into(),
+            filesz: phdr.p_filesz(endian).into(),
+        })
+        .collect())
 }
 
 fn workspace_root() -> Result<PathBuf, String> {

--- a/xtask/src/build_plan.rs
+++ b/xtask/src/build_plan.rs
@@ -70,7 +70,7 @@ pub struct StageBuildPlan {
     pub display_name: String,
     /// Cargo feature set.
     pub features: FeatureSet,
-    /// Whether this stage needs a flat `.bin` produced by objcopy.
+    /// Whether this stage needs a flat `.bin` extracted from ELF PT_LOAD data.
     pub needs_flat_binary: bool,
     /// `-Z build-std=...` value.
     pub build_std: &'static str,

--- a/xtask/src/qemu.rs
+++ b/xtask/src/qemu.rs
@@ -581,7 +581,7 @@ fn create_pflash_image(binary: &Path, flash_size: usize) -> Result<PathBuf, Stri
 /// Create an x86 pflash image by overlaying the FFS image onto the raw
 /// stage binary.
 ///
-/// The raw stage `.bin` (from objcopy) is a full flash-sized image with
+/// The raw stage `.bin` (extracted from ELF PT_LOAD data) is a full flash-sized image with
 /// boot code at the correct offsets (reset vector at end, 16/32/64-bit
 /// entry code near end, main code at start). The FFS image contains the
 /// stage segments + kernel payload at offset 0 (mapped to flash base).


### PR DESCRIPTION
## Summary
- replace goblin ELF parsing with the Rust object crate
- replace llvm-objcopy/objcopy flat-binary and .text extraction with object-based extraction
- update architecture docs and related comments

## Testing
- cargo fmt --all -- --check
- cargo check -p xtask -p fstart-mp -p fstart-smm-image