### PR TITLE
Add x86 S3 resume plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "fstart-types",
  "postcard",
  "ufmt",
+ "zerocopy",
 ]
 
 [[package]]
@@ -575,6 +576,7 @@ dependencies = [
  "fstart-driver-intel-ich7",
  "fstart-driver-intel-ich8",
  "fstart-driver-intel-pineview",
+ "fstart-driver-intel-spi",
  "fstart-driver-ite8721f",
  "fstart-driver-ns16550",
  "fstart-driver-nsc-pc87382",
@@ -700,6 +702,7 @@ dependencies = [
  "fstart-smbus-intel",
  "fstart-smm-runtime",
  "fstart-superio",
+ "fstart-types",
  "heapless",
  "serde",
  "tock-registers",
@@ -725,6 +728,7 @@ dependencies = [
  "fstart-smbus-intel",
  "fstart-smm-runtime",
  "fstart-superio",
+ "fstart-types",
  "heapless",
  "serde",
  "tock-registers",
@@ -758,6 +762,17 @@ dependencies = [
  "heapless",
  "serde",
  "tock-registers",
+ "ufmt",
+]
+
+[[package]]
+name = "fstart-driver-intel-spi"
+version = "0.1.0"
+dependencies = [
+ "fstart-log",
+ "fstart-pio",
+ "fstart-services",
+ "serde",
  "ufmt",
 ]
 
@@ -1129,6 +1144,7 @@ dependencies = [
  "fstart-pio",
  "fstart-services",
  "fstart-types",
+ "postcard",
  "ufmt",
 ]
 
@@ -1152,6 +1168,7 @@ version = "0.1.0"
 dependencies = [
  "embedded-hal",
  "fstart-pci",
+ "fstart-types",
 ]
 
 [[package]]
@@ -1238,6 +1255,7 @@ dependencies = [
  "fstart-driver-intel-ich7",
  "fstart-driver-intel-ich8",
  "fstart-driver-intel-pineview",
+ "fstart-driver-intel-spi",
  "fstart-driver-ite8721f",
  "fstart-driver-ns16550",
  "fstart-driver-nsc-pc87382",
@@ -1283,6 +1301,7 @@ dependencies = [
  "fstart-log",
  "fstart-services",
  "fstart-types",
+ "postcard",
  "ufmt",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
   "crates/fstart-driver-intel-ich7",
   "crates/fstart-driver-intel-gm965",
   "crates/fstart-driver-intel-ich8",
+  "crates/fstart-driver-intel-spi",
   "crates/fstart-mainboard-lenovo-x61",
   "crates/fstart-driver-i2c-ck505",
   "crates/fstart-smbus-intel",
@@ -99,6 +100,7 @@ ufmt = { version = "0.2", default-features = false }
 bitflags = "2"
 tock-registers = "0.10"
 x86 = { version = "0.52", default-features = false }
+zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 
 # Device tree
 dtoolkit = { version = "0.1", default-features = false }
@@ -172,6 +174,7 @@ fstart-driver-intel-pineview = { path = "crates/fstart-driver-intel-pineview" }
 fstart-driver-intel-ich7 = { path = "crates/fstart-driver-intel-ich7" }
 fstart-driver-intel-gm965 = { path = "crates/fstart-driver-intel-gm965" }
 fstart-driver-intel-ich8 = { path = "crates/fstart-driver-intel-ich8" }
+fstart-driver-intel-spi = { path = "crates/fstart-driver-intel-spi" }
 fstart-mainboard-lenovo-x61 = { path = "crates/fstart-mainboard-lenovo-x61" }
 fstart-driver-i2c-ck505 = { path = "crates/fstart-driver-i2c-ck505" }
 fstart-smbus-intel = { path = "crates/fstart-smbus-intel" }

--- a/boards/foxconn-d41s-uefi/board.ron
+++ b/boards/foxconn-d41s-uefi/board.ron
@@ -300,7 +300,6 @@
                 ConsoleInit( device: "superio" ),
                 BootMedia(MemoryMapped(
                     base: 0xFF000000, size: 0x01000000,
-                    ram_copy_addr: 0x2000000,
                 )),
                 SigVerify,
                 DriverInit,

--- a/boards/foxconn-d41s/board.ron
+++ b/boards/foxconn-d41s/board.ron
@@ -247,6 +247,13 @@
                 ),
             ],
         ),
+        (
+            name: "spi_flash",
+            driver: IntelSpi((
+                chipset: Ich7,
+                mode: Auto,
+            )),
+        ),
     ],
 
     stages: MultiStage([
@@ -270,6 +277,8 @@
                 // Opens NB BARs (MCHBAR, DMIBAR), PAM, graphics clocks; SB SMBus
                 // (needed by DramInit), BARs, PIRQ, GPIO, CIR, IOAPIC, HPET.
                 EarlyInit( devices: ["northbridge", "southbridge"] ),
+                // Detect S3 after PMBASE/PM1_CNT setup and before DRAM init.
+                ResumeDetect( device: "southbridge" ),
                 // DDR2 training needs SMBus (enabled by EarlyInit).
                 DramInit( device: "northbridge" ),
                 // Load the ramstage from FFS in flash and jump to it.
@@ -298,7 +307,6 @@
                 ConsoleInit( device: "superio" ),
                 BootMedia(MemoryMapped(
                     base: 0xFF000000, size: 0x01000000,
-                    ram_copy_addr: 0x2000000,
                 )),
                 SigVerify,
                 DriverInit,
@@ -316,6 +324,10 @@
                 // then SPI/SMI/TCO/BIOS-interface lockdown.
                 PostDramInit( devices: ["southbridge"] ),
                 FinalizeInit( devices: ["southbridge"] ),
+                // Cache the compressed ramstage FFS entry in firmware-owned RAM.
+                // TODO: move this address into board.smm/TSEG config once SMRAM
+                // cache reservation is schema-driven.
+                StageCacheSave(stage: "ramstage"),
                 // Temporarily skip SMM while debugging legacy IRQ/SERIRQ state.
                 // We clean ICH7 PM/GPE/SMI status in normal firmware code before
                 // Linux handoff instead of relying on the SMI handler.
@@ -422,6 +434,20 @@
             module_args: true,
         ),
     ),
+
+    // Compressed ramstage cache for S3 resume. This is regular RAM for now;
+    // StageCacheSave reserves it from e820 after copying the compressed FFS
+    // entry. Keep it below 0x03fff000: the ramstage handoff buffer lives at
+    // ramstage_entry(0x04000000) - 0x1000.
+    stage_cache: Some((
+        backend: Memory,
+        base: 0x03E00000,
+        size: 0x00100000,
+    )),
+
+    mrc_cache: Some((
+        size: 0x00010000,
+    )),
 
     payload: (
         kind: LinuxBoot,

--- a/boards/lenovo-x61/board.ron
+++ b/boards/lenovo-x61/board.ron
@@ -248,6 +248,13 @@
             ],
         ),
         (
+            name: "spi_flash",
+            driver: IntelSpi((
+                chipset: Ich8,
+                mode: Auto,
+            )),
+        ),
+        (
             name: "mainboard",
             driver: LenovoX61Mainboard((
                 dock_early_console: true,
@@ -266,6 +273,7 @@
                 PreConsoleInit( devices: ["northbridge", "southbridge", "mainboard"] ),
                 ConsoleInit( device: "uart0" ),
                 EarlyInit( devices: ["northbridge", "southbridge"] ),
+                ResumeDetect( device: "southbridge" ),
                 DramInit( device: "northbridge" ),
                 BootMedia(MemoryMapped( base: 0xFFE80000, size: 0x00180000 )),
                 StageLoad( next_stage: "ramstage" ),
@@ -284,7 +292,6 @@
                 BootMedia(MemoryMapped(
                     base: 0xFFE80000,
                     size: 0x00180000,
-                    ram_copy_addr: Some(0x02000000),
                 )),
                 SigVerify,
                 DriverInit,
@@ -374,6 +381,15 @@
             ( locator: "DIMM1" ),
         ],
     ),
+
+    stage_cache: Some((
+        backend: Tseg,
+        size: 0x00080000,
+    )),
+
+    mrc_cache: Some((
+        size: 0x00010000,
+    )),
 
     // CrabEFI UEFI payload — linked as a library.
     // No kernel file — CrabEFI boots via its EFI boot manager.

--- a/boards/qemu-q35-uefi/board.ron
+++ b/boards/qemu-q35-uefi/board.ron
@@ -99,8 +99,8 @@
                 AcpiLoad( device: "fw_cfg0" ),
                 PciInit( device: "pci0" ),
                 // FFS at flash offset 0x100000 — same as bootblock.
-                // Copied to RAM at 32 MiB for fast LZ4/SHA operations.
-                BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000, ram_copy_addr: Some(0x2000000) )),
+                // Read from the memory-mapped flash window.
+                BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000 )),
                 SigVerify,
                 PayloadLoad,
             ],

--- a/boards/qemu-q35/board.ron
+++ b/boards/qemu-q35/board.ron
@@ -71,8 +71,8 @@
             // FFS at flash offset 0x100000 (1 MiB) — after stage code, before boot block.
             // Stage code (.text + .rodata + .ltext) occupies ~640 KiB at the
             // start of flash; 1 MiB gives headroom for growth.
-            // On x86, codegen copies FFS to RAM before use (fast LZ4/SHA).
-            BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000, ram_copy_addr: Some(0x2000000) )),
+            // FFS is read from the memory-mapped flash window.
+            BootMedia(MemoryMapped( base: 0xFF900000, size: 0x006FF000 )),
             SigVerify,
             DriverInit,
             PayloadLoad,

--- a/crates/fstart-acpi/src/lib.rs
+++ b/crates/fstart-acpi/src/lib.rs
@@ -45,6 +45,7 @@ pub mod ext;
 pub mod gtdt;
 pub mod iort;
 pub mod platform;
+pub mod resume;
 pub mod sbsa;
 pub mod sink;
 pub mod spcr;

--- a/crates/fstart-acpi/src/resume.rs
+++ b/crates/fstart-acpi/src/resume.rs
@@ -1,0 +1,143 @@
+//! ACPI S3 wake-vector discovery.
+//!
+//! The S3 path must use the OS-owned ACPI tables left in memory, not newly
+//! generated firmware tables. This module scans the legacy BIOS area for the
+//! old RSDP, walks RSDT/XSDT to FADT, then reads the FACS firmware waking
+//! vector.
+
+/// Legacy BIOS area scanned by coreboot for the OS RSDP on S3 resume.
+pub const LEGACY_RSDP_SCAN_START: usize = 0x000e_0000;
+/// End of the legacy RSDP scan range, exclusive.
+pub const LEGACY_RSDP_SCAN_END: usize = 0x0010_0000;
+const RSDP_SIGNATURE: &[u8; 8] = b"RSD PTR ";
+const FADT_SIGNATURE: &[u8; 4] = b"FACP";
+
+/// Locate an ACPI S3 firmware waking vector from preserved OS tables.
+///
+/// # Safety
+///
+/// The caller must ensure the legacy BIOS area and ACPI physical addresses are
+/// identity-mapped and readable. This is intended for firmware running before
+/// paging changes on x86 resume.
+pub unsafe fn find_wakeup_vector_legacy() -> Option<u64> {
+    let mut addr = LEGACY_RSDP_SCAN_START;
+    while addr < LEGACY_RSDP_SCAN_END {
+        if let Some(vector) = unsafe { find_wakeup_vector_from_rsdp(addr) } {
+            return Some(vector);
+        }
+        addr += 16;
+    }
+    None
+}
+
+/// Locate an ACPI S3 firmware waking vector from a candidate RSDP address.
+///
+/// # Safety
+///
+/// `rsdp_addr` and table pointers discovered from it must be readable physical
+/// memory mappings.
+pub unsafe fn find_wakeup_vector_from_rsdp(rsdp_addr: usize) -> Option<u64> {
+    let rsdp = unsafe { core::slice::from_raw_parts(rsdp_addr as *const u8, 36) };
+    if &rsdp[0..8] != RSDP_SIGNATURE || checksum(&rsdp[..20]) != 0 {
+        return None;
+    }
+
+    let revision = rsdp[15];
+    let rsdt_addr = u32::from_le_bytes(rsdp[16..20].try_into().ok()?) as usize;
+
+    if revision >= 2 && checksum(rsdp) == 0 {
+        let xsdt_addr = u64::from_le_bytes(rsdp[24..32].try_into().ok()?) as usize;
+        if xsdt_addr != 0 {
+            if let Some(fadt) = unsafe { find_table(xsdt_addr, true, FADT_SIGNATURE) } {
+                return unsafe { wake_vector_from_fadt(fadt) };
+            }
+        }
+    }
+
+    if rsdt_addr != 0 {
+        if let Some(fadt) = unsafe { find_table(rsdt_addr, false, FADT_SIGNATURE) } {
+            return unsafe { wake_vector_from_fadt(fadt) };
+        }
+    }
+    None
+}
+
+unsafe fn find_table(root_addr: usize, xsdt: bool, signature: &[u8; 4]) -> Option<usize> {
+    let header = unsafe { core::slice::from_raw_parts(root_addr as *const u8, 36) };
+    checksum_table(root_addr)?;
+    let len = u32::from_le_bytes(header[4..8].try_into().ok()?) as usize;
+    if len < 36 {
+        return None;
+    }
+    let entry_size = if xsdt { 8 } else { 4 };
+    let entries = (len - 36) / entry_size;
+    let table = unsafe { core::slice::from_raw_parts(root_addr as *const u8, len) };
+    for i in 0..entries {
+        let off = 36 + i * entry_size;
+        let addr = if xsdt {
+            u64::from_le_bytes(table[off..off + 8].try_into().ok()?) as usize
+        } else {
+            u32::from_le_bytes(table[off..off + 4].try_into().ok()?) as usize
+        };
+        if addr == 0 {
+            continue;
+        }
+        let sig = unsafe { core::slice::from_raw_parts(addr as *const u8, 4) };
+        if sig == signature && checksum_table(addr).is_some() {
+            return Some(addr);
+        }
+    }
+    None
+}
+
+unsafe fn wake_vector_from_fadt(fadt_addr: usize) -> Option<u64> {
+    let fadt = unsafe { core::slice::from_raw_parts(fadt_addr as *const u8, 148) };
+    let len = u32::from_le_bytes(fadt[4..8].try_into().ok()?) as usize;
+    if len < 116 {
+        return None;
+    }
+
+    // FADT Firmware Control field at offset 36, X_Firmware_Control at 132.
+    let facs32 = u32::from_le_bytes(fadt[36..40].try_into().ok()?) as u64;
+    let facs = if len >= 140 {
+        let facs64 = u64::from_le_bytes(fadt[132..140].try_into().ok()?);
+        if facs64 != 0 {
+            facs64
+        } else {
+            facs32
+        }
+    } else {
+        facs32
+    };
+    if facs == 0 {
+        return None;
+    }
+
+    let facs_bytes = unsafe { core::slice::from_raw_parts(facs as usize as *const u8, 32) };
+    if &facs_bytes[0..4] != b"FACS" {
+        return None;
+    }
+    // FACS FirmwareWakingVector offset 12; XFirmwareWakingVector offset 24.
+    let vector32 = u32::from_le_bytes(facs_bytes[12..16].try_into().ok()?) as u64;
+    let vector64 = u64::from_le_bytes(facs_bytes[24..32].try_into().ok()?);
+    match (vector64, vector32) {
+        (v, _) if v != 0 => Some(v),
+        (_, v) if v != 0 => Some(v),
+        _ => None,
+    }
+}
+
+fn checksum_table(addr: usize) -> Option<()> {
+    // SAFETY: caller arranged that ACPI physical tables are readable.
+    let header = unsafe { core::slice::from_raw_parts(addr as *const u8, 36) };
+    let len = u32::from_le_bytes(header[4..8].try_into().ok()?) as usize;
+    if len < 36 {
+        return None;
+    }
+    let bytes = unsafe { core::slice::from_raw_parts(addr as *const u8, len) };
+    (checksum(bytes) == 0).then_some(())
+}
+
+fn checksum(bytes: &[u8]) -> u8 {
+    bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte))
+}

--- a/crates/fstart-capabilities/Cargo.toml
+++ b/crates/fstart-capabilities/Cargo.toml
@@ -35,3 +35,4 @@ fstart-fit = { workspace = true, optional = true }
 fstart-smbios = { workspace = true, optional = true }
 fstart-acpi = { workspace = true, optional = true }
 postcard = { workspace = true, optional = true }
+zerocopy = { workspace = true }

--- a/crates/fstart-capabilities/src/lib.rs
+++ b/crates/fstart-capabilities/src/lib.rs
@@ -41,7 +41,10 @@ pub mod fit;
 #[cfg(feature = "handoff")]
 pub mod handoff;
 
+pub mod mrc_cache;
 pub mod next_stage;
+#[cfg(feature = "ffs")]
+pub mod stage_cache;
 
 #[cfg(feature = "smbios")]
 pub mod smbios;

--- a/crates/fstart-capabilities/src/mrc_cache.rs
+++ b/crates/fstart-capabilities/src/mrc_cache.rs
@@ -1,0 +1,216 @@
+//! Generic MRC/training-data cache record helpers.
+//!
+//! This mirrors coreboot's split: chipset RAM init owns platform validation
+//! (CPU id, SPD CRCs, expected struct size), while the generic layer owns a
+//! small persistent-record format and integrity checks. Storage is discovered
+//! through a named FFS raw region; board RON controls the region size, not a
+//! hardcoded SPI offset.
+
+use fstart_services::{BootMedia, ServiceError};
+#[cfg(feature = "ffs")]
+use fstart_types::ffs::RegionContent;
+use zerocopy::byteorder::{LE, U16, U32};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+/// Coreboot-compatible-ish training-data cache signature: `MRCD`.
+pub const MRC_CACHE_SIGNATURE: u32 = u32::from_le_bytes(*b"MRCD");
+/// fstart record format version.
+pub const MRC_CACHE_FORMAT_VERSION: u16 = 1;
+/// Default FFS raw-region name for MRC/training data.
+pub const DEFAULT_MRC_CACHE_REGION: &str = "mrc-cache";
+
+/// Persistent metadata header stored immediately before MRC payload bytes.
+#[derive(Debug, Clone, Copy, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned)]
+#[repr(C)]
+pub struct MrcCacheHeader {
+    /// Magic signature, [`MRC_CACHE_SIGNATURE`].
+    pub signature: U32<LE>,
+    /// Generic fstart record format version.
+    pub format_version: U16<LE>,
+    /// Platform-owned cache ABI version.
+    pub data_version: U16<LE>,
+    /// FNV-1a hash of the rustc version string used to build the payload.
+    ///
+    /// This is part of the ABI guard for cached native Rust structs. The
+    /// chipset owner supplies the value because it knows whether the payload is
+    /// a raw Rust struct or a stable hand-serialized format.
+    pub rustc_version_hash: U32<LE>,
+    /// Payload size in bytes.
+    pub data_size: U32<LE>,
+    /// FNV-1a hash of payload bytes.
+    pub data_hash: U32<LE>,
+    /// FNV-1a hash of this header with `header_hash` zeroed.
+    pub header_hash: U32<LE>,
+}
+
+impl MrcCacheHeader {
+    /// Serialized header size.
+    pub const SIZE: usize = 24;
+
+    /// Build a header for `data` and platform `data_version`.
+    pub fn new(data_version: u16, rustc_version_hash: u32, data: &[u8]) -> Self {
+        let mut header = Self {
+            signature: U32::new(MRC_CACHE_SIGNATURE),
+            format_version: U16::new(MRC_CACHE_FORMAT_VERSION),
+            data_version: U16::new(data_version),
+            rustc_version_hash: U32::new(rustc_version_hash),
+            data_size: U32::new(data.len() as u32),
+            data_hash: U32::new(fnv1a32(data)),
+            header_hash: U32::new(0),
+        };
+        header.header_hash = U32::new(header.compute_header_hash());
+        header
+    }
+
+    /// Parse a little-endian header from bytes.
+    pub fn parse(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < Self::SIZE {
+            return None;
+        }
+        let header = Self::ref_from_bytes(&bytes[..Self::SIZE]).ok()?;
+        Some(*header)
+    }
+
+    /// Write this header to `out` in little-endian form.
+    pub fn write_to(self, out: &mut [u8]) -> Result<(), ServiceError> {
+        if out.len() < Self::SIZE {
+            return Err(ServiceError::InvalidParam);
+        }
+        out[..Self::SIZE].copy_from_slice(self.as_bytes());
+        Ok(())
+    }
+
+    /// Validate header fields and payload integrity.
+    pub fn validate(
+        self,
+        expected_data_version: u16,
+        expected_rustc_version_hash: u32,
+        data: &[u8],
+    ) -> Result<(), MrcCacheError> {
+        if self.signature.get() != MRC_CACHE_SIGNATURE {
+            return Err(MrcCacheError::BadSignature);
+        }
+        if self.format_version.get() != MRC_CACHE_FORMAT_VERSION
+            || self.data_version.get() != expected_data_version
+        {
+            return Err(MrcCacheError::VersionMismatch);
+        }
+        if self.rustc_version_hash.get() != expected_rustc_version_hash {
+            return Err(MrcCacheError::RustcVersionMismatch);
+        }
+        if self.data_size.get() as usize != data.len() {
+            return Err(MrcCacheError::SizeMismatch);
+        }
+        if self.compute_header_hash() != self.header_hash.get() {
+            return Err(MrcCacheError::HeaderHashMismatch);
+        }
+        if fnv1a32(data) != self.data_hash.get() {
+            return Err(MrcCacheError::DataHashMismatch);
+        }
+        Ok(())
+    }
+
+    fn compute_header_hash(self) -> u32 {
+        let mut buf = [0u8; Self::SIZE];
+        let mut tmp = self;
+        tmp.header_hash = U32::new(0);
+        let _ = tmp.write_to(&mut buf);
+        fnv1a32(&buf)
+    }
+}
+
+/// MRC cache validation error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MrcCacheError {
+    /// Cache header magic is not `MRCD`.
+    BadSignature,
+    /// Generic format or platform data version mismatch.
+    VersionMismatch,
+    /// Cached payload was produced by a different rustc version.
+    RustcVersionMismatch,
+    /// Header payload size does not match supplied data.
+    SizeMismatch,
+    /// Header integrity hash mismatch.
+    HeaderHashMismatch,
+    /// Payload integrity hash mismatch.
+    DataHashMismatch,
+    /// Configured FFS region is not a raw cache region.
+    BadRegion,
+    /// Storage I/O failed.
+    Io,
+}
+
+/// Locate the configured MRC cache raw region in an FFS manifest.
+#[cfg(feature = "ffs")]
+pub fn find_region(
+    media: &impl BootMedia,
+    anchor_data: &[u8],
+    name: &str,
+) -> Result<(usize, usize), MrcCacheError> {
+    let anchor = unsafe { fstart_ffs::FfsReader::read_anchor_volatile(anchor_data) }
+        .map_err(|_| MrcCacheError::Io)?;
+    let manifest =
+        crate::read_manifest_from_media(media, &anchor).map_err(|_| MrcCacheError::Io)?;
+    let region =
+        fstart_ffs::FfsReader::find_region(&manifest, name).map_err(|_| MrcCacheError::Io)?;
+    if !matches!(region.content, RegionContent::Raw { .. }) {
+        return Err(MrcCacheError::BadRegion);
+    }
+    Ok((region.offset as usize, region.size as usize))
+}
+
+/// Read and validate one MRC cache record from `media` at `offset`.
+pub fn read_record(
+    media: &impl BootMedia,
+    offset: usize,
+    expected_data_version: u16,
+    expected_rustc_version_hash: u32,
+    out: &mut [u8],
+) -> Result<usize, MrcCacheError> {
+    let mut header_buf = [0u8; MrcCacheHeader::SIZE];
+    media
+        .read_at(offset, &mut header_buf)
+        .map_err(|_| MrcCacheError::Io)?;
+    let header = MrcCacheHeader::parse(&header_buf).ok_or(MrcCacheError::BadSignature)?;
+    let size = header.data_size.get() as usize;
+    if size > out.len() {
+        return Err(MrcCacheError::SizeMismatch);
+    }
+    media
+        .read_at(offset + MrcCacheHeader::SIZE, &mut out[..size])
+        .map_err(|_| MrcCacheError::Io)?;
+    header.validate(
+        expected_data_version,
+        expected_rustc_version_hash,
+        &out[..size],
+    )?;
+    Ok(size)
+}
+
+/// Build a record in `out`, returning total bytes written.
+pub fn build_record(
+    data_version: u16,
+    rustc_version_hash: u32,
+    data: &[u8],
+    out: &mut [u8],
+) -> Result<usize, ServiceError> {
+    let total = MrcCacheHeader::SIZE
+        .checked_add(data.len())
+        .ok_or(ServiceError::InvalidParam)?;
+    if out.len() < total {
+        return Err(ServiceError::InvalidParam);
+    }
+    MrcCacheHeader::new(data_version, rustc_version_hash, data)
+        .write_to(&mut out[..MrcCacheHeader::SIZE])?;
+    out[MrcCacheHeader::SIZE..total].copy_from_slice(data);
+    Ok(total)
+}
+
+fn fnv1a32(bytes: &[u8]) -> u32 {
+    let mut hash = 0x811c_9dc5u32;
+    for byte in bytes {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}

--- a/crates/fstart-capabilities/src/next_stage.rs
+++ b/crates/fstart-capabilities/src/next_stage.rs
@@ -57,6 +57,12 @@ pub fn read_stage_to_addr(
 #[cfg(feature = "handoff")]
 pub fn serialize_handoff(dram_size: u64, handoff_addr: u64) -> Result<usize, &'static str> {
     let handoff_data = fstart_types::handoff::StageHandoff::new(dram_size);
+    #[cfg(target_arch = "x86_64")]
+    let handoff_data = {
+        let mut handoff_data = handoff_data;
+        handoff_data.resume.boot_path = fstart_services::resume::boot_path();
+        handoff_data
+    };
     // SAFETY: handoff_addr points to writable RAM, 4K below next stage load_addr.
     let handoff_buf = unsafe {
         core::slice::from_raw_parts_mut(

--- a/crates/fstart-capabilities/src/stage_cache.rs
+++ b/crates/fstart-capabilities/src/stage_cache.rs
@@ -1,0 +1,199 @@
+//! Persistent compressed-stage cache helpers.
+//!
+//! The cache stores the already-compressed FFS entry bytes. On resume, firmware
+//! can copy this entry back into a scratch/loader path and use the normal FFS
+//! segment decompressor, avoiding SPI reads for the ramstage body.
+
+use fstart_services::{BootMedia, ServiceError, StageCacheProvider};
+use fstart_types::ffs::EntryContent;
+
+/// Stage-cache header magic: `FSC1`.
+pub const STAGE_CACHE_MAGIC: u32 = u32::from_le_bytes(*b"FSC1");
+/// Stage-cache format version.
+pub const STAGE_CACHE_VERSION: u16 = 1;
+
+/// Header stored before cached compressed FFS entry bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C, packed)]
+pub struct StageCacheHeader {
+    /// Magic signature.
+    pub magic: u32,
+    /// Format version.
+    pub version: u16,
+    /// Header size in bytes.
+    pub header_size: u16,
+    /// Cached FFS entry size in bytes.
+    pub entry_size: u32,
+    /// FNV-1a hash of cached entry bytes.
+    pub entry_hash: u32,
+    /// Original FFS image offset of the cached entry.
+    pub source_offset: u32,
+}
+
+impl StageCacheHeader {
+    /// Serialized header size.
+    pub const SIZE: usize = 20;
+
+    /// Build a header for cached bytes.
+    pub fn new(source_offset: u32, entry: &[u8]) -> Self {
+        Self {
+            magic: STAGE_CACHE_MAGIC,
+            version: STAGE_CACHE_VERSION,
+            header_size: Self::SIZE as u16,
+            entry_size: entry.len() as u32,
+            entry_hash: fnv1a32(entry),
+            source_offset,
+        }
+    }
+
+    /// Write the header to a byte slice.
+    pub fn write_to(self, out: &mut [u8]) -> Result<(), ServiceError> {
+        if out.len() < Self::SIZE {
+            return Err(ServiceError::InvalidParam);
+        }
+        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
+        out[4..6].copy_from_slice(&self.version.to_le_bytes());
+        out[6..8].copy_from_slice(&self.header_size.to_le_bytes());
+        out[8..12].copy_from_slice(&self.entry_size.to_le_bytes());
+        out[12..16].copy_from_slice(&self.entry_hash.to_le_bytes());
+        out[16..20].copy_from_slice(&self.source_offset.to_le_bytes());
+        Ok(())
+    }
+}
+
+/// Save one named stage into a normal-RAM cache and reserve it from E820.
+#[cfg(feature = "ffs")]
+pub fn save_stage_cache_memory(
+    anchor_data: &[u8],
+    media: &impl BootMedia,
+    stage_name: &str,
+    cache_base: u64,
+    cache_size: u64,
+) -> Result<(), ServiceError> {
+    save_compressed_stage_to_cache(
+        anchor_data,
+        media,
+        stage_name,
+        cache_base,
+        cache_size as usize,
+    )?;
+    unsafe {
+        fstart_services::memory_detect::e820_state_mut().reserve_range(cache_base, cache_size);
+    }
+    Ok(())
+}
+
+/// Save one named stage into a provider-owned TSEG/SMRAM cache.
+#[cfg(feature = "ffs")]
+pub fn save_stage_cache_tseg(
+    anchor_data: &[u8],
+    media: &impl BootMedia,
+    stage_name: &str,
+    requested_size: u64,
+    provider: &impl StageCacheProvider,
+) -> Result<(), ServiceError> {
+    let (cache_base, cache_size) = provider
+        .stage_cache_region(requested_size)
+        .ok_or(ServiceError::InvalidParam)?;
+    provider.stage_cache_open()?;
+    let result = save_compressed_stage_to_cache(
+        anchor_data,
+        media,
+        stage_name,
+        cache_base,
+        cache_size as usize,
+    );
+    let close_result = provider.stage_cache_close();
+    result?;
+    close_result?;
+    Ok(())
+}
+
+/// Open a provider-owned stage cache and return its physical range.
+///
+/// The caller owns the matching close. This is used by x86 post-CAR stage load,
+/// which intentionally keeps SMRAM open across a non-returning jump and lets the
+/// next stage close it before MP/SMM initialization.
+pub fn open_stage_cache_provider(
+    provider: &impl StageCacheProvider,
+    requested_size: u64,
+) -> Result<(u64, u64), ServiceError> {
+    let (base, size) = provider
+        .stage_cache_region(requested_size)
+        .ok_or(ServiceError::InvalidParam)?;
+    provider.stage_cache_open()?;
+    Ok((base, size))
+}
+
+/// Close a provider-owned stage cache before SMM/MP initialization claims SMRAM.
+pub fn close_stage_cache_provider(provider: &impl StageCacheProvider) -> Result<(), ServiceError> {
+    provider.stage_cache_close()
+}
+
+/// Copy one named stage's compressed FFS entry bytes to a firmware-owned cache.
+///
+/// The destination should be reserved memory, preferably SMRAM/TSEG while open.
+#[cfg(feature = "ffs")]
+fn save_compressed_stage_to_cache(
+    anchor_data: &[u8],
+    media: &impl BootMedia,
+    stage_name: &str,
+    cache_base: u64,
+    cache_size: usize,
+) -> Result<(), ServiceError> {
+    if cache_size < StageCacheHeader::SIZE {
+        return Err(ServiceError::InvalidParam);
+    }
+    let anchor = unsafe { fstart_ffs::FfsReader::read_anchor_volatile(anchor_data) }
+        .map_err(|_| ServiceError::IoError)?;
+    let manifest =
+        crate::read_manifest_from_media(media, &anchor).map_err(|_| ServiceError::IoError)?;
+    let image_size = if anchor.total_image_size == 0 {
+        media.size()
+    } else {
+        (anchor.total_image_size as usize).min(media.size())
+    };
+
+    for region in &manifest.regions {
+        let Ok(entry) = fstart_ffs::FfsReader::find_entry(region, stage_name) else {
+            continue;
+        };
+        let EntryContent::File { .. } = &entry.content else {
+            continue;
+        };
+        let source_offset = (region.offset + entry.offset) as usize;
+        let entry_size = entry.size as usize;
+        let total = StageCacheHeader::SIZE
+            .checked_add(entry_size)
+            .ok_or(ServiceError::InvalidParam)?;
+        if total > cache_size || source_offset.saturating_add(entry_size) > image_size {
+            return Err(ServiceError::InvalidParam);
+        }
+
+        let cache = unsafe { core::slice::from_raw_parts_mut(cache_base as *mut u8, total) };
+        media
+            .read_at(source_offset, &mut cache[StageCacheHeader::SIZE..])
+            .map_err(|_| ServiceError::IoError)?;
+        StageCacheHeader::new(source_offset as u32, &cache[StageCacheHeader::SIZE..])
+            .write_to(&mut cache[..StageCacheHeader::SIZE])?;
+        fstart_log::info!(
+            "stage_cache: saved '{}' entry offset={:#x} size={:#x} cache={:#x}",
+            stage_name,
+            source_offset as u64,
+            entry_size as u64,
+            cache_base,
+        );
+        return Ok(());
+    }
+
+    Err(ServiceError::InvalidParam)
+}
+
+fn fnv1a32(bytes: &[u8]) -> u32 {
+    let mut hash = 0x811c_9dc5u32;
+    for byte in bytes {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}

--- a/crates/fstart-codegen/src/ron_loader.rs
+++ b/crates/fstart-codegen/src/ron_loader.rs
@@ -87,6 +87,10 @@ struct RonBoardConfig {
     #[serde(default)]
     smm: Option<fstart_types::smm::SmmConfig>,
     #[serde(default)]
+    stage_cache: Option<fstart_types::resume::StageCacheConfig>,
+    #[serde(default)]
+    mrc_cache: Option<fstart_types::board::MrcCacheConfig>,
+    #[serde(default)]
     boot_hart_id: u32,
 }
 
@@ -228,6 +232,8 @@ fn convert(ron: RonBoardConfig) -> Result<ParsedBoard, String> {
         acpi: ron.acpi,
         smbios: ron.smbios,
         smm: ron.smm,
+        stage_cache: ron.stage_cache,
+        mrc_cache: ron.mrc_cache,
         boot_hart_id: ron.boot_hart_id,
     };
 

--- a/crates/fstart-codegen/src/stage_gen/board_gen/board_impl.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/board_impl.rs
@@ -11,7 +11,7 @@ use super::caps_tables::{
     acpi_load_body, acpi_prepare_body, memory_detect_body, smbios_prepare_body,
 };
 use super::fdt::{fdt_prepare_body, return_to_fel_body, stage_load_body};
-use super::init_caps::{dram_init_body, late_driver_init_body, pci_init_body};
+use super::init_caps::{dram_init_body, late_driver_init_body, pci_init_body, resume_detect_body};
 use super::lifecycle::{init_all_devices_body, init_device_body};
 use super::logger::install_logger_body;
 use super::model::BoardEmitModel;
@@ -22,21 +22,18 @@ use super::sunxi::{boot_media_select_body, load_next_stage_body};
 
 /// Emit the `impl fstart_stage_runtime::Board for _BoardDevices` block.
 pub(super) fn emit_board_impl(platform: Platform, ctx: &BoardEmitModel<'_>) -> TokenStream {
-    let jump_with_handoff_body = match platform {
-        Platform::X86_64 => quote! {
-            let _ = (entry, handoff_addr);
-            fstart_platform::halt()
-        },
-        _ => quote! { fstart_platform::jump_to_with_handoff(entry, handoff_addr) },
-    };
+    let jump_with_handoff_body =
+        quote! { fstart_platform::jump_to_with_handoff(entry, handoff_addr) };
 
     let sig_verify_body = super::security::sig_verify_body(ctx);
     let fdt_prepare_body = fdt_prepare_body(platform, ctx);
     let install_logger_body = install_logger_body(ctx);
     let stage_load_body = stage_load_body(ctx);
+    let stage_cache_save_body = super::fdt::stage_cache_save_body(ctx);
     let return_to_fel_body = return_to_fel_body(platform, ctx);
     let pci_init_body = pci_init_body(ctx);
     let dram_init_body = dram_init_body(ctx);
+    let resume_detect_body = resume_detect_body(ctx);
     let pre_console_init_body = phase_init_body(
         ctx,
         PhaseSpec::new(
@@ -77,6 +74,16 @@ pub(super) fn emit_board_impl(platform: Platform, ctx: &BoardEmitModel<'_>) -> T
     let init_device_body = init_device_body(ctx);
     let init_all_devices_body = init_all_devices_body(ctx);
     let late_driver_init_body = late_driver_init_body(ctx);
+    let acpi_s3_resume_body = if platform == Platform::X86_64 {
+        quote! {
+            match fstart_services::resume::boot_path() {
+                fstart_types::BootPath::S3Resume => fstart_platform::acpi_s3_resume(),
+                fstart_types::BootPath::Normal => fstart_platform::halt(),
+            }
+        }
+    } else {
+        quote! { fstart_platform::halt() }
+    };
     let boot_media_context_publish = if ctx.stage.uses_ffs {
         let anchor = anchor_bytes_stmt();
         quote! {
@@ -107,6 +114,10 @@ pub(super) fn emit_board_impl(platform: Platform, ctx: &BoardEmitModel<'_>) -> T
                 #init_all_devices_body
             }
 
+            fn set_handoff(&mut self, handoff: Option<fstart_types::handoff::StageHandoff>) {
+                self._handoff = handoff;
+            }
+
             unsafe fn install_logger(&self, id: fstart_types::DeviceId) {
                 #install_logger_body
             }
@@ -124,8 +135,12 @@ pub(super) fn emit_board_impl(platform: Platform, ctx: &BoardEmitModel<'_>) -> T
             fn fdt_prepare(&self) { #fdt_prepare_body }
             fn payload_load(&self) -> ! { #payload_load_body }
             fn stage_load(&self, next_stage: &str) -> ! { #stage_load_body }
+            fn stage_cache_save(&self, stage: &str) {
+                #stage_cache_save_body
+            }
             fn acpi_prepare(&mut self) { #acpi_prepare_body }
             fn smbios_prepare(&self) { #smbios_prepare_body }
+            fn acpi_s3_resume(&self) -> ! { #acpi_s3_resume_body }
 
             fn mp_init(
                 &mut self,
@@ -176,6 +191,13 @@ pub(super) fn emit_board_impl(platform: Platform, ctx: &BoardEmitModel<'_>) -> T
                 id: fstart_types::DeviceId,
             ) -> Result<(), fstart_services::device::DeviceError> {
                 #dram_init_body
+            }
+
+            fn resume_detect(
+                &mut self,
+                id: fstart_types::DeviceId,
+            ) -> Result<(), fstart_services::device::DeviceError> {
+                #resume_detect_body
             }
 
             fn pci_init(

--- a/crates/fstart-codegen/src/stage_gen/board_gen/fdt.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/fdt.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use fstart_types::memory::{FlashLayout, RegionKind};
-use fstart_types::{Capability, FdtSource, PayloadConfig, Platform};
+use fstart_types::{Capability, FdtSource, PayloadConfig, Platform, StageCacheBackend};
 
 use crate::stage_gen::tokens::hex_addr;
 
@@ -163,10 +163,53 @@ pub(super) fn stage_load_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
 
     if ctx.config.platform == Platform::X86_64 {
         let postcar_config = x86_postcar_config_tokens(ctx);
+        let cache_setup = match ctx.config.stage_cache {
+            Some(cache) if cache.backend == StageCacheBackend::Tseg => {
+                let providers: Vec<_> = ctx
+                    .runtime_devices
+                    .providers(fstart_device_registry::Service::StageCacheProvider)
+                    .collect();
+                let cache_size = hex_addr(cache.size);
+                if providers.len() == 1 {
+                    let field = quote::format_ident!("{}", providers[0].name);
+                    quote! {
+                        let mut _stage_cache_base = 0u64;
+                        let mut _stage_cache_size = 0u64;
+                        if let Some(provider) = self.#field.as_ref() {
+                            match fstart_capabilities::stage_cache::open_stage_cache_provider(
+                                provider,
+                                #cache_size,
+                            ) {
+                                Ok((base, size)) => {
+                                    // Keep SMRAM open across this non-returning StageLoad so
+                                    // the post-CAR loader can populate/read the TSEG cache.
+                                    // The next stage closes it during MP/SMM init, matching
+                                    // coreboot's open-copy-close ownership model.
+                                    _stage_cache_base = base;
+                                    _stage_cache_size = size;
+                                }
+                                Err(_) => {
+                                    fstart_log::error!("stage_load: failed to open TSEG stage cache");
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    quote! { let (_stage_cache_base, _stage_cache_size) = (0u64, 0u64); }
+                }
+            }
+            Some(cache) if cache.backend == StageCacheBackend::Memory => {
+                let cache_base = hex_addr(cache.base);
+                let cache_size = hex_addr(cache.size);
+                quote! { let (_stage_cache_base, _stage_cache_size) = (#cache_base, #cache_size); }
+            }
+            _ => quote! { let (_stage_cache_base, _stage_cache_size) = (0u64, 0u64); },
+        };
         return quote! {
             fstart_log::info!("stage_load: generated trampoline enter");
             #anchor
             #postcar_config
+            #cache_setup
             fstart_log::info!("stage_load: anchor slice ready");
             match self._boot_media {
                 fstart_stage_runtime::BootMediaState::Mmio { base, size } => {
@@ -181,6 +224,8 @@ pub(super) fn stage_load_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
                             _anchor_bytes,
                             base,
                             size,
+                            _stage_cache_base,
+                            _stage_cache_size,
                         );
                     }
                 }
@@ -217,6 +262,78 @@ pub(super) fn stage_load_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
             "stage_load: capability returned without jumping — halting",
         );
         fstart_platform::halt()
+    }
+}
+
+/// Emit the body of `Board::stage_cache_save`.
+pub(super) fn stage_cache_save_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
+    if !ctx.stage.uses_ffs {
+        return quote! {
+            let _ = stage;
+            fstart_log::error!("stage_cache_save: stage does not use FFS");
+        };
+    }
+    let Some(cache) = ctx.config.stage_cache else {
+        return quote! {
+            let _ = stage;
+            fstart_log::error!("stage_cache_save: board.stage_cache is not configured");
+        };
+    };
+
+    let anchor = anchor_bytes_stmt();
+    let cache_size = hex_addr(cache.size);
+    let usage = match cache.backend {
+        StageCacheBackend::Memory => {
+            let cache_base = hex_addr(cache.base);
+            quote! {
+                if let Err(_) = fstart_capabilities::stage_cache::save_stage_cache_memory(
+                    _anchor_bytes,
+                    &_bm,
+                    stage,
+                    #cache_base,
+                    #cache_size,
+                ) {
+                    fstart_log::error!("stage_cache_save: failed to cache '{}'", stage);
+                }
+            }
+        }
+        StageCacheBackend::Tseg => {
+            let providers: Vec<_> = ctx
+                .runtime_devices
+                .providers(fstart_device_registry::Service::StageCacheProvider)
+                .collect();
+            if providers.len() != 1 {
+                quote! {
+                    fstart_log::error!("stage_cache_save: TSEG backend requires exactly one StageCacheProvider");
+                }
+            } else {
+                let field = quote::format_ident!("{}", providers[0].name);
+                quote! {
+                    let Some(provider) = self.#field.as_ref() else {
+                        fstart_log::error!("stage_cache_save: StageCacheProvider not initialized");
+                        return;
+                    };
+                    if fstart_capabilities::stage_cache::save_stage_cache_tseg(
+                        _anchor_bytes,
+                        &_bm,
+                        stage,
+                        #cache_size,
+                        provider,
+                    ).is_err() {
+                        fstart_log::error!("stage_cache_save: failed to cache '{}'", stage);
+                    }
+                }
+            }
+        }
+    };
+    let none_body = quote! {
+        fstart_log::error!("stage_cache_save: no boot media configured");
+    };
+    let match_body = match_boot_media(ctx, &usage, "stage_cache_save", &none_body);
+
+    quote! {
+        #anchor
+        #match_body
     }
 }
 

--- a/crates/fstart-codegen/src/stage_gen/board_gen/init_caps.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/init_caps.rs
@@ -21,8 +21,11 @@ pub(super) fn dram_init_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
                     let dev = self.#field
                         .as_mut()
                         .ok_or(fstart_services::device::DeviceError::InitFailed)?;
-                    _MemoryController::dram_init(dev)
-                        .map_err(|_| fstart_services::device::DeviceError::InitFailed)?;
+                    _MemoryController::dram_init_with_boot_path(
+                        dev,
+                        fstart_services::resume::boot_path(),
+                    )
+                    .map_err(|_| fstart_services::device::DeviceError::InitFailed)?;
                     Ok(())
                 }
             }
@@ -34,6 +37,44 @@ pub(super) fn dram_init_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
             #(#arms)*
             _ => {
                 fstart_log::error!("dram_init: unknown MemoryController id {}", id);
+                Err(fstart_services::device::DeviceError::InitFailed)
+            }
+        }
+    }
+}
+
+/// Emit the body of `Board::resume_detect`.
+pub(super) fn resume_detect_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
+    let arms: Vec<TokenStream> = ctx
+        .runtime_devices
+        .providers(Service::ResumeDetector)
+        .map(|device| {
+            let field = format_ident!("{}", device.name);
+            let id_lit = proc_macro2::Literal::u8_unsuffixed(device.index as u8);
+            quote! {
+                #id_lit => {
+                    use fstart_services::ResumeDetector as _ResumeDetector;
+                    let dev = self.#field
+                        .as_mut()
+                        .ok_or(fstart_services::device::DeviceError::InitFailed)?;
+                    let path = _ResumeDetector::detect_boot_path(dev)
+                        .map_err(|_| fstart_services::device::DeviceError::InitFailed)?;
+                    fstart_services::resume::set_boot_path(path);
+                    match path {
+                        fstart_types::BootPath::Normal => fstart_log::info!("resume_detect: normal boot"),
+                        fstart_types::BootPath::S3Resume => fstart_log::info!("resume_detect: ACPI S3 resume"),
+                    }
+                    Ok(())
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        match id {
+            #(#arms)*
+            _ => {
+                fstart_log::error!("resume_detect: unknown ResumeDetector id {}", id);
                 Err(fstart_services::device::DeviceError::InitFailed)
             }
         }

--- a/crates/fstart-codegen/src/stage_gen/board_gen/lifecycle.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/lifecycle.rs
@@ -200,10 +200,7 @@ pub(super) fn init_all_devices_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
 
     let bm_preamble = if has_any_gated && is_egon {
         quote! {
-            // SAFETY: _egon_sram_base is the BROM entry point.
-            let _bm = unsafe {
-                fstart_soc_sunxi::boot_media_at(self._egon_sram_base as usize)
-            };
+            let _bm = fstart_soc_sunxi::boot_media_at(self._egon_sram_base as usize);
         }
     } else {
         quote! { let _ = gated; }

--- a/crates/fstart-codegen/src/stage_gen/board_gen/mp.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/mp.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use fstart_device_registry::Service;
-use fstart_types::{BootMedium, Capability};
+use fstart_types::{BootMedium, Capability, StageCacheBackend};
 
 use crate::stage_gen::tokens::hex_addr;
 
@@ -93,6 +93,35 @@ pub(super) fn mp_init_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
         })
         .unwrap_or_else(|| quote! { None });
 
+    let stage_cache_close = match ctx.config.stage_cache {
+        Some(cache) if cache.backend == StageCacheBackend::Tseg => {
+            let providers: Vec<_> = ctx
+                .runtime_devices
+                .providers(Service::StageCacheProvider)
+                .collect();
+            if providers.len() == 1 {
+                let field = format_ident!("{}", providers[0].name);
+                quote! {
+                    if let Some(provider) = self.#field.as_ref() {
+                        // X86 StageLoad may intentionally leave SMRAM open so the
+                        // post-CAR loader can populate/read the TSEG stage cache.
+                        // Close it at MP/SMM setup time, like coreboot, before
+                        // normal payload execution continues. If SMM is enabled,
+                        // SmmOps may reopen it for handler installation and close
+                        // it again from post_smm_init().
+                        if fstart_capabilities::stage_cache::close_stage_cache_provider(provider).is_err() {
+                            fstart_log::error!("mp: failed to close TSEG stage cache");
+                            return Err(fstart_stage_runtime::RuntimeError::Failed);
+                        }
+                    }
+                }
+            } else {
+                quote! {}
+            }
+        }
+        _ => quote! {},
+    };
+
     let smm_ops_expr = if let Some(idx) = smm_provider {
         let field = format_ident!("{}", ctx.devices[idx].name.as_str());
         quote! {
@@ -119,6 +148,7 @@ pub(super) fn mp_init_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
     };
 
     quote! {
+        #stage_cache_close
         let smm_ops: Option<&dyn fstart_mp::SmmOps> = #smm_ops_expr;
         let smm_image: Option<&[u8]> = #smm_image_expr;
         let microcode_blob: Option<&'static [u8]> = #microcode_expr;

--- a/crates/fstart-codegen/src/stage_gen/board_gen/sunxi.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/sunxi.rs
@@ -29,11 +29,7 @@ pub(super) fn boot_media_select_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
     }
 
     quote! {
-        // SAFETY: _egon_sram_base is the BROM entry point where the
-        // eGON header is mapped in SRAM.
-        let _bm = unsafe {
-            fstart_soc_sunxi::boot_media_at(self._egon_sram_base as usize)
-        };
+        let _bm = fstart_soc_sunxi::boot_media_at(self._egon_sram_base as usize);
         fstart_log::info!("boot media detect: {:#x}", _bm);
         for candidate in candidates {
             if candidate.media_ids.iter().any(|&id| id == _bm) {
@@ -160,9 +156,9 @@ pub(super) fn load_next_stage_body(ctx: &BoardEmitModel<'_>) -> TokenStream {
         };
 
         let ns_ffs_offset =
-            unsafe { fstart_soc_sunxi::next_stage_offset_at(self._egon_sram_base as usize) } as u64;
+            fstart_soc_sunxi::next_stage_offset_at(self._egon_sram_base as usize) as u64;
         let ns_size =
-            unsafe { fstart_soc_sunxi::next_stage_size_at(self._egon_sram_base as usize) } as usize;
+            fstart_soc_sunxi::next_stage_size_at(self._egon_sram_base as usize) as usize;
         if ns_ffs_offset == 0 || ns_size == 0 {
             fstart_log::error!("FATAL: eGON header has zero next_stage_offset/size");
             fstart_platform::halt();

--- a/crates/fstart-codegen/src/stage_gen/board_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/board_gen/tests.rs
@@ -181,16 +181,12 @@ fn adapter_compiles_for_qemu_armv7() {
 }
 
 #[test]
-fn x86_adapter_has_jump_to_with_handoff_fallback() {
-    // On x86_64, fstart_platform has no jump_to_with_handoff; the
-    // emitter must substitute halt() so the trait impl still
-    // type-checks in downstream firmware builds.
+fn x86_adapter_has_jump_to_with_handoff() {
     let src = adapter_source_for_board("qemu-q35");
     assert!(src.contains("impl fstart_stage_runtime::Board for _BoardDevices"));
-    // Ensure we did not emit a call to the missing symbol.
     assert!(
-        !src.contains("fstart_platform::jump_to_with_handoff"),
-        "x86 adapter must not reference the non-existent jump_to_with_handoff; got:\n{src}"
+        src.contains("fstart_platform::jump_to_with_handoff"),
+        "x86 adapter should use platform handoff jump; got:\n{src}"
     );
 }
 

--- a/crates/fstart-codegen/src/stage_gen/direct_flow.rs
+++ b/crates/fstart-codegen/src/stage_gen/direct_flow.rs
@@ -149,6 +149,18 @@ fn capability_tokens(idx: usize, cap: &Capability, ctx: &DirectCtx<'_>) -> Token
                 _inited.set(#id);
             }
         }
+        C::ResumeDetect { device } => {
+            let id = ctx.ids.lit(device.as_str(), "ResumeDetect");
+            quote! {
+                if fstart_stage_runtime::Board::init_device(&mut board, #id).is_err() {
+                    fstart_stage_runtime::Board::halt(&board);
+                }
+                if fstart_stage_runtime::Board::resume_detect(&mut board, #id).is_err() {
+                    fstart_stage_runtime::Board::halt(&board);
+                }
+                _inited.set(#id);
+            }
+        }
         C::PreConsoleInit { devices } => phase_tokens(
             "PreConsoleInit",
             devices,
@@ -206,6 +218,10 @@ fn capability_tokens(idx: usize, cap: &Capability, ctx: &DirectCtx<'_>) -> Token
             fstart_stage_runtime::Board::fdt_prepare(&board);
         },
         C::PayloadLoad => quote! {
+            #[cfg(target_arch = "x86_64")]
+            if fstart_services::resume::is_s3_resume() {
+                fstart_stage_runtime::Board::acpi_s3_resume(&board);
+            }
             fstart_stage_runtime::Board::payload_load(&board);
         },
         C::StageLoad { next_stage } => {
@@ -214,10 +230,37 @@ fn capability_tokens(idx: usize, cap: &Capability, ctx: &DirectCtx<'_>) -> Token
                 fstart_stage_runtime::Board::stage_load(&board, #next_stage);
             }
         }
+        C::StageCacheSave { stage } => {
+            let stage = stage.as_str();
+            quote! {
+                #[cfg(target_arch = "x86_64")]
+                if fstart_services::resume::is_s3_resume() {
+                    // On S3 the cache should already contain the previous normal-boot stage.
+                } else {
+                    fstart_stage_runtime::Board::stage_cache_save(&board, #stage);
+                }
+                #[cfg(not(target_arch = "x86_64"))]
+                fstart_stage_runtime::Board::stage_cache_save(&board, #stage);
+            }
+        }
         C::AcpiPrepare => quote! {
+            #[cfg(target_arch = "x86_64")]
+            if fstart_services::resume::is_s3_resume() {
+                // Preserve OS-owned ACPI tables on S3 resume.
+            } else {
+                fstart_stage_runtime::Board::acpi_prepare(&mut board);
+            }
+            #[cfg(not(target_arch = "x86_64"))]
             fstart_stage_runtime::Board::acpi_prepare(&mut board);
         },
         C::SmBiosPrepare => quote! {
+            #[cfg(target_arch = "x86_64")]
+            if fstart_services::resume::is_s3_resume() {
+                // Preserve OS-owned SMBIOS tables on S3 resume.
+            } else {
+                fstart_stage_runtime::Board::smbios_prepare(&board);
+            }
+            #[cfg(not(target_arch = "x86_64"))]
             fstart_stage_runtime::Board::smbios_prepare(&board);
         },
         C::AcpiLoad { device } => single_device_call(device.as_str(), "AcpiLoad", ctx, |id| {

--- a/crates/fstart-codegen/src/stage_gen/tests.rs
+++ b/crates/fstart-codegen/src/stage_gen/tests.rs
@@ -105,6 +105,8 @@ fn test_parsed_board(capabilities: heapless::Vec<Capability, 16>) -> ParsedBoard
         acpi: None,
         smbios: None,
         smm: None,
+        stage_cache: None,
+        mrc_cache: None,
         boot_hart_id: 0,
     };
 
@@ -274,6 +276,8 @@ fn test_parsed_board_with_i2c_bus(capabilities: heapless::Vec<Capability, 16>) -
         acpi: None,
         smbios: None,
         smm: None,
+        stage_cache: None,
+        mrc_cache: None,
         boot_hart_id: 0,
     };
 
@@ -618,7 +622,6 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
             let _ = v.push(Capability::BootMedia(BootMedium::MemoryMapped {
                 base: 0x2000_0000,
                 size: 0x200_0000,
-                ram_copy_addr: None,
             }));
             let _ = v.push(Capability::SigVerify);
             let _ = v.push(Capability::StageLoad {
@@ -694,6 +697,8 @@ fn test_multi_stage_parsed_board() -> ParsedBoard {
         acpi: None,
         smbios: None,
         smm: None,
+        stage_cache: None,
+        mrc_cache: None,
         boot_hart_id: 0,
     };
 
@@ -752,7 +757,6 @@ fn test_stage_ending_with_payload_load_no_completion() {
     let _ = caps.push(Capability::BootMedia(BootMedium::MemoryMapped {
         base: 0x2000_0000,
         size: 0x200_0000,
-        ram_copy_addr: None,
     }));
     let _ = caps.push(Capability::PayloadLoad);
     let parsed = test_parsed_board(caps);
@@ -1075,7 +1079,7 @@ fn direct_flow_lenovo_x61_bootblock_and_ramstage_calls_are_explicit() {
     for (source, needle, context) in [
         (
             bootblock.as_str(),
-            "fstart_stage_runtime::Board::pre_console_init(&mut board, &[0, 1, 8])",
+            "fstart_stage_runtime::Board::pre_console_init(&mut board, &[0, 1, 9])",
             "bootblock PreConsoleInit",
         ),
         (
@@ -1115,12 +1119,12 @@ fn direct_flow_lenovo_x61_bootblock_and_ramstage_calls_are_explicit() {
         ),
         (
             ramstage.as_str(),
-            "fstart_stage_runtime::Board::post_dram_init(&mut board, &[0, 1, 8])",
+            "fstart_stage_runtime::Board::post_dram_init(&mut board, &[0, 1, 9])",
             "ramstage PostDramInit",
         ),
         (
             ramstage.as_str(),
-            "fstart_stage_runtime::Board::finalize_init(&mut board, &[1, 8])",
+            "fstart_stage_runtime::Board::finalize_init(&mut board, &[1, 9])",
             "ramstage FinalizeInit",
         ),
         (

--- a/crates/fstart-codegen/src/stage_gen/validation.rs
+++ b/crates/fstart-codegen/src/stage_gen/validation.rs
@@ -79,6 +79,14 @@ pub(super) fn validate_capability_ordering(
             Capability::DramInit { .. } => {
                 memory_ready = true;
             }
+            Capability::ResumeDetect { .. } if !console_inited => {
+                return Some(
+                    "ResumeDetect capability requires ConsoleInit to appear earlier \
+                     in the capability list (needed for logging)"
+                        .to_string(),
+                );
+            }
+            Capability::ResumeDetect { .. } => {}
             Capability::PreConsoleInit { .. } => {
                 // Pre-console phases must be log-free and may run before the
                 // logger exists.
@@ -202,6 +210,19 @@ pub(super) fn validate_capability_ordering(
                         .to_string(),
                 );
             }
+            Capability::StageCacheSave { .. } if !console_inited => {
+                return Some(
+                    "StageCacheSave capability requires ConsoleInit to appear earlier \
+                     in the capability list (needed for logging)"
+                        .to_string(),
+                );
+            }
+            Capability::StageCacheSave { .. } if !boot_media_declared => {
+                return Some(
+                    "StageCacheSave capability requires BootMedia to appear earlier".to_string(),
+                );
+            }
+            Capability::StageCacheSave { .. } => {}
             Capability::PayloadLoad if !console_inited => {
                 return Some(
                     "PayloadLoad capability requires ConsoleInit to appear earlier \
@@ -279,7 +300,10 @@ pub(super) fn needs_ffs(capabilities: &[Capability]) -> bool {
     capabilities.iter().any(|c| {
         matches!(
             c,
-            Capability::SigVerify | Capability::StageLoad { .. } | Capability::PayloadLoad
+            Capability::SigVerify
+                | Capability::StageLoad { .. }
+                | Capability::StageCacheSave { .. }
+                | Capability::PayloadLoad
         )
     })
 }
@@ -405,6 +429,13 @@ fn validate_capability_service(
             device.as_str(),
             Service::MemoryController,
             "DramInit",
+        ),
+        Capability::ResumeDetect { device } => require_device_service(
+            config,
+            device_services,
+            device.as_str(),
+            Service::ResumeDetector,
+            "ResumeDetect",
         ),
         Capability::PreConsoleInit { devices } => require_devices_service(
             config,

--- a/crates/fstart-device-registry/Cargo.toml
+++ b/crates/fstart-device-registry/Cargo.toml
@@ -37,6 +37,7 @@ fstart-driver-intel-pineview = { path = "../fstart-driver-intel-pineview", optio
 fstart-driver-intel-ich7 = { path = "../fstart-driver-intel-ich7", optional = true }
 fstart-driver-intel-gm965 = { path = "../fstart-driver-intel-gm965", optional = true }
 fstart-driver-intel-ich8 = { path = "../fstart-driver-intel-ich8", optional = true }
+fstart-driver-intel-spi = { path = "../fstart-driver-intel-spi", optional = true }
 fstart-mainboard-lenovo-x61 = { path = "../fstart-mainboard-lenovo-x61", optional = true }
 fstart-driver-i2c-ck505 = { path = "../fstart-driver-i2c-ck505", optional = true }
 
@@ -68,6 +69,7 @@ intel-pineview = ["dep:fstart-driver-intel-pineview"]
 intel-ich7 = ["dep:fstart-driver-intel-ich7"]
 intel-gm965 = ["dep:fstart-driver-intel-gm965"]
 intel-ich8 = ["dep:fstart-driver-intel-ich8"]
+intel-spi = ["dep:fstart-driver-intel-spi"]
 lenovo-x61-mainboard = ["dep:fstart-mainboard-lenovo-x61"]
 i2c-ck505 = ["dep:fstart-driver-i2c-ck505"]
 
@@ -98,6 +100,7 @@ all-drivers = [
   "intel-ich7",
   "intel-gm965",
   "intel-ich8",
+  "intel-spi",
   "lenovo-x61-mainboard",
   "i2c-ck505",
 ]

--- a/crates/fstart-device-registry/src/lib.rs
+++ b/crates/fstart-device-registry/src/lib.rs
@@ -144,6 +144,11 @@ pub mod intel_ich8 {
     pub use fstart_driver_intel_ich8::IntelIch8Config;
 }
 
+#[cfg(feature = "intel-spi")]
+pub mod intel_spi {
+    pub use fstart_driver_intel_spi::IntelSpiConfig;
+}
+
 #[cfg(feature = "lenovo-x61-mainboard")]
 pub mod lenovo_x61_mainboard {
     pub use fstart_mainboard_lenovo_x61::LenovoX61MainboardConfig;
@@ -174,6 +179,8 @@ pub enum Service {
     Framebuffer,
     AcpiTableProvider,
     MemoryDetector,
+    ResumeDetector,
+    StageCacheProvider,
     SuperIoHost,
     Southbridge,
     Mainboard,
@@ -204,6 +211,8 @@ impl Service {
             Self::Framebuffer => "Framebuffer",
             Self::AcpiTableProvider => "AcpiTableProvider",
             Self::MemoryDetector => "MemoryDetector",
+            Self::ResumeDetector => "ResumeDetector",
+            Self::StageCacheProvider => "StageCacheProvider",
             Self::SuperIoHost => "SuperIoHost",
             Self::Southbridge => "Southbridge",
             Self::Mainboard => "Mainboard",
@@ -419,6 +428,10 @@ pub enum DriverInstance {
     /// Intel ICH8 / ICH8-M southbridge.
     #[cfg(feature = "intel-ich8")]
     IntelIch8(intel_ich8::IntelIch8Config),
+
+    /// Intel ICH/PCH SPI flash controller.
+    #[cfg(feature = "intel-spi")]
+    IntelSpi(intel_spi::IntelSpiConfig),
 
     /// Lenovo ThinkPad X61 mainboard glue.
     #[cfg(feature = "lenovo-x61-mainboard")]
@@ -749,6 +762,7 @@ impl DriverInstance {
                     Service::EarlyInit,
                     Service::PostDramInit,
                     Service::FinalizeInit,
+                    Service::ResumeDetector,
                 ],
                 compatible: &["intel,ich7", "intel,nm10"],
                 has_acpi: true,
@@ -766,6 +780,7 @@ impl DriverInstance {
                     Service::PciHost,
                     Service::PciRootBus,
                     Service::SmmOps,
+                    Service::StageCacheProvider,
                     Service::PreConsoleInit,
                     Service::EarlyInit,
                     Service::StageLocalInit,
@@ -787,9 +802,21 @@ impl DriverInstance {
                     Service::EarlyInit,
                     Service::PostDramInit,
                     Service::FinalizeInit,
+                    Service::ResumeDetector,
                 ],
                 compatible: &["intel,ich8", "intel,ich8m", "intel,82801hx"],
                 has_acpi: true,
+                is_bus_device: false,
+            },
+            #[cfg(feature = "intel-spi")]
+            Self::IntelSpi(_) => &DriverMeta {
+                name: "intel-spi",
+                type_name: "IntelSpi",
+                module_path: "fstart_driver_intel_spi",
+                config_type: "IntelSpiConfig",
+                static_services: &[Service::BlockDevice],
+                compatible: &["intel,ich-spi", "intel-spi"],
+                has_acpi: false,
                 is_bus_device: false,
             },
             #[cfg(feature = "lenovo-x61-mainboard")]
@@ -987,6 +1014,8 @@ impl DriverInstance {
             Self::IntelGm965(cfg) => serde::Serialize::serialize(cfg, ser),
             #[cfg(feature = "intel-ich8")]
             Self::IntelIch8(cfg) => serde::Serialize::serialize(cfg, ser),
+            #[cfg(feature = "intel-spi")]
+            Self::IntelSpi(cfg) => serde::Serialize::serialize(cfg, ser),
             #[cfg(feature = "lenovo-x61-mainboard")]
             Self::LenovoX61Mainboard(cfg) => serde::Serialize::serialize(cfg, ser),
             #[cfg(feature = "i2c-ck505")]

--- a/crates/fstart-driver-intel-gm965/Cargo.toml
+++ b/crates/fstart-driver-intel-gm965/Cargo.toml
@@ -13,7 +13,7 @@ acpi = [
   "dep:fstart-cpu-intel",
   "fstart-cpu-intel/acpi",
 ]
-ffs-vbt = ["dep:fstart-crypto", "dep:fstart-ffs", "dep:fstart-types"]
+ffs-vbt = ["dep:fstart-crypto", "dep:fstart-ffs"]
 
 [dependencies]
 fstart-acpi = { workspace = true, features = ["x86"], optional = true }
@@ -34,7 +34,7 @@ fstart-pmio-ich = { workspace = true }
 fstart-services = { workspace = true, features = ["pci"] }
 fstart-smbus-intel = { workspace = true }
 fstart-smm = { workspace = true }
-fstart-types = { workspace = true, optional = true }
+fstart-types = { workspace = true }
 fstart-spd = { workspace = true }
 heapless = { workspace = true }
 serde = { workspace = true }

--- a/crates/fstart-driver-intel-gm965/src/lib.rs
+++ b/crates/fstart-driver-intel-gm965/src/lib.rs
@@ -33,8 +33,9 @@ use fstart_services::memory_detect::{
 };
 use fstart_services::{
     EarlyInit, MemoryController, PciBdf, PciHost, PciRootBus, PciWindow, PostDramInit,
-    PreConsoleInit, ServiceError, StageLocalInit,
+    PreConsoleInit, ServiceError, StageCacheProvider, StageLocalInit,
 };
+use fstart_types::BootPath;
 use serde::{Deserialize, Serialize};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -1994,6 +1995,29 @@ impl MemoryDetector for IntelGm965 {
     }
 }
 
+impl StageCacheProvider for IntelGm965 {
+    fn stage_cache_region(&self, requested_size: u64) -> Option<(u64, u64)> {
+        let tseg_base = u64::from(self.tseg_base());
+        let tseg_size = u64::from(self.tseg_size());
+        if tseg_base == 0 || requested_size == 0 || requested_size > tseg_size {
+            return None;
+        }
+        // Match coreboot's external stage cache placement: carve from the high
+        // end of TSEG. A later layout pass can subtract IED/OPAL subregions.
+        Some((tseg_base + tseg_size - requested_size, requested_size))
+    }
+
+    fn stage_cache_open(&self) -> Result<(), ServiceError> {
+        self.smm_open();
+        Ok(())
+    }
+
+    fn stage_cache_close(&self) -> Result<(), ServiceError> {
+        self.smm_close();
+        Ok(())
+    }
+}
+
 impl SmmOps for IntelGm965 {
     fn smm_info(&self) -> Option<SmmInfo> {
         let (base, size) = self.smm_region();
@@ -2115,13 +2139,20 @@ impl SmmOps for IntelGm965 {
 }
 
 impl MemoryController for IntelGm965 {
-    fn dram_init(&mut self) -> Result<(), ServiceError> {
+    fn dram_init_with_boot_path(&mut self, boot_path: BootPath) -> Result<(), ServiceError> {
         let mut smbus = fstart_smbus_intel::I801SmBus::new(self.config.smbus_base);
         smbus.host_reset();
         let mut info = raminit::probe_dimms(&mut smbus, &self.config.spd_addresses)?;
         self.detected_size = info.total_bytes();
-        raminit::cold_boot_train(&mut info, &self.mchbar(), self.igd_ggc())?;
-        self.memory_test()?;
+        if boot_path.is_s3_resume() {
+            fstart_log::info!(
+                "gm965: S3 resume requested; using non-JEDEC native resume path (MRC cache restore pending)"
+            );
+            raminit::s3_resume_train(&mut info, &self.mchbar(), self.igd_ggc())?;
+        } else {
+            raminit::cold_boot_train(&mut info, &self.mchbar(), self.igd_ggc())?;
+            self.memory_test()?;
+        }
         self.thermal_sensor_init(&info, &mut smbus);
         Ok(())
     }

--- a/crates/fstart-driver-intel-gm965/src/raminit.rs
+++ b/crates/fstart-driver-intel-gm965/src/raminit.rs
@@ -1314,6 +1314,26 @@ pub fn probe_dimms(
 /// programming, DDR2 JEDEC commands, final memory map, receive-enable
 /// calibration, guarded EPD channel population, and DRAM power-management setup.
 pub fn cold_boot_train(info: &mut RaminitInfo, mch: &MchBar, ggc: u16) -> Result<(), ServiceError> {
+    train(info, mch, ggc, false)
+}
+
+/// Run GM965 DDR2 initialization for an S3 resume path.
+///
+/// Mirrors the coreboot GM965 S3 flow by avoiding the destructive pre-JEDEC
+/// temporary map and JEDEC/MRS command sequence while still restoring the
+/// controller registers needed to regain access to preserved memory. Once the
+/// GM965 MRC cache payload is wired, this path should also restore cached
+/// receive-enable training values instead of recalibrating them.
+pub fn s3_resume_train(info: &mut RaminitInfo, mch: &MchBar, ggc: u16) -> Result<(), ServiceError> {
+    train(info, mch, ggc, true)
+}
+
+fn train(
+    info: &mut RaminitInfo,
+    mch: &MchBar,
+    ggc: u16,
+    s3_resume: bool,
+) -> Result<(), ServiceError> {
     reset_on_stale_rcomp(mch);
     init_pmcon();
 
@@ -1335,7 +1355,9 @@ pub fn cold_boot_train(info: &mut RaminitInfo, mch: &MchBar, ggc: u16) -> Result
     mch.setbits32(mchbar::POST_JEDEC_TIM0, 0x0300_0000);
     mch.setbits32(mchbar::POST_JEDEC_TIM1, 0x0300_0000);
 
-    program_map(info, mch, true, ggc);
+    if !s3_resume {
+        program_map(info, mch, true, ggc);
+    }
     rcomp_init(info, mch);
     odt_and_io_setup(info, mch);
     program_timings(info, mch);
@@ -1344,7 +1366,9 @@ pub fn cold_boot_train(info: &mut RaminitInfo, mch: &MchBar, ggc: u16) -> Result
     mch.clrbits32(mchbar::RCOMP_CFG3, 1 << 17);
     mch.clrbits32(mchbar::RCOMP_CTRL, (3 << 16) | (3 << 4));
 
-    jedec_init_ddr2(info, mch);
+    if !s3_resume {
+        jedec_init_ddr2(info, mch);
+    }
     post_jedec_and_final(info, mch, ggc);
     receive_enable_training(info, mch)?;
 
@@ -1366,7 +1390,8 @@ pub fn cold_boot_train(info: &mut RaminitInfo, mch: &MchBar, ggc: u16) -> Result
     mch.write32(mchbar::SSKPD, 0xcafe);
 
     fstart_log::info!(
-        "gm965 raminit: complete total={} MiB tolud={} MiB rec=({},{}),({},{})",
+        "gm965 raminit: complete s3={} total={} MiB tolud={} MiB rec=({},{}),({},{})",
+        s3_resume,
         info.tom_mb,
         info.tolud_mb,
         info.rec_coarse[0] as u32,

--- a/crates/fstart-driver-intel-ich7/Cargo.toml
+++ b/crates/fstart-driver-intel-ich7/Cargo.toml
@@ -25,6 +25,7 @@ fstart-services = { workspace = true, features = ["pci"] }
 fstart-smm-runtime = { workspace = true }
 fstart-smbus-intel = { workspace = true }
 fstart-superio = { workspace = true }
+fstart-types = { workspace = true }
 serde = { workspace = true }
 tock-registers = { workspace = true }
 ufmt = { workspace = true }

--- a/crates/fstart-driver-intel-ich7/src/lib.rs
+++ b/crates/fstart-driver-intel-ich7/src/lib.rs
@@ -228,10 +228,12 @@ pub mod ich7 {
 }
 use fstart_services::device::{Device, DeviceError};
 use fstart_services::{
-    EarlyInit, FinalizeInit, PostDramInit, PreConsoleInit, ServiceError, SmBus, Southbridge,
+    EarlyInit, FinalizeInit, PostDramInit, PreConsoleInit, ResumeDetector, ServiceError, SmBus,
+    Southbridge,
 };
 use fstart_smbus_intel::I801SmBus;
 use fstart_superio::LpcBaseProvider;
+use fstart_types::BootPath;
 use heapless::Vec as HVec;
 use serde::{Deserialize, Serialize};
 
@@ -1079,6 +1081,18 @@ impl IntelIch7 {
         // triggers a CF9 reset when needed, so not returning
         // BOOT_PATH_RESET here is safe for initial bring-up.
         0 // BOOT_PATH_NORMAL
+    }
+}
+
+impl ResumeDetector for IntelIch7 {
+    fn detect_boot_path(&self) -> Result<BootPath, ServiceError> {
+        let path = if self.detect_s3_resume() {
+            BootPath::S3Resume
+        } else {
+            BootPath::Normal
+        };
+        fstart_services::resume::set_boot_path(path);
+        Ok(path)
     }
 }
 

--- a/crates/fstart-driver-intel-ich8/Cargo.toml
+++ b/crates/fstart-driver-intel-ich8/Cargo.toml
@@ -25,6 +25,7 @@ fstart-services = { workspace = true, features = ["pci"] }
 fstart-smm-runtime = { workspace = true }
 fstart-smbus-intel = { workspace = true }
 fstart-superio = { workspace = true }
+fstart-types = { workspace = true }
 heapless = { workspace = true }
 serde = { workspace = true }
 tock-registers = { workspace = true }

--- a/crates/fstart-driver-intel-ich8/src/lib.rs
+++ b/crates/fstart-driver-intel-ich8/src/lib.rs
@@ -17,9 +17,11 @@ use fstart_pci::{pci_type0_config, PciType0Config, PciType1Config, PCI_COMMAND_B
 use fstart_pmio_ich::{self as pmio, PmIo};
 use fstart_services::device::{Device, DeviceError};
 use fstart_services::{
-    EarlyInit, FinalizeInit, PostDramInit, PreConsoleInit, ServiceError, SmBus, Southbridge,
+    EarlyInit, FinalizeInit, PostDramInit, PreConsoleInit, ResumeDetector, ServiceError, SmBus,
+    Southbridge,
 };
 use fstart_smbus_intel::I801SmBus;
+use fstart_types::BootPath;
 use heapless::Vec as HVec;
 use serde::{Deserialize, Serialize};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -947,6 +949,7 @@ pub struct IntelIch8 {
     config: &'static IntelIch8Config,
     smbus: Option<I801SmBus>,
     pm: PmIo,
+    s3_resume_detected: bool,
 }
 
 // SAFETY: firmware performs chipset init on the BSP before concurrency exists.
@@ -1989,6 +1992,7 @@ impl Device for IntelIch8 {
             config,
             smbus: None,
             pm: PmIo::new(ich8::DEFAULT_PMBASE),
+            s3_resume_detected: false,
         })
     }
 
@@ -2029,8 +2033,12 @@ impl EarlyInit for IntelIch8 {
         self.pm().write32(GPE0_EN_ICH8, self.config.gpe0_en);
         self.enable_hpet();
         self.setup_dmi();
-        let _ = self.detect_s3_resume();
-        fstart_log::info!("intel-ich8: early init complete (fd_mask={:#x})", fd);
+        self.s3_resume_detected = self.detect_s3_resume();
+        fstart_log::info!(
+            "intel-ich8: early init complete (fd_mask={:#x}, s3={})",
+            fd,
+            self.s3_resume_detected,
+        );
         Ok(())
     }
 }
@@ -2102,6 +2110,18 @@ impl fstart_superio::LpcBaseProvider for IntelIch8 {
         // directly by the X61 mainboard hook while disconnected from generic
         // driver init.
         0x164e
+    }
+}
+
+impl ResumeDetector for IntelIch8 {
+    fn detect_boot_path(&self) -> Result<BootPath, ServiceError> {
+        let path = if self.s3_resume_detected || self.detect_s3_resume() {
+            BootPath::S3Resume
+        } else {
+            BootPath::Normal
+        };
+        fstart_services::resume::set_boot_path(path);
+        Ok(path)
     }
 }
 

--- a/crates/fstart-driver-intel-pineview/Cargo.toml
+++ b/crates/fstart-driver-intel-pineview/Cargo.toml
@@ -13,7 +13,7 @@ acpi = [
   "dep:fstart-cpu-intel",
   "fstart-cpu-intel/acpi",
 ]
-ffs-vbt = ["dep:fstart-crypto", "dep:fstart-ffs", "dep:fstart-types"]
+ffs-vbt = ["dep:fstart-crypto", "dep:fstart-ffs"]
 
 [dependencies]
 fstart-acpi = { workspace = true, features = ["x86"], optional = true }
@@ -36,7 +36,7 @@ fstart-services = { workspace = true, features = ["pci"] }
 fstart-smm = { workspace = true }
 fstart-spd = { workspace = true }
 fstart-smbus-intel = { workspace = true }
-fstart-types = { workspace = true, optional = true }
+fstart-types = { workspace = true }
 serde = { workspace = true }
 tock-registers = { workspace = true }
 ufmt = { workspace = true }

--- a/crates/fstart-driver-intel-pineview/src/lib.rs
+++ b/crates/fstart-driver-intel-pineview/src/lib.rs
@@ -39,6 +39,7 @@ use fstart_services::memory_controller::MemoryController;
 use fstart_services::memory_detect::{E820Entry, E820Kind, MemoryDetector};
 use fstart_services::pci::{PciBdf, PciRootBus, PciWindow};
 use fstart_services::{EarlyInit, PciHost, PreConsoleInit, ServiceError, SmBus, StageLocalInit};
+use fstart_types::BootPath;
 use serde::{Deserialize, Serialize};
 use tock_registers::interfaces::{Readable, Writeable};
 
@@ -656,12 +657,18 @@ impl MemoryDetector for IntelPineview {
 }
 
 impl MemoryController for IntelPineview {
-    fn dram_init(&mut self) -> Result<(), ServiceError> {
+    fn dram_init_with_boot_path(&mut self, boot_path: BootPath) -> Result<(), ServiceError> {
         let mut smbus = fstart_smbus_intel::I801SmBus::new(0x0400);
         if self.config.ck505_pre_raminit {
             pineview_ck505_pre_raminit(&mut smbus);
         }
-        let boot_path = if self.detect_warm_reset() { 1 } else { 0 };
+        let boot_path = if boot_path.is_s3_resume() {
+            2
+        } else if self.detect_warm_reset() {
+            1
+        } else {
+            0
+        };
         let platform_type = self.platform_type();
         let size = raminit::sdram_initialize(
             &self.mchbar(),

--- a/crates/fstart-driver-intel-spi/Cargo.toml
+++ b/crates/fstart-driver-intel-spi/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fstart-driver-intel-spi"
+description = "Intel ICH/PCH SPI flash controller driver"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+fstart-log = { workspace = true }
+fstart-pio = { workspace = true }
+fstart-services = { workspace = true }
+serde = { workspace = true }
+ufmt = { workspace = true }

--- a/crates/fstart-driver-intel-spi/src/chipsets.rs
+++ b/crates/fstart-driver-intel-spi/src/chipsets.rs
@@ -1,0 +1,379 @@
+//! Intel Chipset PCI ID Table
+//!
+//! This module contains the PCI device IDs for Intel chipsets and their
+//! corresponding SPI controller types, ported from flashprog's chipset_enable.c.
+//!
+//! # TODO: Missing chipsets from rflasher
+//!
+//! The following chipset types are defined in rflasher but not here:
+//! - `TunnelCreek` (Atom E6xx, device ID 0x8186)
+//! - `Centerton` (Atom S1220/S1240/S1260)
+//! - `Series8Wellsburg`
+//! - `SnowRidge`
+//!
+//! Additional PCI device IDs missing (partial list):
+//! - More 6 Series variants: 0x1c47 (UM67), 0x1c4b (HM67), 0x1c4c (Q65), 0x1c50 (B65), etc.
+//! - More 7 Series variants: 0x1e41/42/43 (samples), 0x1e46 (Z75), 0x1e48 (Q75), etc.
+//! - DH89xxCC (Cave Creek) 0x2310, Coleto Creek 0x2390
+//! - ICH9 Eng. Sample 0x2910
+//! - ICH10R Eng. Sample 0x3a10, ICH10 Eng. Sample 0x3a1e
+//! - More 5 Series: 0x3b00/01/08/0a/0b/0d/0e/12/16/1e
+//! - EP80579 0x5031
+//! - More 8 Series variants: 0x8c40/41/42/43/46/49/4c/4e/52/56
+//! - More 9 Series: 0x8cc1/cc2/cc3
+//! - More 8 Series LP: 0x9c41/47
+//! - More 9 Series LP: 0x9cc1/cc2/cc6/cc7/cc9/ccb
+//! - More 100 Series: 0x9d41/43/46/4b/50/51/53/56, 0xa141/42/47/4a/4d/4e/52/53/54
+//! - More C620: 0xa1c0/c4/c5
+//! - More 300 Series: 0xa30e, 0xa323
+//! - 500 Series: 0x438f (W580)
+//!
+//! Full list: compare with rflasher/crates/rflasher-internal/src/intel_pci.rs
+
+const INTEL_VID: u16 = 0x8086;
+
+/// Intel chipset generation/type
+///
+/// This enum defines the SPI controller variants and their register layouts.
+/// The ordering is significant: chipsets are grouped by compatible SPI engines.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[repr(u8)]
+pub enum IchChipset {
+    /// Unknown chipset
+    Unknown = 0,
+    // TODO: Add these pre-SPI chipsets from rflasher if needed:
+    // Ich,       // Original ICH
+    // Ich2345,   // ICH2/ICH3/ICH4/ICH5
+    // Ich6,      // ICH6
+    // Poulsbo,   // Intel SCH Poulsbo
+    // TunnelCreek, // Atom E6xx (device ID 0x8186)
+    // Centerton, // Atom S1220/S1240/S1260
+    /// ICH7
+    Ich7,
+
+    // ======== ICH9 compatible from here on ========
+    /// ICH8 (first ICH9-compatible SPI engine)
+    Ich8,
+    /// ICH9
+    Ich9,
+    /// ICH10
+    Ich10,
+    /// 5 Series (Ibex Peak)
+    Series5IbexPeak,
+    /// 6 Series (Cougar Point)
+    Series6CougarPoint,
+    /// 7 Series (Panther Point)
+    Series7PantherPoint,
+    /// Bay Trail / Avoton / Rangeley (Silvermont architecture)
+    BayTrail,
+
+    // ======== New component density from here on ========
+    /// 8 Series (Lynx Point)
+    Series8LynxPoint,
+    /// 8 Series LP (Lynx Point LP)
+    Series8LynxPointLp,
+    // TODO: Add Series8Wellsburg from rflasher
+    /// 9 Series (Wildcat Point)
+    Series9WildcatPoint,
+    /// 9 Series LP (Wildcat Point LP)
+    Series9WildcatPointLp,
+
+    // ======== PCH100 compatible from here on ========
+    /// 100 Series (Sunrise Point)
+    Series100SunrisePoint,
+    /// C620 Series (Lewisburg)
+    C620Lewisburg,
+    /// 300 Series (Cannon Point)
+    Series300CannonPoint,
+    /// 400/500 Series (Tiger Point)
+    Series500TigerPoint,
+    /// Apollo Lake
+    ApolloLake,
+    /// Gemini Lake
+    GeminiLake,
+    /// Elkhart Lake
+    ElkhartLake,
+
+    // ======== New access permissions from here on ========
+    /// C740 Series (Emmitsburg)
+    C740Emmitsburg,
+    // TODO: Add SnowRidge from rflasher
+    /// Meteor Lake
+    MeteorLake,
+    /// Lunar Lake
+    LunarLake,
+    /// Arrow Lake
+    ArrowLake,
+}
+
+impl IchChipset {
+    /// Marker for ICH9-compatible SPI engine
+    pub const SPI_ENGINE_ICH9: Self = Self::Ich8;
+
+    /// Marker for PCH100-compatible SPI engine
+    pub const SPI_ENGINE_PCH100: Self = Self::Series100SunrisePoint;
+
+    /// Returns true if this chipset uses ICH9-compatible SPI engine
+    pub fn is_ich9_compatible(self) -> bool {
+        self >= Self::SPI_ENGINE_ICH9
+    }
+
+    /// Returns true if this chipset uses PCH100-compatible SPI engine
+    pub fn is_pch100_compatible(self) -> bool {
+        self >= Self::SPI_ENGINE_PCH100
+    }
+
+    /// Returns true if this driver supports hardware sequencing (hwseq).
+    ///
+    /// ICH8 has an ICH9-like hardware sequencing engine, but the flash
+    /// partition boundary register is undocumented, so this driver keeps ICH8
+    /// on software sequencing.
+    pub fn supports_hwseq(self) -> bool {
+        self >= Self::Ich9
+    }
+}
+
+impl core::fmt::Display for IchChipset {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "Unknown"),
+            Self::Ich7 => write!(f, "ICH7"),
+            Self::Ich8 => write!(f, "ICH8"),
+            Self::Ich9 => write!(f, "ICH9"),
+            Self::Ich10 => write!(f, "ICH10"),
+            Self::Series5IbexPeak => write!(f, "5 Series (Ibex Peak)"),
+            Self::Series6CougarPoint => write!(f, "6 Series (Cougar Point)"),
+            Self::Series7PantherPoint => write!(f, "7 Series (Panther Point)"),
+            Self::BayTrail => write!(f, "Bay Trail"),
+            Self::Series8LynxPoint => write!(f, "8 Series (Lynx Point)"),
+            Self::Series8LynxPointLp => write!(f, "8 Series LP (Lynx Point LP)"),
+            Self::Series9WildcatPoint => write!(f, "9 Series (Wildcat Point)"),
+            Self::Series9WildcatPointLp => write!(f, "9 Series LP (Wildcat Point LP)"),
+            Self::Series100SunrisePoint => write!(f, "100 Series (Sunrise Point)"),
+            Self::C620Lewisburg => write!(f, "C620 (Lewisburg)"),
+            Self::Series300CannonPoint => write!(f, "300 Series (Cannon Point)"),
+            Self::Series500TigerPoint => write!(f, "500 Series (Tiger Point)"),
+            Self::ApolloLake => write!(f, "Apollo Lake"),
+            Self::GeminiLake => write!(f, "Gemini Lake"),
+            Self::ElkhartLake => write!(f, "Elkhart Lake"),
+            Self::C740Emmitsburg => write!(f, "C740 (Emmitsburg)"),
+            Self::MeteorLake => write!(f, "Meteor Lake"),
+            Self::LunarLake => write!(f, "Lunar Lake"),
+            Self::ArrowLake => write!(f, "Arrow Lake"),
+        }
+    }
+}
+
+/// A chipset enable entry in the PCI ID table
+#[derive(Debug, Clone)]
+pub struct ChipsetEnable {
+    /// PCI vendor ID
+    pub vendor_id: u16,
+    /// PCI device ID
+    pub device_id: u16,
+    /// Device/chipset name
+    pub device_name: &'static str,
+    /// Chipset type (determines which register layout to use)
+    pub chipset: IchChipset,
+}
+
+impl ChipsetEnable {
+    /// Create a new chipset enable entry
+    const fn new(
+        vendor_id: u16,
+        device_id: u16,
+        device_name: &'static str,
+        chipset: IchChipset,
+    ) -> Self {
+        Self {
+            vendor_id,
+            device_id,
+            device_name,
+            chipset,
+        }
+    }
+}
+
+/// Intel chipset PCI ID table
+///
+/// Keep this list sorted by device ID for easier maintenance.
+/// Based on flashprog's chipset_enables[] array.
+pub static INTEL_CHIPSETS: &[ChipsetEnable] = &[
+    // Bay Trail
+    ChipsetEnable::new(INTEL_VID, 0x0f1c, "Bay Trail", IchChipset::BayTrail),
+    // Braswell
+    ChipsetEnable::new(INTEL_VID, 0x229c, "Braswell", IchChipset::BayTrail),
+    // ICH7
+    ChipsetEnable::new(INTEL_VID, 0x27b0, "ICH7DH", IchChipset::Ich7),
+    ChipsetEnable::new(INTEL_VID, 0x27b8, "ICH7/ICH7R", IchChipset::Ich7),
+    ChipsetEnable::new(INTEL_VID, 0x27b9, "ICH7M", IchChipset::Ich7),
+    ChipsetEnable::new(INTEL_VID, 0x27bc, "NM10", IchChipset::Ich7),
+    ChipsetEnable::new(INTEL_VID, 0x27bd, "ICH7MDH", IchChipset::Ich7),
+    // ICH8
+    ChipsetEnable::new(INTEL_VID, 0x2810, "ICH8/ICH8R", IchChipset::Ich8),
+    ChipsetEnable::new(INTEL_VID, 0x2811, "ICH8M-E", IchChipset::Ich8),
+    ChipsetEnable::new(INTEL_VID, 0x2812, "ICH8DH", IchChipset::Ich8),
+    ChipsetEnable::new(INTEL_VID, 0x2814, "ICH8DO", IchChipset::Ich8),
+    ChipsetEnable::new(INTEL_VID, 0x2815, "ICH8M", IchChipset::Ich8),
+    // ICH9
+    ChipsetEnable::new(INTEL_VID, 0x2912, "ICH9DH", IchChipset::Ich9),
+    ChipsetEnable::new(INTEL_VID, 0x2914, "ICH9DO", IchChipset::Ich9),
+    ChipsetEnable::new(INTEL_VID, 0x2916, "ICH9R", IchChipset::Ich9),
+    ChipsetEnable::new(INTEL_VID, 0x2917, "ICH9M-E", IchChipset::Ich9),
+    ChipsetEnable::new(INTEL_VID, 0x2918, "ICH9", IchChipset::Ich9),
+    ChipsetEnable::new(INTEL_VID, 0x2919, "ICH9M", IchChipset::Ich9),
+    // Gemini Lake
+    ChipsetEnable::new(INTEL_VID, 0x31e8, "Gemini Lake", IchChipset::GeminiLake),
+    // ICH10
+    ChipsetEnable::new(INTEL_VID, 0x3a14, "ICH10DO", IchChipset::Ich10),
+    ChipsetEnable::new(INTEL_VID, 0x3a16, "ICH10R", IchChipset::Ich10),
+    ChipsetEnable::new(INTEL_VID, 0x3a18, "ICH10", IchChipset::Ich10),
+    ChipsetEnable::new(INTEL_VID, 0x3a1a, "ICH10D", IchChipset::Ich10),
+    // 5 Series (Ibex Peak)
+    ChipsetEnable::new(INTEL_VID, 0x3b02, "P55", IchChipset::Series5IbexPeak),
+    ChipsetEnable::new(INTEL_VID, 0x3b03, "PM55", IchChipset::Series5IbexPeak),
+    ChipsetEnable::new(INTEL_VID, 0x3b06, "H55", IchChipset::Series5IbexPeak),
+    ChipsetEnable::new(INTEL_VID, 0x3b07, "QM57", IchChipset::Series5IbexPeak),
+    ChipsetEnable::new(INTEL_VID, 0x3b09, "HM55", IchChipset::Series5IbexPeak),
+    ChipsetEnable::new(INTEL_VID, 0x3b0f, "QS57", IchChipset::Series5IbexPeak),
+    // 500 Series (Tiger Point)
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x4380,
+        "Z590/H570/W580/Q570",
+        IchChipset::Series500TigerPoint,
+    ),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x4381,
+        "H510/B560",
+        IchChipset::Series500TigerPoint,
+    ),
+    ChipsetEnable::new(INTEL_VID, 0x4387, "HM570", IchChipset::Series500TigerPoint),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x4388,
+        "QM580/WM590",
+        IchChipset::Series500TigerPoint,
+    ),
+    // Elkhart Lake
+    ChipsetEnable::new(INTEL_VID, 0x4b23, "Elkhart Lake", IchChipset::ElkhartLake),
+    // Apollo Lake
+    ChipsetEnable::new(INTEL_VID, 0x5ae8, "Apollo Lake", IchChipset::ApolloLake),
+    // Meteor Lake
+    ChipsetEnable::new(INTEL_VID, 0x7e23, "Meteor Lake", IchChipset::MeteorLake),
+    // 6 Series (Cougar Point)
+    ChipsetEnable::new(INTEL_VID, 0x1c44, "Z68", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c46, "P67", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c49, "HM65", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c4a, "H67", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c4e, "Q67", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c4f, "QM67", IchChipset::Series6CougarPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1c5c, "H61", IchChipset::Series6CougarPoint),
+    // 7 Series (Panther Point)
+    ChipsetEnable::new(INTEL_VID, 0x1e44, "Z77", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e47, "Q77", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e49, "B75", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e4a, "H77", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e55, "QM77", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e57, "HM77", IchChipset::Series7PantherPoint),
+    ChipsetEnable::new(INTEL_VID, 0x1e59, "HM76", IchChipset::Series7PantherPoint),
+    // 8 Series (Lynx Point)
+    ChipsetEnable::new(INTEL_VID, 0x8c44, "Z87", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c4a, "H87", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c4b, "HM87", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c4f, "QM87", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c50, "B85", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c54, "C224", IchChipset::Series8LynxPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8c5c, "H81", IchChipset::Series8LynxPoint),
+    // 9 Series
+    ChipsetEnable::new(INTEL_VID, 0x8cc4, "Z97", IchChipset::Series9WildcatPoint),
+    ChipsetEnable::new(INTEL_VID, 0x8cc6, "H97", IchChipset::Series9WildcatPoint),
+    // 8 Series LP (Lynx Point LP)
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9c43,
+        "Lynx Point LP Premium",
+        IchChipset::Series8LynxPointLp,
+    ),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9c45,
+        "Lynx Point LP Mainstream",
+        IchChipset::Series8LynxPointLp,
+    ),
+    // 9 Series LP
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9cc3,
+        "Broadwell U Premium",
+        IchChipset::Series9WildcatPointLp,
+    ),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9cc5,
+        "Broadwell U Base",
+        IchChipset::Series9WildcatPointLp,
+    ),
+    // 100 Series (Sunrise Point)
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9d48,
+        "Skylake U Premium",
+        IchChipset::Series100SunrisePoint,
+    ),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0x9d4e,
+        "Kaby Lake U Premium",
+        IchChipset::Series100SunrisePoint,
+    ),
+    ChipsetEnable::new(INTEL_VID, 0xa143, "H110", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(INTEL_VID, 0xa144, "H170", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(INTEL_VID, 0xa145, "Z170", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(INTEL_VID, 0xa146, "Q170", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(INTEL_VID, 0xa148, "B150", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(INTEL_VID, 0xa149, "C236", IchChipset::Series100SunrisePoint),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0xa150,
+        "CM236",
+        IchChipset::Series100SunrisePoint,
+    ),
+    // C620 Series (Lewisburg)
+    ChipsetEnable::new(INTEL_VID, 0xa1a4, "C620 Series", IchChipset::C620Lewisburg),
+    ChipsetEnable::new(INTEL_VID, 0xa1c1, "C621 Series", IchChipset::C620Lewisburg),
+    ChipsetEnable::new(INTEL_VID, 0xa1c2, "C622 Series", IchChipset::C620Lewisburg),
+    ChipsetEnable::new(INTEL_VID, 0xa1c3, "C624 Series", IchChipset::C620Lewisburg),
+    ChipsetEnable::new(INTEL_VID, 0xa1c6, "C627 Series", IchChipset::C620Lewisburg),
+    ChipsetEnable::new(INTEL_VID, 0xa1c7, "C628 Series", IchChipset::C620Lewisburg),
+    // 300 Series (Cannon Point)
+    ChipsetEnable::new(INTEL_VID, 0xa303, "H310", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa304, "H370", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa305, "Z390", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa306, "Q370", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa308, "B360", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa30d, "HM370", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(
+        INTEL_VID,
+        0xa324,
+        "Cannon Point LP",
+        IchChipset::Series300CannonPoint,
+    ),
+    // 400 Series (Comet Lake)
+    ChipsetEnable::new(INTEL_VID, 0xa3c8, "B460", IchChipset::Series300CannonPoint),
+    ChipsetEnable::new(INTEL_VID, 0xa3da, "H410", IchChipset::Series300CannonPoint),
+    // Lunar Lake
+    ChipsetEnable::new(INTEL_VID, 0xa823, "Lunar Lake", IchChipset::LunarLake),
+    // Arrow Lake
+    ChipsetEnable::new(INTEL_VID, 0xae23, "Arrow Lake", IchChipset::ArrowLake),
+];
+
+/// Find a chipset enable entry by PCI vendor/device ID
+pub fn find_chipset(vendor_id: u16, device_id: u16) -> Option<&'static ChipsetEnable> {
+    INTEL_CHIPSETS
+        .iter()
+        .find(|enable| enable.vendor_id == vendor_id && enable.device_id == device_id)
+}

--- a/crates/fstart-driver-intel-spi/src/lib.rs
+++ b/crates/fstart-driver-intel-spi/src/lib.rs
@@ -1,0 +1,1620 @@
+//! Intel ICH/PCH SPI Controller Driver
+//!
+//! This module implements the SPI controller driver for Intel ICH/PCH chipsets.
+//! It supports both hardware sequencing (hwseq) and software sequencing (swseq)
+//! modes.
+//!
+//! # Supported Chipsets
+//!
+//! - ICH7: Original SPI controller (swseq only)
+//! - ICH8: ICH9-like registers at the ICH7 RCBA offset; uses swseq here
+//!   because the hardware-sequencing FPB is undocumented
+//! - ICH9-ICH10 and 5-9 Series (Ibex Peak through Wildcat Point): hwseq when
+//!   descriptor-backed, swseq otherwise
+//! - 100+ Series (Sunrise Point and later): New register layout, hwseq only
+//!
+//! # Operating Modes
+//!
+//! - **Hardware Sequencing**: The SPI controller handles read/write/erase
+//!   operations internally. This is the default for PCH100+.
+//! - **Software Sequencing**: We control the SPI protocol directly.
+//!   More flexible but may not be available on locked-down systems.
+//!
+//! # TODO: Missing features from rflasher/flashprog
+//!
+//! The following features are implemented in rflasher but not yet here:
+//!
+//! ## Access Permission Handling (MEDIUM priority)
+//! - `handle_access_permissions()` - Check FRAP/FREG for region access
+//! - `handle_protected_ranges()` - Check/clear PRx registers when not locked
+//! - BIOS_BM_WAP/RAP reading for C740+ chipsets
+
+#![no_std]
+#![allow(dead_code)]
+
+use core::cell::UnsafeCell;
+
+use serde::{Deserialize, Serialize};
+
+use fstart_services::{BlockDevice, Device, DeviceError, ServiceError};
+
+mod chipsets;
+mod regs;
+
+pub use chipsets::IchChipset;
+use regs::*;
+
+type Result<T> = core::result::Result<T, SpiError>;
+
+/// Intel SPI driver error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpiError {
+    UnsupportedChipset,
+    InitFailed,
+    WriteProtected,
+    AccessDenied,
+    CycleError,
+    Timeout,
+    InvalidArgument,
+    AddressOutOfRange,
+    InvalidDescriptor,
+    NotSupported,
+}
+
+/// SPI controller operating mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SpiMode {
+    /// Automatic mode selection.
+    #[default]
+    Auto,
+    /// Force hardware sequencing.
+    HardwareSequencing,
+    /// Force software sequencing.
+    SoftwareSequencing,
+}
+
+#[derive(Clone, Copy)]
+struct PciAddress {
+    bus: u8,
+    device: u8,
+    function: u8,
+}
+
+impl PciAddress {
+    const fn new(bus: u8, device: u8, function: u8) -> Self {
+        Self {
+            bus,
+            device,
+            function,
+        }
+    }
+}
+
+struct PciDevice {
+    address: PciAddress,
+}
+
+fn pci_read_config_u8(addr: PciAddress, reg: u8) -> u8 {
+    let shift = (reg & 3) * 8;
+    ((unsafe { fstart_pio::pci_cfg_read32(addr.bus, addr.device, addr.function, reg & !3) }
+        >> shift)
+        & 0xff) as u8
+}
+
+fn pci_read_config_u32(addr: PciAddress, reg: u8) -> u32 {
+    unsafe { fstart_pio::pci_cfg_read32(addr.bus, addr.device, addr.function, reg) }
+}
+
+fn pci_write_config_u8(addr: PciAddress, reg: u8, val: u8) {
+    let shift = (reg & 3) * 8;
+    let aligned = reg & !3;
+    let mut cur =
+        unsafe { fstart_pio::pci_cfg_read32(addr.bus, addr.device, addr.function, aligned) };
+    cur = (cur & !(0xff << shift)) | (u32::from(val) << shift);
+    unsafe { fstart_pio::pci_cfg_write32(addr.bus, addr.device, addr.function, aligned, cur) };
+}
+
+struct MmioRegion {
+    base: u64,
+}
+
+impl MmioRegion {
+    unsafe fn new(base: u64, _size: usize) -> Self {
+        Self { base }
+    }
+
+    fn read8(&self, offset: u64) -> u8 {
+        unsafe { core::ptr::read_volatile((self.base + offset) as *const u8) }
+    }
+    fn read16(&self, offset: u64) -> u16 {
+        unsafe { core::ptr::read_volatile((self.base + offset) as *const u16) }
+    }
+    fn read32(&self, offset: u64) -> u32 {
+        unsafe { core::ptr::read_volatile((self.base + offset) as *const u32) }
+    }
+    fn write8(&self, offset: u64, value: u8) {
+        unsafe { core::ptr::write_volatile((self.base + offset) as *mut u8, value) }
+    }
+    fn write16(&self, offset: u64, value: u16) {
+        unsafe { core::ptr::write_volatile((self.base + offset) as *mut u16, value) }
+    }
+    fn write32(&self, offset: u64, value: u32) {
+        unsafe { core::ptr::write_volatile((self.base + offset) as *mut u32, value) }
+    }
+}
+
+fn delay_us(us: u32) {
+    for _ in 0..us.saturating_mul(64) {
+        core::hint::spin_loop();
+    }
+}
+
+trait SpiController {
+    fn name(&self) -> &'static str;
+    fn is_locked(&self) -> bool;
+    fn writes_enabled(&self) -> bool;
+    fn enable_writes(&mut self) -> Result<()>;
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()>;
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<()>;
+    fn erase(&mut self, addr: u32, len: u32) -> Result<()>;
+    fn mode(&self) -> SpiMode;
+    fn get_bios_region(&self) -> Option<(u32, u32)>;
+}
+
+const SWSEQ_MAX_DATA: usize = 64;
+const SPI_WRITE_TIMEOUT_US: u32 = 60_000_000;
+const SPI_CYCLE_TIMEOUT_US: u32 = 60_000;
+const SWSEQ_3B_ADDR_MASK: u32 = 0x00ff_ffff;
+const ICH7_REG_BBAR: u64 = 0x50;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OpcodeType {
+    Read,
+    Write,
+    AddressRead,
+    AddressWrite,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Opcode {
+    code: u8,
+    kind: OpcodeType,
+    atomic: u8,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Opcodes {
+    preop: [u8; 2],
+    table: [Opcode; 8],
+}
+
+impl Default for Opcodes {
+    fn default() -> Self {
+        Self {
+            preop: [JEDEC_WREN, JEDEC_EWSR],
+            table: [
+                Opcode {
+                    code: JEDEC_BYTE_PROGRAM,
+                    kind: OpcodeType::AddressWrite,
+                    atomic: 1,
+                },
+                Opcode {
+                    code: JEDEC_READ,
+                    kind: OpcodeType::AddressRead,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_SE,
+                    kind: OpcodeType::AddressWrite,
+                    atomic: 1,
+                },
+                Opcode {
+                    code: JEDEC_RDSR,
+                    kind: OpcodeType::Read,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_REMS,
+                    kind: OpcodeType::AddressRead,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_WRSR,
+                    kind: OpcodeType::Write,
+                    atomic: 2,
+                },
+                Opcode {
+                    code: JEDEC_RDID,
+                    kind: OpcodeType::Read,
+                    atomic: 0,
+                },
+                Opcode {
+                    code: JEDEC_CE_C7,
+                    kind: OpcodeType::Write,
+                    atomic: 1,
+                },
+            ],
+        }
+    }
+}
+
+impl Opcodes {
+    fn find(&self, code: u8) -> Option<Opcode> {
+        self.table.iter().copied().find(|op| op.code == code)
+    }
+
+    fn opmenu(&self) -> u64 {
+        let mut value = 0u64;
+        for (i, op) in self.table.iter().enumerate() {
+            value |= (op.code as u64) << (i * 8);
+        }
+        value
+    }
+
+    fn optype(&self) -> u16 {
+        let mut value = 0u16;
+        for (i, op) in self.table.iter().enumerate() {
+            let ty = match op.kind {
+                OpcodeType::Read => 0,
+                OpcodeType::Write => 1,
+                OpcodeType::AddressRead => 2,
+                OpcodeType::AddressWrite => 3,
+            };
+            value |= ty << (i * 2);
+        }
+        value
+    }
+}
+
+/// Intel ICH/PCH SPI flash controller configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IntelSpiConfig {
+    /// Chipset generation/register layout.
+    pub chipset: IchChipset,
+    /// LPC/eSPI bridge PCI bus.
+    #[serde(default)]
+    pub lpc_bus: u8,
+    /// LPC/eSPI bridge PCI device.
+    #[serde(default = "default_lpc_device")]
+    pub lpc_device: u8,
+    /// LPC/eSPI bridge PCI function.
+    #[serde(default)]
+    pub lpc_function: u8,
+    /// Requested sequencing mode.
+    #[serde(default)]
+    pub mode: SpiMode,
+}
+
+const fn default_lpc_device() -> u8 {
+    0x1f
+}
+
+/// Intel ICH/PCH SPI flash block device.
+pub struct IntelSpi {
+    controller: UnsafeCell<Option<IntelSpiController>>,
+    config: &'static IntelSpiConfig,
+}
+
+// SAFETY: the driver serializes access through firmware's single-threaded
+// execution model; interior mutability is used only to satisfy BlockDevice's
+// shared-reference API for MMIO register transactions.
+unsafe impl Send for IntelSpi {}
+// SAFETY: see Send; no concurrent firmware threads access this device.
+unsafe impl Sync for IntelSpi {}
+
+impl Device for IntelSpi {
+    const NAME: &'static str = "intel-spi";
+    const COMPATIBLE: &'static [&'static str] = &["intel,ich-spi", "intel-spi"];
+    type Config = IntelSpiConfig;
+
+    fn new(config: &'static Self::Config) -> core::result::Result<Self, DeviceError> {
+        Ok(Self {
+            controller: UnsafeCell::new(None),
+            config,
+        })
+    }
+
+    fn init(&mut self) -> core::result::Result<(), DeviceError> {
+        let pci_dev = PciDevice {
+            address: PciAddress::new(
+                self.config.lpc_bus,
+                self.config.lpc_device,
+                self.config.lpc_function,
+            ),
+        };
+        let controller = IntelSpiController::new(&pci_dev, self.config.chipset, self.config.mode)
+            .map_err(|_| DeviceError::InitFailed)?;
+        *self.controller.get_mut() = Some(controller);
+        Ok(())
+    }
+}
+
+impl IntelSpi {
+    fn with_controller_mut<R>(
+        &self,
+        f: impl FnOnce(&mut IntelSpiController) -> Result<R>,
+    ) -> Result<R> {
+        let controller = unsafe { &mut *self.controller.get() };
+        let Some(controller) = controller.as_mut() else {
+            return Err(SpiError::InitFailed);
+        };
+        f(controller)
+    }
+}
+
+impl BlockDevice for IntelSpi {
+    fn read(&self, offset: u64, buf: &mut [u8]) -> core::result::Result<usize, ServiceError> {
+        let addr = u32::try_from(offset).map_err(|_| ServiceError::InvalidParam)?;
+        self.with_controller_mut(|controller| controller.read(addr, buf))
+            .map_err(spi_to_service_error)?;
+        Ok(buf.len())
+    }
+
+    fn write(&self, offset: u64, buf: &[u8]) -> core::result::Result<usize, ServiceError> {
+        let addr = u32::try_from(offset).map_err(|_| ServiceError::InvalidParam)?;
+        self.with_controller_mut(|controller| {
+            if !controller.writes_enabled() {
+                controller.enable_writes()?;
+            }
+            controller.write(addr, buf)
+        })
+        .map_err(spi_to_service_error)?;
+        Ok(buf.len())
+    }
+
+    fn erase(&self, offset: u64, size: u64) -> core::result::Result<(), ServiceError> {
+        let addr = u32::try_from(offset).map_err(|_| ServiceError::InvalidParam)?;
+        let len = u32::try_from(size).map_err(|_| ServiceError::InvalidParam)?;
+        self.with_controller_mut(|controller| {
+            if !controller.writes_enabled() {
+                controller.enable_writes()?;
+            }
+            controller.erase(addr, len)
+        })
+        .map_err(spi_to_service_error)
+    }
+
+    fn size(&self) -> u64 {
+        self.with_controller_mut(|controller| Ok(controller.flash_size))
+            .unwrap_or(0)
+            .into()
+    }
+
+    fn block_size(&self) -> u32 {
+        1
+    }
+}
+
+fn spi_to_service_error(error: SpiError) -> ServiceError {
+    match error {
+        SpiError::Timeout => ServiceError::Timeout,
+        SpiError::InvalidArgument | SpiError::AddressOutOfRange => ServiceError::InvalidParam,
+        SpiError::WriteProtected | SpiError::AccessDenied => ServiceError::HardwareError,
+        SpiError::NotSupported | SpiError::UnsupportedChipset => ServiceError::NotSupported,
+        _ => ServiceError::HardwareError,
+    }
+}
+
+/// Intel ICH/PCH SPI Controller
+struct IntelSpiController {
+    /// Memory-mapped SPI registers
+    spibar: MmioRegion,
+    /// Chipset generation
+    generation: IchChipset,
+    /// PCI address of LPC/eSPI bridge
+    lpc_addr: PciAddress,
+    /// Whether configuration is locked (HSFS.FLOCKDN)
+    locked: bool,
+    /// Whether software sequencing is locked (DLOCK.SSEQ_LOCKDN on PCH100+)
+    swseq_locked: bool,
+    /// Flash descriptor valid
+    desc_valid: bool,
+    /// Actual operating mode (after validation)
+    mode: SpiMode,
+    /// BIOS Write Enable state
+    writes_enabled: bool,
+    /// Address mask for hardware sequencing
+    hwseq_addr_mask: u32,
+    /// HSFC FCYCLE field mask
+    hsfc_fcycle_mask: u16,
+    /// Total flash size in bytes (derived from flash descriptor or address mask)
+    flash_size: u32,
+    /// Current opcodes (for software sequencing)
+    opcodes: Opcodes,
+    /// Effective software-sequencing lower address bound from BBAR, when applicable.
+    swseq_bbar_lower_bound: Option<u32>,
+}
+
+impl IntelSpiController {
+    /// Initialize a new SPI controller for the detected chipset
+    pub fn new(
+        pci_dev: &PciDevice,
+        generation: IchChipset,
+        requested_mode: SpiMode,
+    ) -> Result<Self> {
+        // Get SPI BAR address
+        let spibar_addr = Self::get_spibar_address(pci_dev, generation)?;
+        fstart_log::debug!("SPI BAR at physical address: {:#x}", spibar_addr);
+
+        // Map the SPI registers (512 bytes should be enough for all generations)
+        // SAFETY: spibar_addr is decoded from the chipset's SPI BAR register,
+        // a valid MMIO region for SPI controller registers.
+        let spibar = unsafe { MmioRegion::new(spibar_addr, 0x200) };
+
+        // Determine address mask based on generation
+        let hwseq_addr_mask = if generation.is_pch100_compatible() {
+            PCH100_FADDR_FLA
+        } else {
+            ICH9_FADDR_FLA
+        };
+
+        // Initialize controller with default values
+        // flash_size starts as the maximum addressable size based on address mask,
+        // and will be refined during init() if a valid flash descriptor is present
+        let mut controller = Self {
+            spibar,
+            generation,
+            lpc_addr: pci_dev.address,
+            locked: false,
+            swseq_locked: false,
+            desc_valid: false,
+            mode: SpiMode::Auto,
+            writes_enabled: false,
+            hwseq_addr_mask,
+            hsfc_fcycle_mask: if generation.is_pch100_compatible() {
+                PCH100_HSFC_FCYCLE
+            } else {
+                HSFC_FCYCLE
+            },
+            // Default to max addressable size; will be refined from flash descriptor
+            flash_size: hwseq_addr_mask + 1,
+            opcodes: Opcodes::default(),
+            swseq_bbar_lower_bound: None,
+        };
+
+        // Initialize the controller
+        controller.init(requested_mode)?;
+
+        Ok(controller)
+    }
+
+    /// Get the SPI BAR physical address from PCI config space
+    fn get_spibar_address(pci_dev: &PciDevice, generation: IchChipset) -> Result<u64> {
+        if generation.is_pch100_compatible() {
+            // PCH100+ (Sunrise Point and later): SPI controller is a separate PCI device
+            // at function 5 (00:1f.5), not part of the LPC bridge at function 0.
+            let spi_addr = PciAddress::new(pci_dev.address.bus, pci_dev.address.device, 5);
+
+            // Read SPIBAR (BAR0) from PCI config space
+            let spibar_raw = pci_read_config_u32(spi_addr, PCI_REG_SPIBAR);
+
+            // SPIBAR is a 32-bit memory BAR. Mask off the lower 12 bits
+            let addr = (spibar_raw & 0xFFFF_F000) as u64;
+
+            fstart_log::debug!(
+                "Raw SPIBAR register: {:#010x}, masked addr: {:#010x}",
+                spibar_raw,
+                addr
+            );
+
+            if addr == 0 {
+                fstart_log::error!("SPIBAR is 0 - SPI controller may be hidden or disabled");
+                return Err(SpiError::InitFailed);
+            }
+
+            Ok(addr)
+        } else if generation.is_ich9_compatible() || generation == IchChipset::Ich7 {
+            // ICH7-ICH10, 5-9 Series: SPI is at an offset within RCBA
+            Self::get_spibar_via_rcba(pci_dev, generation)
+        } else {
+            Err(SpiError::UnsupportedChipset)
+        }
+    }
+
+    /// Get SPI BAR via RCBA (Root Complex Base Address)
+    fn get_spibar_via_rcba(pci_dev: &PciDevice, generation: IchChipset) -> Result<u64> {
+        // Read RCBA from LPC bridge config space
+        let rcba = pci_read_config_u32(pci_dev.address, PCI_REG_RCBA);
+
+        // Check if RCBA is enabled (bit 0)
+        if rcba & 1 == 0 {
+            fstart_log::error!("RCBA not enabled");
+            return Err(SpiError::InitFailed);
+        }
+
+        // RCBA is 32-bit aligned, mask off lower bits
+        let rcba_base = (rcba & !0x3FFF) as u64;
+
+        // SPI offset within RCBA depends on chipset generation.
+        // ICH7 and ICH8 both use RCBA+0x3020; ICH9 moved the SPI BAR to RCBA+0x3800.
+        // (TunnelCreek and Centerton also use 0x3020 when they are added.)
+        let spi_offset = match generation {
+            IchChipset::Ich7 | IchChipset::Ich8 => RCBA_SPI_OFFSET_ICH7,
+            _ => RCBA_SPI_OFFSET_ICH9,
+        };
+
+        Ok(rcba_base + spi_offset)
+    }
+
+    /// Initialize the SPI controller
+    fn init(&mut self, requested_mode: SpiMode) -> Result<()> {
+        if self.generation == IchChipset::Ich7 {
+            self.init_ich7(requested_mode)
+        } else if self.generation.is_ich9_compatible() {
+            self.init_ich9(requested_mode)
+        } else {
+            Err(SpiError::UnsupportedChipset)
+        }
+    }
+
+    /// Initialize ICH7 SPI controller.
+    ///
+    /// ICH7 only supports software sequencing. Opcode tables are programmed
+    /// when unlocked and read back when locked; BBAR is cleared when possible
+    /// and then tracked as a lower bound for swseq accesses.
+    fn init_ich7(&mut self, requested_mode: SpiMode) -> Result<()> {
+        if requested_mode == SpiMode::HardwareSequencing {
+            fstart_log::error!("Hardware sequencing requested but not supported on ICH7");
+            return Err(SpiError::NotSupported);
+        }
+        let spis = self.spibar.read16(ICH7_REG_SPIS);
+        fstart_log::debug!("ICH7 SPIS: {:#06x}", spis);
+
+        // Check for lockdown (bit 15 of SPIS)
+        if spis & (1 << 15) != 0 {
+            fstart_log::warn!("ICH7 SPI Configuration Lockdown activated");
+            self.locked = true;
+        }
+
+        self.init_ich7_opcodes();
+
+        self.update_ich7_bbar_lower_bound();
+
+        // ICH7 only supports swseq
+        self.mode = SpiMode::SoftwareSequencing;
+        self.desc_valid = false;
+
+        fstart_log::info!("Using swseq mode on ICH7 (hwseq not supported)");
+        Ok(())
+    }
+
+    /// Initialize ICH9+ SPI controller (including PCH100+)
+    ///
+    /// TODO: Additional init steps from rflasher:
+    /// - handle_access_permissions() - Check FRAP/FREG region access
+    /// - handle_protected_ranges() - Check/clear PRx registers
+    /// - Log SSFS/SSFC registers for debugging
+    fn init_ich9(&mut self, requested_mode: SpiMode) -> Result<()> {
+        // Read HSFS
+        let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+        fstart_log::debug!("HSFS: {:#06x}", hsfs);
+        self.print_hsfs(hsfs);
+
+        // Check for lockdown
+        if hsfs & HSFS_FLOCKDN != 0 {
+            fstart_log::info!("SPI Configuration is locked down");
+            self.locked = true;
+        }
+
+        // Check descriptor valid
+        if hsfs & HSFS_FDV != 0 {
+            self.desc_valid = true;
+            fstart_log::debug!("Flash Descriptor is valid");
+        }
+
+        // PCH100+ specific: check DLOCK.SSEQ_LOCKDN before any possible
+        // software-sequencing setup. PCH100 uses different swseq offsets, so
+        // never touch ICH9 PREOP/OPTYPE/OPMENU offsets on those chipsets.
+        if self.generation.is_pch100_compatible() {
+            let dlock = self.spibar.read32(PCH100_REG_DLOCK);
+            fstart_log::debug!("DLOCK: {:#010x}", dlock);
+            // TODO: Log all DLOCK bits like rflasher's print_dlock()
+
+            if dlock & DLOCK_SSEQ_LOCKDN != 0 {
+                fstart_log::info!("Software sequencing is locked (DLOCK.SSEQ_LOCKDN=1)");
+                self.swseq_locked = true;
+            }
+        }
+
+        // TODO: handle_access_permissions() - check FRAP/FREG
+        // TODO: handle_protected_ranges() - check/clear PRx registers
+
+        // Determine operating mode
+        self.determine_mode(requested_mode)?;
+
+        // Calculate flash size from descriptor regions
+        self.calculate_flash_size();
+
+        // Clear any pending errors
+        let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+        if hsfs & HSFS_FCERR != 0 {
+            fstart_log::debug!("Clearing HSFS.FCERR");
+            self.spibar.write16(ICH9_REG_HSFS, HSFS_FCERR);
+        }
+
+        if self.mode == SpiMode::SoftwareSequencing && !self.generation.is_pch100_compatible() {
+            self.init_ich9_opcodes();
+        }
+
+        // ICH8 and Bay Trail have ICH9-like SPI engines but no documented
+        // ICH9-compatible BBAR. Do not touch ICH9_REG_BBAR on those chipsets.
+        if !self.generation.is_pch100_compatible()
+            && self.generation != IchChipset::Ich8
+            && self.generation != IchChipset::BayTrail
+        {
+            self.update_ich9_bbar_lower_bound();
+        }
+
+        Ok(())
+    }
+
+    fn update_ich7_bbar_lower_bound(&mut self) {
+        let original = self.spibar.read32(ICH7_REG_BBAR);
+        fstart_log::debug!("ICH7 BBAR: {:#010x}", original);
+        if !self.locked {
+            self.spibar.write32(ICH7_REG_BBAR, original & !BBAR_MASK);
+        }
+        let effective = self.spibar.read32(ICH7_REG_BBAR) & BBAR_MASK;
+        self.swseq_bbar_lower_bound = Some(effective);
+        if effective != 0 {
+            fstart_log::warn!("ICH7 BBAR restricts swseq access below {:#x}", effective);
+        }
+    }
+
+    fn update_ich9_bbar_lower_bound(&mut self) {
+        let original = self.spibar.read32(ICH9_REG_BBAR);
+        fstart_log::debug!("BBAR: {:#010x}", original);
+        if !self.locked {
+            self.spibar.write32(ICH9_REG_BBAR, original & !BBAR_MASK);
+        }
+        let effective = self.spibar.read32(ICH9_REG_BBAR) & BBAR_MASK;
+        self.swseq_bbar_lower_bound = Some(effective);
+        if effective != 0 {
+            fstart_log::warn!("BBAR restricts swseq access below {:#x}", effective);
+        }
+    }
+
+    fn init_ich7_opcodes(&mut self) {
+        if self.locked {
+            self.read_ich7_opcodes();
+        } else {
+            self.program_ich7_opcodes();
+        }
+    }
+
+    fn init_ich9_opcodes(&mut self) {
+        if self.locked || self.swseq_locked {
+            self.read_ich9_opcodes();
+        } else {
+            self.program_ich9_opcodes();
+        }
+    }
+
+    fn read_ich7_opcodes(&mut self) {
+        self.opcodes.preop = self.spibar.read16(ICH7_REG_PREOP).to_le_bytes();
+        let opmenu = self.spibar.read32(ICH7_REG_OPMENU) as u64
+            | ((self.spibar.read32(ICH7_REG_OPMENU + 4) as u64) << 32);
+        let optype = self.spibar.read16(ICH7_REG_OPTYPE);
+        self.update_opcode_menu(opmenu, optype);
+    }
+
+    fn read_ich9_opcodes(&mut self) {
+        let preop = self.spibar.read16(ICH9_REG_PREOP);
+        self.opcodes.preop = preop.to_le_bytes();
+        let opmenu = self.spibar.read32(ICH9_REG_OPMENU) as u64
+            | ((self.spibar.read32(ICH9_REG_OPMENU + 4) as u64) << 32);
+        let optype = self.spibar.read16(ICH9_REG_OPTYPE);
+        self.update_opcode_menu(opmenu, optype);
+    }
+
+    fn update_opcode_menu(&mut self, opmenu: u64, optype: u16) {
+        for i in 0..8 {
+            let code = ((opmenu >> (i * 8)) & 0xff) as u8;
+            let kind = match (optype >> (i * 2)) & 0x3 {
+                0 => OpcodeType::Read,
+                1 => OpcodeType::Write,
+                2 => OpcodeType::AddressRead,
+                _ => OpcodeType::AddressWrite,
+            };
+            self.opcodes.table[i] = Opcode {
+                code,
+                kind,
+                atomic: Self::atomic_for_opcode(code, self.opcodes.preop),
+            };
+        }
+        fstart_log::debug!("SPI opcode menu: {:#018x}, type: {:#06x}", opmenu, optype);
+    }
+
+    fn atomic_for_opcode(code: u8, preop: [u8; 2]) -> u8 {
+        let wanted_preop = match code {
+            JEDEC_WRSR => JEDEC_EWSR,
+            JEDEC_BYTE_PROGRAM | JEDEC_SE | JEDEC_BE_52 | JEDEC_BE_D8 | JEDEC_CE_60
+            | JEDEC_CE_C7 => JEDEC_WREN,
+            _ => return 0,
+        };
+
+        if preop[0] == wanted_preop {
+            1
+        } else if preop[1] == wanted_preop {
+            2
+        } else {
+            0
+        }
+    }
+
+    fn program_ich7_opcodes(&self) {
+        self.spibar
+            .write16(ICH7_REG_PREOP, u16::from_le_bytes(self.opcodes.preop));
+        self.spibar.write16(ICH7_REG_OPTYPE, self.opcodes.optype());
+        let opmenu = self.opcodes.opmenu();
+        self.spibar.write32(ICH7_REG_OPMENU, opmenu as u32);
+        self.spibar
+            .write32(ICH7_REG_OPMENU + 4, (opmenu >> 32) as u32);
+    }
+
+    fn program_ich9_opcodes(&self) {
+        self.spibar
+            .write16(ICH9_REG_PREOP, u16::from_le_bytes(self.opcodes.preop));
+        self.spibar.write16(ICH9_REG_OPTYPE, self.opcodes.optype());
+        let opmenu = self.opcodes.opmenu();
+        self.spibar.write32(ICH9_REG_OPMENU, opmenu as u32);
+        self.spibar
+            .write32(ICH9_REG_OPMENU + 4, (opmenu >> 32) as u32);
+    }
+
+    /// Determine the operating mode based on hardware and user request.
+    ///
+    /// ICH7 and ICH8 use software sequencing. Later descriptor-capable
+    /// chipsets default to hardware sequencing when possible.
+    fn determine_mode(&mut self, requested: SpiMode) -> Result<()> {
+        // Validate user's explicit request
+        if requested == SpiMode::HardwareSequencing {
+            if !self.generation.supports_hwseq() {
+                fstart_log::error!("Hardware sequencing requested but not supported on ICH7");
+                return Err(SpiError::NotSupported);
+            }
+            if !self.desc_valid {
+                fstart_log::error!(
+                    "Hardware sequencing requested but flash descriptor is not valid"
+                );
+                return Err(SpiError::InvalidDescriptor);
+            }
+            if self.generation == IchChipset::Ich8 {
+                fstart_log::error!(
+                    "Hardware sequencing is not supported on ICH8: FPB is undocumented"
+                );
+                return Err(SpiError::NotSupported);
+            }
+        } else if requested == SpiMode::SoftwareSequencing {
+            if self.generation.is_pch100_compatible() {
+                fstart_log::error!(
+                    "Software sequencing is not implemented for PCH100+ register layout"
+                );
+                return Err(SpiError::NotSupported);
+            }
+            if self.swseq_locked {
+                fstart_log::error!("Software sequencing requested but locked");
+                return Err(SpiError::NotSupported);
+            }
+        }
+
+        // Determine effective mode for Auto
+        let effective_mode = if requested != SpiMode::Auto {
+            requested
+        } else if !self.generation.supports_hwseq() {
+            // ICH7: swseq only (hwseq not available)
+            fstart_log::debug!("Using swseq (ICH7 has no hwseq support)");
+            SpiMode::SoftwareSequencing
+        } else if self.generation == IchChipset::Ich8 {
+            // ICH8 has no documented FPB at the ICH9 offset; use swseq.
+            fstart_log::debug!("Using swseq on ICH8 (hwseq FPB is undocumented)");
+            SpiMode::SoftwareSequencing
+        } else if self.desc_valid {
+            if self.swseq_locked {
+                fstart_log::info!("Using hwseq (swseq is locked via DLOCK.SSEQ_LOCKDN)");
+            } else {
+                fstart_log::debug!("Using hwseq (flash descriptor valid)");
+            }
+            SpiMode::HardwareSequencing
+        } else {
+            if self.generation.is_pch100_compatible() {
+                fstart_log::error!(
+                    "PCH100+ auto mode requires a valid flash descriptor; swseq offsets are not implemented"
+                );
+                return Err(SpiError::InvalidDescriptor);
+            }
+            // No valid flash descriptor - must use swseq.
+            fstart_log::warn!("Flash descriptor not valid, falling back to swseq");
+            SpiMode::SoftwareSequencing
+        };
+
+        self.mode = effective_mode;
+        fstart_log::info!("Intel SPI mode selected");
+
+        Ok(())
+    }
+
+    /// Calculate flash size from flash descriptor regions
+    ///
+    /// When the flash descriptor is valid, we read all FREG registers to find
+    /// the highest region limit, which gives us the total flash size.
+    /// If no valid descriptor, we fall back to the maximum addressable size.
+    fn calculate_flash_size(&mut self) {
+        if !self.desc_valid {
+            // No valid descriptor, use max addressable size from address mask
+            self.flash_size = self.hwseq_addr_mask + 1;
+            fstart_log::debug!(
+                "No flash descriptor, using max addressable size: {} MB",
+                self.flash_size / (1024 * 1024)
+            );
+            return;
+        }
+
+        // Read all 5 FREG registers (FREG0-FREG4) to find highest limit
+        // FREG0 = Flash Descriptor, FREG1 = BIOS, FREG2 = ME, FREG3 = GbE, FREG4 = Platform Data
+        let mut max_limit: u32 = 0;
+
+        for i in 0..5 {
+            let freg = self.spibar.read32(ICH9_REG_FREG0 + (i * 4) as u64);
+            let base = freg_base(freg);
+            let limit = freg_limit(freg);
+
+            // A valid region has base <= limit
+            if base <= limit {
+                if limit > max_limit {
+                    max_limit = limit;
+                }
+                fstart_log::debug!("FREG{}: base={:#x}, limit={:#x}", i, base, limit);
+            }
+        }
+
+        // Flash size is the limit + 1 (since limit is the last valid address)
+        // Use saturating_add to prevent overflow
+        self.flash_size = max_limit.saturating_add(1);
+
+        // Sanity check: flash_size should not exceed address mask capability
+        let max_addressable = self.hwseq_addr_mask + 1;
+        if self.flash_size > max_addressable {
+            fstart_log::warn!(
+                "Flash size {} MB exceeds addressable range {} MB, capping",
+                self.flash_size / (1024 * 1024),
+                max_addressable / (1024 * 1024)
+            );
+            self.flash_size = max_addressable;
+        }
+
+        fstart_log::info!(
+            "Flash size: {} MB (from descriptor)",
+            self.flash_size / (1024 * 1024)
+        );
+    }
+
+    /// Print HSFS register bits for debugging
+    fn print_hsfs(&self, hsfs: u16) {
+        fstart_log::debug!(
+            "HSFS: FDONE={} FCERR={} AEL={} SCIP={} FDV={} FLOCKDN={}",
+            (hsfs & HSFS_FDONE) != 0,
+            (hsfs & HSFS_FCERR) != 0,
+            (hsfs & HSFS_AEL) != 0,
+            (hsfs & HSFS_SCIP) != 0,
+            (hsfs & HSFS_FDV) != 0,
+            (hsfs & HSFS_FLOCKDN) != 0
+        );
+    }
+
+    /// Enable BIOS write access via BIOS_CNTL register
+    fn enable_bios_write_internal(&mut self) -> Result<()> {
+        let bios_cntl = pci_read_config_u8(self.lpc_addr, PCI_REG_BIOS_CNTL);
+        fstart_log::debug!("BIOS_CNTL: {:#04x}", bios_cntl);
+
+        // Check if BIOS Lock Enable is set
+        if bios_cntl & BIOS_CNTL_BLE != 0 {
+            fstart_log::warn!("BIOS Lock Enable (BLE) is set - writes may trigger SMI");
+        }
+
+        // Check if SMM BIOS Write Protect is set
+        if bios_cntl & BIOS_CNTL_SMM_BWP != 0 {
+            fstart_log::warn!("SMM BIOS Write Protect is set - cannot enable writes");
+            return Err(SpiError::WriteProtected);
+        }
+
+        // Enable BIOS Write Enable
+        if bios_cntl & BIOS_CNTL_BWE == 0 {
+            let new_val = bios_cntl | BIOS_CNTL_BWE;
+            pci_write_config_u8(self.lpc_addr, PCI_REG_BIOS_CNTL, new_val);
+
+            // Verify
+            let verify = pci_read_config_u8(self.lpc_addr, PCI_REG_BIOS_CNTL);
+            if verify & BIOS_CNTL_BWE == 0 {
+                fstart_log::error!("Failed to enable BIOS Write Enable");
+                return Err(SpiError::WriteProtected);
+            }
+
+            fstart_log::info!("BIOS Write Enable activated");
+            self.writes_enabled = true;
+        } else {
+            fstart_log::debug!("BIOS Write Enable already active");
+            self.writes_enabled = true;
+        }
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Hardware Sequencing Operations
+    // ========================================================================
+
+    /// Set the flash address for hardware sequencing
+    ///
+    /// Returns an error if the address exceeds the flash size or address mask.
+    /// Unlike the previous implementation, this does NOT silently truncate
+    /// out-of-range addresses, which could lead to data corruption.
+    fn hwseq_set_addr(&self, addr: u32) -> Result<()> {
+        // Check if address exceeds flash size
+        if addr >= self.flash_size {
+            fstart_log::error!(
+                "Address {:#x} exceeds flash size {:#x}",
+                addr,
+                self.flash_size
+            );
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        // Check if address exceeds the hardware address mask
+        // This catches addresses that would be silently truncated
+        if addr != (addr & self.hwseq_addr_mask) {
+            fstart_log::error!(
+                "Address {:#x} exceeds hardware address space (mask {:#x})",
+                addr,
+                self.hwseq_addr_mask
+            );
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        self.spibar.write32(ICH9_REG_FADDR, addr);
+        Ok(())
+    }
+
+    /// Wait for hardware sequencing cycle to complete
+    fn hwseq_wait_for_cycle(&self, timeout_us: u32) -> Result<()> {
+        let done_or_err = HSFS_FDONE | HSFS_FCERR;
+
+        let mut elapsed = 0u32;
+        loop {
+            let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+
+            if hsfs & done_or_err != 0 {
+                // Clear status bits by writing 1s to them (W1C)
+                self.spibar.write16(ICH9_REG_HSFS, hsfs);
+
+                if hsfs & HSFS_FCERR != 0 {
+                    fstart_log::error!("Hardware sequencing cycle error");
+                    return Err(SpiError::CycleError);
+                }
+
+                return Ok(());
+            }
+
+            if elapsed >= timeout_us {
+                fstart_log::error!("Hardware sequencing timeout");
+                return Err(SpiError::Timeout);
+            }
+
+            delay_us(1);
+            elapsed += 1;
+        }
+    }
+
+    /// Read data using hardware sequencing
+    fn hwseq_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        let len = buf.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        // Validate that the entire read range fits within flash
+        let end_addr = addr
+            .checked_add(len as u32)
+            .ok_or(SpiError::AddressOutOfRange)?;
+        if end_addr > self.flash_size {
+            fstart_log::error!(
+                "Read range [{:#x}, {:#x}) exceeds flash size {:#x}",
+                addr,
+                end_addr,
+                self.flash_size
+            );
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        let mut offset = 0;
+        let mut current_addr = addr;
+
+        // Clear any pending status
+        let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+        self.spibar.write16(ICH9_REG_HSFS, hsfs);
+
+        while offset < len {
+            // Calculate block size (max 64 bytes, respect 256-byte page boundaries)
+            let remaining = len - offset;
+            let page_remaining = 256 - (current_addr as usize & 0xFF);
+            let block_len = remaining.min(HWSEQ_MAX_DATA).min(page_remaining);
+
+            self.hwseq_set_addr(current_addr)?;
+
+            // Set up read cycle
+            let mut hsfc = self.spibar.read16(ICH9_REG_HSFC);
+            hsfc &= !self.hsfc_fcycle_mask; // Clear FCYCLE (0 = read)
+            hsfc &= !HSFC_FDBC; // Clear byte count
+            hsfc |= ((block_len - 1) as u16) << HSFC_FDBC_OFF; // Set byte count
+            hsfc |= HSFC_FGO; // Start
+            self.spibar.write16(ICH9_REG_HSFC, hsfc);
+
+            // Wait for completion (30 second timeout)
+            self.hwseq_wait_for_cycle(30_000_000)?;
+
+            // Read data from FDATA registers
+            self.read_fdata(&mut buf[offset..offset + block_len]);
+
+            offset += block_len;
+            current_addr += block_len as u32;
+        }
+
+        Ok(())
+    }
+
+    /// Write data using hardware sequencing
+    fn hwseq_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        let len = data.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+
+        // Validate that the entire write range fits within flash
+        let end_addr = addr
+            .checked_add(len as u32)
+            .ok_or(SpiError::AddressOutOfRange)?;
+        if end_addr > self.flash_size {
+            fstart_log::error!(
+                "Write range [{:#x}, {:#x}) exceeds flash size {:#x}",
+                addr,
+                end_addr,
+                self.flash_size
+            );
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        let mut offset = 0;
+        let mut current_addr = addr;
+
+        // Clear any pending status
+        let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+        self.spibar.write16(ICH9_REG_HSFS, hsfs);
+
+        while offset < len {
+            // Calculate block size (max 64 bytes, respect 256-byte page boundaries)
+            let remaining = len - offset;
+            let page_remaining = 256 - (current_addr as usize & 0xFF);
+            let block_len = remaining.min(HWSEQ_MAX_DATA).min(page_remaining);
+
+            self.hwseq_set_addr(current_addr)?;
+
+            // Fill data registers first (before starting cycle)
+            self.write_fdata(&data[offset..offset + block_len]);
+
+            // Set up write cycle
+            let mut hsfc = self.spibar.read16(ICH9_REG_HSFC);
+            hsfc &= !self.hsfc_fcycle_mask; // Clear FCYCLE
+            hsfc |= 0x2 << HSFC_FCYCLE_OFF; // Set write cycle
+            hsfc &= !HSFC_FDBC; // Clear byte count
+            hsfc |= ((block_len - 1) as u16) << HSFC_FDBC_OFF; // Set byte count
+            hsfc |= HSFC_FGO; // Start
+            self.spibar.write16(ICH9_REG_HSFC, hsfc);
+
+            // Wait for completion (30 second timeout)
+            self.hwseq_wait_for_cycle(30_000_000)?;
+
+            offset += block_len;
+            current_addr += block_len as u32;
+        }
+
+        Ok(())
+    }
+
+    /// Erase a block using hardware sequencing
+    fn hwseq_erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+
+        // Hardware sequencing uses 4KB erase blocks
+        const ERASE_SIZE: u32 = 4096;
+
+        if addr & (ERASE_SIZE - 1) != 0 || len & (ERASE_SIZE - 1) != 0 {
+            fstart_log::error!("Erase address/length must be 4KB aligned");
+            return Err(SpiError::InvalidArgument);
+        }
+
+        let mut current_addr = addr;
+        let end_addr = addr.checked_add(len).ok_or(SpiError::AddressOutOfRange)?;
+
+        // Validate that the entire erase range fits within flash
+        if end_addr > self.flash_size {
+            fstart_log::error!(
+                "Erase range [{:#x}, {:#x}) exceeds flash size {:#x}",
+                addr,
+                end_addr,
+                self.flash_size
+            );
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        // Clear any pending status
+        let hsfs = self.spibar.read16(ICH9_REG_HSFS);
+        self.spibar.write16(ICH9_REG_HSFS, hsfs);
+
+        while current_addr < end_addr {
+            self.hwseq_set_addr(current_addr)?;
+
+            // Set up erase cycle
+            let mut hsfc = self.spibar.read16(ICH9_REG_HSFC);
+            hsfc &= !self.hsfc_fcycle_mask; // Clear FCYCLE
+            hsfc |= 0x3 << HSFC_FCYCLE_OFF; // Set erase cycle
+            hsfc |= HSFC_FGO; // Start
+            self.spibar.write16(ICH9_REG_HSFC, hsfc);
+
+            // Wait for completion (60 second timeout for erase)
+            self.hwseq_wait_for_cycle(60_000_000)?;
+
+            current_addr += ERASE_SIZE;
+        }
+
+        Ok(())
+    }
+
+    fn swseq_addr_mask(&self) -> Result<u32> {
+        if self.generation.is_pch100_compatible() {
+            Err(SpiError::NotSupported)
+        } else {
+            // Only 3-byte address opcodes are implemented for swseq today.
+            Ok(SWSEQ_3B_ADDR_MASK)
+        }
+    }
+
+    fn validate_swseq_range(&self, addr: u32, len: usize) -> Result<()> {
+        if len > u32::MAX as usize {
+            return Err(SpiError::AddressOutOfRange);
+        }
+        let len = len as u32;
+        let end = addr.checked_add(len).ok_or(SpiError::AddressOutOfRange)?;
+        if end > self.flash_size {
+            return Err(SpiError::AddressOutOfRange);
+        }
+
+        let mask = self.swseq_addr_mask()?;
+        if len != 0 {
+            let last = end - 1;
+            if addr != (addr & mask) || last != (last & mask) {
+                return Err(SpiError::AddressOutOfRange);
+            }
+            if self
+                .swseq_bbar_lower_bound
+                .is_some_and(|lower_bound| addr < lower_bound)
+            {
+                let lower_bound = self.swseq_bbar_lower_bound.unwrap_or(0);
+                fstart_log::error!(
+                    "Swseq range starts below effective BBAR lower bound: addr={:#x}, BBAR={:#x}",
+                    addr,
+                    lower_bound
+                );
+                return Err(SpiError::AddressOutOfRange);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn swseq_read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        self.validate_swseq_range(addr, buf.len())?;
+        let op = self
+            .opcodes
+            .find(JEDEC_READ)
+            .ok_or(SpiError::NotSupported)?;
+        let mut offset = 0;
+        while offset < buf.len() {
+            let chunk = (buf.len() - offset).min(SWSEQ_MAX_DATA);
+            self.run_swseq_opcode(op, addr + offset as u32, &mut buf[offset..offset + chunk])?;
+            offset += chunk;
+        }
+        Ok(())
+    }
+
+    fn swseq_write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+        self.validate_swseq_range(addr, data.len())?;
+        let op = self
+            .opcodes
+            .find(JEDEC_BYTE_PROGRAM)
+            .ok_or(SpiError::NotSupported)?;
+        let mut offset = 0;
+        while offset < data.len() {
+            let page_remaining = 256 - ((addr as usize + offset) & 0xff);
+            let chunk = (data.len() - offset)
+                .min(SWSEQ_MAX_DATA)
+                .min(page_remaining);
+            let mut scratch = [0u8; SWSEQ_MAX_DATA];
+            scratch[..chunk].copy_from_slice(&data[offset..offset + chunk]);
+            self.run_swseq_opcode(op, addr + offset as u32, &mut scratch[..chunk])?;
+            self.swseq_wait_wip(SPI_WRITE_TIMEOUT_US)?;
+            offset += chunk;
+        }
+        Ok(())
+    }
+
+    fn swseq_erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        if !self.writes_enabled {
+            return Err(SpiError::WriteProtected);
+        }
+        const ERASE_SIZE: u32 = 4096;
+        if addr & (ERASE_SIZE - 1) != 0 || len & (ERASE_SIZE - 1) != 0 {
+            return Err(SpiError::InvalidArgument);
+        }
+        self.validate_swseq_range(addr, len as usize)?;
+        let op = self.opcodes.find(JEDEC_SE).ok_or(SpiError::NotSupported)?;
+        let mut current = addr;
+        let end = addr.checked_add(len).ok_or(SpiError::AddressOutOfRange)?;
+        while current < end {
+            self.run_swseq_opcode(op, current, &mut [])?;
+            self.swseq_wait_wip(SPI_WRITE_TIMEOUT_US)?;
+            current += ERASE_SIZE;
+        }
+        Ok(())
+    }
+
+    fn run_swseq_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        if self.generation == IchChipset::Ich7 {
+            self.run_ich7_opcode(op, addr, data)
+        } else {
+            self.run_ich9_opcode(op, addr, data)
+        }
+    }
+
+    fn opcode_index(&self, op: Opcode) -> Result<u8> {
+        self.opcodes
+            .table
+            .iter()
+            .position(|candidate| candidate.code == op.code)
+            .map(|i| i as u8)
+            .ok_or(SpiError::NotSupported)
+    }
+
+    fn swseq_wait_wip(&mut self, timeout_us: u32) -> Result<()> {
+        let op = self
+            .opcodes
+            .find(JEDEC_RDSR)
+            .ok_or(SpiError::NotSupported)?;
+        let mut elapsed = 0;
+        loop {
+            let mut status = [0u8; 1];
+            self.run_swseq_opcode(op, 0, &mut status)?;
+            if status[0] & 1 == 0 {
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn run_ich7_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        let is_write = matches!(op.kind, OpcodeType::Write | OpcodeType::AddressWrite);
+        let index = self.opcode_index(op)?;
+        let mut elapsed = 0;
+        while self.spibar.read16(ICH7_REG_SPIS) & SPIS_SCIP != 0 {
+            if elapsed >= SPI_CYCLE_TIMEOUT_US {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+
+        let old_addr = self.spibar.read32(ICH7_REG_SPIA) & !0x00ff_ffff;
+        self.spibar
+            .write32(ICH7_REG_SPIA, old_addr | (addr & 0x00ff_ffff));
+        if is_write && !data.is_empty() {
+            self.write_ich7_data(data);
+        }
+
+        let mut spis = self.spibar.read16(ICH7_REG_SPIS) & SPIS_RESERVED_MASK;
+        spis |= SPIS_CDS | SPIS_FCERR;
+        self.spibar.write16(ICH7_REG_SPIS, spis);
+
+        let mut spic = ((index as u16) << 4) & 0x0070;
+        if !data.is_empty() {
+            spic |= SPIC_DS | (((data.len() as u16 - 1) & 0x3f) << 8);
+        }
+        if op.atomic == 2 {
+            spic |= SPIC_SPOP;
+        }
+        if op.atomic != 0 {
+            spic |= SPIC_ACS;
+        }
+        spic |= SPIC_SCGO;
+        self.spibar.write16(ICH7_REG_SPIC, spic);
+
+        self.wait_ich7_cycle(if op.atomic == 0 {
+            SPI_CYCLE_TIMEOUT_US
+        } else {
+            SPI_WRITE_TIMEOUT_US
+        })?;
+        if !is_write && !data.is_empty() {
+            self.read_ich7_data(data);
+        }
+        Ok(())
+    }
+
+    fn run_ich9_opcode(&mut self, op: Opcode, addr: u32, data: &mut [u8]) -> Result<()> {
+        let is_write = matches!(op.kind, OpcodeType::Write | OpcodeType::AddressWrite);
+        let index = self.opcode_index(op)?;
+        let mut elapsed = 0;
+        while self.spibar.read8(ICH9_REG_SSFS) as u32 & SSFS_SCIP != 0 {
+            if elapsed >= SPI_CYCLE_TIMEOUT_US {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+
+        let old_addr = self.spibar.read32(ICH9_REG_FADDR) & !ICH9_FADDR_FLA;
+        self.spibar
+            .write32(ICH9_REG_FADDR, old_addr | (addr & SWSEQ_3B_ADDR_MASK));
+        if is_write && !data.is_empty() {
+            self.write_fdata(data);
+        }
+
+        let mut ssfsc =
+            self.spibar.read32(ICH9_REG_SSFS) & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK);
+        ssfsc |= SSFS_FDONE | SSFS_FCERR | SSFC_SCF_20MHZ;
+        if !data.is_empty() {
+            ssfsc |= SSFC_DS | (((data.len() as u32 - 1) << SSFC_DBC_OFF) & SSFC_DBC);
+        }
+        ssfsc |= (index as u32) << SSFC_COP_OFF;
+        if op.atomic == 2 {
+            ssfsc |= SSFC_SPOP;
+        }
+        if op.atomic != 0 {
+            ssfsc |= SSFC_ACS;
+        }
+        ssfsc |= SSFC_SCGO;
+        self.spibar.write32(ICH9_REG_SSFS, ssfsc);
+
+        self.wait_ich9_cycle(if op.atomic == 0 {
+            SPI_CYCLE_TIMEOUT_US
+        } else {
+            SPI_WRITE_TIMEOUT_US
+        })?;
+        if !is_write && !data.is_empty() {
+            self.read_fdata(data);
+        }
+        Ok(())
+    }
+
+    fn wait_ich7_cycle(&self, timeout_us: u32) -> Result<()> {
+        let mut elapsed = 0;
+        loop {
+            let spis = self.spibar.read16(ICH7_REG_SPIS);
+            if spis & (SPIS_CDS | SPIS_FCERR) != 0 {
+                if spis & SPIS_FCERR != 0 {
+                    self.spibar
+                        .write16(ICH7_REG_SPIS, (spis & SPIS_RESERVED_MASK) | SPIS_FCERR);
+                    return Err(SpiError::CycleError);
+                }
+                self.spibar
+                    .write16(ICH7_REG_SPIS, (spis & SPIS_RESERVED_MASK) | SPIS_CDS);
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn wait_ich9_cycle(&self, timeout_us: u32) -> Result<()> {
+        let mut elapsed = 0;
+        loop {
+            let ssfsc = self.spibar.read32(ICH9_REG_SSFS);
+            if ssfsc & (SSFS_FDONE | SSFS_FCERR) != 0 {
+                if ssfsc & SSFS_FCERR != 0 {
+                    self.spibar.write32(
+                        ICH9_REG_SSFS,
+                        (ssfsc & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK)) | SSFS_FCERR,
+                    );
+                    return Err(SpiError::CycleError);
+                }
+                self.spibar.write32(
+                    ICH9_REG_SSFS,
+                    (ssfsc & (SSFS_RESERVED_MASK | SSFC_RESERVED_MASK)) | SSFS_FDONE,
+                );
+                return Ok(());
+            }
+            if elapsed >= timeout_us {
+                return Err(SpiError::Timeout);
+            }
+            delay_us(10);
+            elapsed += 10;
+        }
+    }
+
+    fn read_ich7_data(&self, buf: &mut [u8]) {
+        for (i, byte) in buf.iter_mut().enumerate() {
+            let word = self.spibar.read32(ICH7_REG_SPID0 + (i & !3) as u64);
+            *byte = (word >> ((i & 3) * 8)) as u8;
+        }
+    }
+
+    fn write_ich7_data(&self, data: &[u8]) {
+        for (i, chunk) in data.chunks(4).enumerate() {
+            let mut word = 0u32;
+            for (j, byte) in chunk.iter().enumerate() {
+                word |= (*byte as u32) << (j * 8);
+            }
+            self.spibar.write32(ICH7_REG_SPID0 + (i * 4) as u64, word);
+        }
+    }
+
+    /// Read data from FDATA registers
+    #[inline(always)]
+    fn read_fdata(&self, buf: &mut [u8]) {
+        let len = buf.len();
+        let mut offset = 0;
+
+        // Process full 32-bit words
+        while offset + 4 <= len {
+            let temp = self.spibar.read32(ICH9_REG_FDATA0 + offset as u64);
+            buf[offset] = temp as u8;
+            buf[offset + 1] = (temp >> 8) as u8;
+            buf[offset + 2] = (temp >> 16) as u8;
+            buf[offset + 3] = (temp >> 24) as u8;
+            offset += 4;
+        }
+
+        // Handle remaining bytes
+        if offset < len {
+            let temp = self.spibar.read32(ICH9_REG_FDATA0 + offset as u64);
+            let remaining = len - offset;
+            if remaining > 0 {
+                buf[offset] = temp as u8;
+            }
+            if remaining > 1 {
+                buf[offset + 1] = (temp >> 8) as u8;
+            }
+            if remaining > 2 {
+                buf[offset + 2] = (temp >> 16) as u8;
+            }
+        }
+    }
+
+    /// Write data to FDATA registers
+    #[inline(always)]
+    fn write_fdata(&self, data: &[u8]) {
+        let len = data.len();
+        if len == 0 {
+            return;
+        }
+
+        let mut offset = 0;
+
+        // Process full 32-bit words
+        while offset + 4 <= len {
+            let temp = (data[offset] as u32)
+                | ((data[offset + 1] as u32) << 8)
+                | ((data[offset + 2] as u32) << 16)
+                | ((data[offset + 3] as u32) << 24);
+            self.spibar.write32(ICH9_REG_FDATA0 + offset as u64, temp);
+            offset += 4;
+        }
+
+        // Handle remaining bytes
+        if offset < len {
+            let mut temp: u32 = 0;
+            let remaining = len - offset;
+            if remaining > 0 {
+                temp |= data[offset] as u32;
+            }
+            if remaining > 1 {
+                temp |= (data[offset + 1] as u32) << 8;
+            }
+            if remaining > 2 {
+                temp |= (data[offset + 2] as u32) << 16;
+            }
+            self.spibar.write32(ICH9_REG_FDATA0 + offset as u64, temp);
+        }
+    }
+}
+
+impl SpiController for IntelSpiController {
+    fn name(&self) -> &'static str {
+        "Intel ICH/PCH SPI"
+    }
+
+    fn is_locked(&self) -> bool {
+        self.locked
+    }
+
+    fn writes_enabled(&self) -> bool {
+        self.writes_enabled
+    }
+
+    fn enable_writes(&mut self) -> Result<()> {
+        self.enable_bios_write_internal()
+    }
+
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<()> {
+        match self.mode {
+            SpiMode::HardwareSequencing => self.hwseq_read(addr, buf),
+            SpiMode::SoftwareSequencing => self.swseq_read(addr, buf),
+            SpiMode::Auto => unreachable!("Mode should be resolved during init"),
+        }
+    }
+
+    fn write(&mut self, addr: u32, data: &[u8]) -> Result<()> {
+        match self.mode {
+            SpiMode::HardwareSequencing => self.hwseq_write(addr, data),
+            SpiMode::SoftwareSequencing => self.swseq_write(addr, data),
+            SpiMode::Auto => unreachable!("Mode should be resolved during init"),
+        }
+    }
+
+    fn erase(&mut self, addr: u32, len: u32) -> Result<()> {
+        match self.mode {
+            SpiMode::HardwareSequencing => self.hwseq_erase(addr, len),
+            SpiMode::SoftwareSequencing => self.swseq_erase(addr, len),
+            SpiMode::Auto => unreachable!("Mode should be resolved during init"),
+        }
+    }
+
+    fn mode(&self) -> SpiMode {
+        self.mode
+    }
+
+    fn get_bios_region(&self) -> Option<(u32, u32)> {
+        // Only return BIOS region if flash descriptor is valid
+        if !self.desc_valid {
+            return None;
+        }
+
+        // Read FREG1 (BIOS region) - offset 0x58 = FREG0 (0x54) + 4
+        let freg1 = self.spibar.read32(ICH9_REG_FREG0 + 4);
+        let base = freg_base(freg1);
+        let limit = freg_limit(freg1);
+
+        // Check if region is valid (base <= limit)
+        if base > limit {
+            fstart_log::debug!(
+                "BIOS region disabled (base {:#x} > limit {:#x})",
+                base,
+                limit
+            );
+            return None;
+        }
+
+        fstart_log::debug!(
+            "BIOS region (FREG1): base={:#x}, limit={:#x}, size={} KB",
+            base,
+            limit,
+            (limit - base + 1) / 1024
+        );
+
+        Some((base, limit))
+    }
+}

--- a/crates/fstart-driver-intel-spi/src/regs.rs
+++ b/crates/fstart-driver-intel-spi/src/regs.rs
@@ -1,0 +1,451 @@
+//! Intel ICH/PCH SPI Controller Register Definitions
+//!
+//! This module contains register offsets and bit definitions for the various
+//! Intel SPI controller generations, ported from flashprog's ichspi.c.
+//!
+//! # Register Layout by Generation
+//!
+//! - ICH7: Original SPI controller, software sequencing only
+//! - ICH8/ICH9: Hardware sequencing introduced, dual flash support
+//! - PCH100+: New register layout at different offsets
+//!
+//! # TODO: Missing register constants from rflasher
+//!
+//! - ICH8_REG_VSCC (0xC1) - Vendor Specific Component Capabilities
+//! - SPIS_RESERVED_MASK (0x7ff0) - ICH7 SPIS reserved bits
+//! - SSFS_RESERVED_MASK (0x000000e2) - ICH9 SSFS reserved bits  
+//! - SSFC_RESERVED_MASK (0xf8008100) - ICH9 SSFC reserved bits
+//! - SSFC_SME_OFF/SSFC_SME (bit 23) - SPI SMI# Enable
+//! - FPB_FPBA_OFF/FPB_FPBA - Flash Partition Boundary bits
+//! - HSFS_WRSDIS (bit 11) - Write Status Disable for PCH100+
+//! - HSFS_PRR34_LOCKDN (bit 12) - PRR3/PRR4 Lock-Down for PCH100+
+//! - HSFC_WET (bit 5) - Write Enable Type
+
+// ============================================================================
+// ICH7 Register Definitions
+// ============================================================================
+
+/// ICH7 SPI Status register (16 bits)
+pub const ICH7_REG_SPIS: u64 = 0x00;
+/// ICH7 SPI Control register (16 bits)
+pub const ICH7_REG_SPIC: u64 = 0x02;
+/// ICH7 SPI Address register (32 bits)
+pub const ICH7_REG_SPIA: u64 = 0x04;
+/// ICH7 SPI Data registers (64 bytes starting here)
+pub const ICH7_REG_SPID0: u64 = 0x08;
+/// ICH7 Pre-opcode register (16 bits)
+pub const ICH7_REG_PREOP: u64 = 0x54;
+/// ICH7 Opcode Type register (16 bits)
+pub const ICH7_REG_OPTYPE: u64 = 0x56;
+/// ICH7 Opcode Menu register (64 bits)
+pub const ICH7_REG_OPMENU: u64 = 0x58;
+
+// ICH7 SPIS bits
+/// SPI Cycle In Progress
+pub const SPIS_SCIP: u16 = 0x0001;
+/// SPI Cycle Grant
+pub const SPIS_GRANT: u16 = 0x0002;
+/// Cycle Done Status
+pub const SPIS_CDS: u16 = 0x0004;
+/// Flash Cycle Error
+pub const SPIS_FCERR: u16 = 0x0008;
+
+// ICH7 SPIS reserved bits mask (for read-modify-write)
+/// Reserved bits in SPIS that should be preserved
+pub const SPIS_RESERVED_MASK: u16 = 0x7ff0;
+
+// ICH7 SPIC bits
+/// SPI Cycle Go
+pub const SPIC_SCGO: u16 = 0x0002;
+/// Atomic Cycle Sequence
+pub const SPIC_ACS: u16 = 0x0004;
+/// Sequence Prefix Opcode Pointer
+pub const SPIC_SPOP: u16 = 0x0008;
+/// Data Cycle
+pub const SPIC_DS: u16 = 0x4000;
+
+// ============================================================================
+// ICH9 Register Definitions
+// ============================================================================
+
+/// ICH9 Hardware Sequencing Flash Status (16 bits)
+pub const ICH9_REG_HSFS: u64 = 0x04;
+/// ICH9 Hardware Sequencing Flash Control (16 bits)
+pub const ICH9_REG_HSFC: u64 = 0x06;
+/// ICH9 Flash Address register (32 bits)
+pub const ICH9_REG_FADDR: u64 = 0x08;
+/// ICH9 Flash Data registers (64 bytes starting here)
+pub const ICH9_REG_FDATA0: u64 = 0x10;
+/// ICH9 Flash Region Access Permissions (32 bits)
+pub const ICH9_REG_FRAP: u64 = 0x50;
+/// ICH9 Flash Region 0 (32 bits each, 5 regions)
+pub const ICH9_REG_FREG0: u64 = 0x54;
+/// ICH9 Protected Range 0 (32 bits each, 5 ranges)
+pub const ICH9_REG_PR0: u64 = 0x74;
+/// ICH9 Software Sequencing Flash Status (8 bits)
+pub const ICH9_REG_SSFS: u64 = 0x90;
+/// ICH9 Software Sequencing Flash Control (24 bits)
+pub const ICH9_REG_SSFC: u64 = 0x91;
+/// ICH9 Pre-opcode register (16 bits)
+pub const ICH9_REG_PREOP: u64 = 0x94;
+/// ICH9 Opcode Type register (16 bits)
+pub const ICH9_REG_OPTYPE: u64 = 0x96;
+/// ICH9 Opcode Menu register (64 bits)
+pub const ICH9_REG_OPMENU: u64 = 0x98;
+/// ICH9 BIOS Base Address Configuration (32 bits)
+pub const ICH9_REG_BBAR: u64 = 0xA0;
+/// ICH8 Vendor Specific Component Capabilities (32 bits)
+pub const ICH8_REG_VSCC: u64 = 0xC1;
+/// ICH9 Lower Vendor Specific Component Capabilities (32 bits)
+pub const ICH9_REG_LVSCC: u64 = 0xC4;
+/// ICH9 Upper Vendor Specific Component Capabilities (32 bits)
+pub const ICH9_REG_UVSCC: u64 = 0xC8;
+/// ICH9 Flash Partition Boundary (32 bits)
+pub const ICH9_REG_FPB: u64 = 0xD0;
+
+// HSFS bits
+/// Flash Cycle Done
+pub const HSFS_FDONE_OFF: u16 = 0;
+pub const HSFS_FDONE: u16 = 1 << HSFS_FDONE_OFF;
+/// Flash Cycle Error
+pub const HSFS_FCERR_OFF: u16 = 1;
+pub const HSFS_FCERR: u16 = 1 << HSFS_FCERR_OFF;
+/// Access Error Log
+pub const HSFS_AEL_OFF: u16 = 2;
+pub const HSFS_AEL: u16 = 1 << HSFS_AEL_OFF;
+/// Block/Sector Erase Size
+pub const HSFS_BERASE_OFF: u16 = 3;
+pub const HSFS_BERASE: u16 = 0x3 << HSFS_BERASE_OFF;
+/// SPI Cycle In Progress
+pub const HSFS_SCIP_OFF: u16 = 5;
+pub const HSFS_SCIP: u16 = 1 << HSFS_SCIP_OFF;
+/// Flash Descriptor Override Pin-Strap Status
+pub const HSFS_FDOPSS_OFF: u16 = 13;
+pub const HSFS_FDOPSS: u16 = 1 << HSFS_FDOPSS_OFF;
+/// Flash Descriptor Valid
+pub const HSFS_FDV_OFF: u16 = 14;
+pub const HSFS_FDV: u16 = 1 << HSFS_FDV_OFF;
+/// Flash Configuration Lock-Down
+pub const HSFS_FLOCKDN_OFF: u16 = 15;
+pub const HSFS_FLOCKDN: u16 = 1 << HSFS_FLOCKDN_OFF;
+
+// PCH100+ specific HSFS bits
+/// Write Status Disable (Sunrise Point+)
+pub const HSFS_WRSDIS_OFF: u16 = 11;
+pub const HSFS_WRSDIS: u16 = 1 << HSFS_WRSDIS_OFF;
+/// PRR3 PRR4 Lock-Down
+pub const HSFS_PRR34_LOCKDN_OFF: u16 = 12;
+pub const HSFS_PRR34_LOCKDN: u16 = 1 << HSFS_PRR34_LOCKDN_OFF;
+
+// HSFC bits
+/// Flash Cycle Go
+pub const HSFC_FGO_OFF: u16 = 0;
+pub const HSFC_FGO: u16 = 1 << HSFC_FGO_OFF;
+/// Flash Cycle (ICH9)
+pub const HSFC_FCYCLE_OFF: u16 = 1;
+pub const HSFC_FCYCLE: u16 = 0x3 << HSFC_FCYCLE_OFF;
+/// Flash Data Byte Count
+pub const HSFC_FDBC_OFF: u16 = 8;
+pub const HSFC_FDBC: u16 = 0x3f << HSFC_FDBC_OFF;
+/// SPI SMI# Enable
+pub const HSFC_SME_OFF: u16 = 15;
+pub const HSFC_SME: u16 = 1 << HSFC_SME_OFF;
+
+// PCH100+ specific HSFC bits
+/// Flash Cycle (PCH100) - 4 bits instead of 2
+pub const PCH100_HSFC_FCYCLE_OFF: u16 = 17 - 16; // Offset within HSFC
+pub const PCH100_HSFC_FCYCLE: u16 = 0xf << PCH100_HSFC_FCYCLE_OFF;
+/// Write Enable Type
+pub const HSFC_WET_OFF: u16 = 21 - 16;
+pub const HSFC_WET: u16 = 1 << HSFC_WET_OFF;
+
+// FADDR masks
+/// ICH9 Flash Address mask (25 bits)
+pub const ICH9_FADDR_FLA: u32 = 0x01ffffff;
+/// PCH100 Flash Address mask (27 bits)
+pub const PCH100_FADDR_FLA: u32 = 0x07ffffff;
+
+// SSFS bits (Software Sequencing)
+/// SPI Cycle In Progress
+pub const SSFS_SCIP_OFF: u32 = 0;
+pub const SSFS_SCIP: u32 = 1 << SSFS_SCIP_OFF;
+/// Cycle Done Status
+pub const SSFS_FDONE_OFF: u32 = 2;
+pub const SSFS_FDONE: u32 = 1 << SSFS_FDONE_OFF;
+/// Flash Cycle Error
+pub const SSFS_FCERR_OFF: u32 = 3;
+pub const SSFS_FCERR: u32 = 1 << SSFS_FCERR_OFF;
+/// Access Error Log
+pub const SSFS_AEL_OFF: u32 = 4;
+pub const SSFS_AEL: u32 = 1 << SSFS_AEL_OFF;
+
+// SSFC bits (offset by 8 since SSFS+SSFC are combined to 32 bits)
+/// SPI Cycle Go
+pub const SSFC_SCGO_OFF: u32 = 1 + 8;
+pub const SSFC_SCGO: u32 = 1 << SSFC_SCGO_OFF;
+/// Atomic Cycle Sequence
+pub const SSFC_ACS_OFF: u32 = 2 + 8;
+pub const SSFC_ACS: u32 = 1 << SSFC_ACS_OFF;
+/// Sequence Prefix Opcode Pointer
+pub const SSFC_SPOP_OFF: u32 = 3 + 8;
+pub const SSFC_SPOP: u32 = 1 << SSFC_SPOP_OFF;
+/// Cycle Opcode Pointer
+pub const SSFC_COP_OFF: u32 = 4 + 8;
+pub const SSFC_COP: u32 = 0x7 << SSFC_COP_OFF;
+/// Data Byte Count
+pub const SSFC_DBC_OFF: u32 = 8 + 8;
+pub const SSFC_DBC: u32 = 0x3f << SSFC_DBC_OFF;
+/// Data Cycle
+pub const SSFC_DS_OFF: u32 = 14 + 8;
+pub const SSFC_DS: u32 = 1 << SSFC_DS_OFF;
+/// SPI Cycle Frequency
+pub const SSFC_SCF_OFF: u32 = 16 + 8;
+pub const SSFC_SCF: u32 = 0x7 << SSFC_SCF_OFF;
+/// 20 MHz clock
+pub const SSFC_SCF_20MHZ: u32 = 0x00000000;
+/// 33 MHz clock
+pub const SSFC_SCF_33MHZ: u32 = 0x01000000;
+/// SPI SMI# Enable
+pub const SSFC_SME_OFF: u32 = 15 + 8;
+pub const SSFC_SME: u32 = 1 << SSFC_SME_OFF;
+/// Reserved bits in SSFS that should be preserved
+pub const SSFS_RESERVED_MASK: u32 = 0x000000e2;
+/// Reserved bits in SSFC that should be preserved
+pub const SSFC_RESERVED_MASK: u32 = 0xf8008100;
+
+// BBAR bits
+/// Bottom of System Flash mask
+pub const BBAR_MASK: u32 = 0x00ffff00;
+
+// Protected Range bits
+/// Write protection enable
+pub const PR_WP_OFF: u32 = 31;
+/// Read protection enable
+pub const PR_RP_OFF: u32 = 15;
+
+// ============================================================================
+// PCH100 (Sunrise Point and later) Register Definitions
+// ============================================================================
+
+/// PCH100 Discrete Lock Bits (32 bits)
+pub const PCH100_REG_DLOCK: u64 = 0x0C;
+/// PCH100 Protected Range 0 (32 bits each, 6 ranges including GPR0)
+pub const PCH100_REG_FPR0: u64 = 0x84;
+/// PCH100 Global Protected Range 0
+pub const PCH100_REG_GPR0: u64 = 0x98;
+/// PCH100 Software Sequencing Flash Status/Control (32 bits)
+pub const PCH100_REG_SSFSC: u64 = 0xA0;
+/// PCH100 Pre-opcode register (16 bits)
+pub const PCH100_REG_PREOP: u64 = 0xA4;
+/// PCH100 Opcode Type register (16 bits)
+pub const PCH100_REG_OPTYPE: u64 = 0xA6;
+/// PCH100 Opcode Menu register (64 bits)
+pub const PCH100_REG_OPMENU: u64 = 0xA8;
+
+// DLOCK bits
+/// BMWAG Lock-Down
+pub const DLOCK_BMWAG_LOCKDN_OFF: u32 = 0;
+pub const DLOCK_BMWAG_LOCKDN: u32 = 1 << DLOCK_BMWAG_LOCKDN_OFF;
+/// BMRAG Lock-Down
+pub const DLOCK_BMRAG_LOCKDN_OFF: u32 = 1;
+pub const DLOCK_BMRAG_LOCKDN: u32 = 1 << DLOCK_BMRAG_LOCKDN_OFF;
+/// SBMWAG Lock-Down
+pub const DLOCK_SBMWAG_LOCKDN_OFF: u32 = 2;
+pub const DLOCK_SBMWAG_LOCKDN: u32 = 1 << DLOCK_SBMWAG_LOCKDN_OFF;
+/// SBMRAG Lock-Down
+pub const DLOCK_SBMRAG_LOCKDN_OFF: u32 = 3;
+pub const DLOCK_SBMRAG_LOCKDN: u32 = 1 << DLOCK_SBMRAG_LOCKDN_OFF;
+/// PR0 Lock-Down
+pub const DLOCK_PR0_LOCKDN_OFF: u32 = 8;
+pub const DLOCK_PR0_LOCKDN: u32 = 1 << DLOCK_PR0_LOCKDN_OFF;
+/// SSEQ Lock-Down
+pub const DLOCK_SSEQ_LOCKDN_OFF: u32 = 16;
+pub const DLOCK_SSEQ_LOCKDN: u32 = 1 << DLOCK_SSEQ_LOCKDN_OFF;
+
+// New access permission registers (C740+)
+/// BIOS Master Write Access Permissions
+pub const BIOS_BM_WAP: u64 = 0x11C;
+/// BIOS Master Read Access Permissions
+pub const BIOS_BM_RAP: u64 = 0x118;
+
+// Apollo Lake specific
+/// Flash Region 12 (Apollo Lake)
+pub const APL_REG_FREG12: u64 = 0xE0;
+
+// ============================================================================
+// SPI Opcode Types
+// ============================================================================
+
+/// Read without address
+pub const SPI_OPCODE_TYPE_READ_NO_ADDRESS: u8 = 0;
+/// Write without address
+pub const SPI_OPCODE_TYPE_WRITE_NO_ADDRESS: u8 = 1;
+/// Read with address
+pub const SPI_OPCODE_TYPE_READ_WITH_ADDRESS: u8 = 2;
+/// Write with address
+pub const SPI_OPCODE_TYPE_WRITE_WITH_ADDRESS: u8 = 3;
+
+// ============================================================================
+// Flash Region helpers
+// ============================================================================
+
+/// Extract base address from FREG register value
+#[inline]
+pub const fn freg_base(freg: u32) -> u32 {
+    (freg & 0x7fff) << 12
+}
+
+/// Extract limit address from FREG register value
+#[inline]
+pub const fn freg_limit(freg: u32) -> u32 {
+    ((freg >> 16) & 0x7fff) << 12 | 0xfff
+}
+
+// ============================================================================
+// PCI Configuration Space
+// ============================================================================
+
+/// PCI config offset for RCBA (Root Complex Base Address) - ICH7-ICH10
+pub const PCI_REG_RCBA: u8 = 0xF0;
+
+/// Offset to SPI registers within RCBA (ICH7 and ICH8)
+pub const RCBA_SPI_OFFSET_ICH7: u64 = 0x3020;
+/// Offset to SPI registers within RCBA (ICH9+)
+pub const RCBA_SPI_OFFSET_ICH9: u64 = 0x3800;
+
+/// SPIBAR register in LPC/eSPI controller config space (PCH100+)
+/// This is actually at function 5 (00:1f.5), BAR0
+pub const PCI_REG_SPIBAR: u8 = 0x10;
+
+// LPC Bridge BIOS_CNTL register
+/// BIOS Control Register offset
+pub const PCI_REG_BIOS_CNTL: u8 = 0xDC;
+
+// BIOS_CNTL bits
+/// BIOS Write Enable
+pub const BIOS_CNTL_BWE: u8 = 1 << 0;
+/// BIOS Lock Enable
+pub const BIOS_CNTL_BLE: u8 = 1 << 1;
+/// SPI Read Configuration Enable
+pub const BIOS_CNTL_SRC: u8 = 0x3 << 2;
+/// Top Swap Status
+pub const BIOS_CNTL_TSS: u8 = 1 << 4;
+/// SMM BIOS Write Protect Disable
+pub const BIOS_CNTL_SMM_BWP: u8 = 1 << 5;
+
+// ============================================================================
+// JEDEC opcodes (common SPI flash commands)
+// ============================================================================
+
+/// Write Enable
+pub const JEDEC_WREN: u8 = 0x06;
+/// Write Disable
+pub const JEDEC_WRDI: u8 = 0x04;
+/// Enable Write Status Register
+pub const JEDEC_EWSR: u8 = 0x50;
+/// Read Status Register
+pub const JEDEC_RDSR: u8 = 0x05;
+/// Write Status Register
+pub const JEDEC_WRSR: u8 = 0x01;
+/// Read Data
+pub const JEDEC_READ: u8 = 0x03;
+/// Fast Read
+pub const JEDEC_FAST_READ: u8 = 0x0B;
+/// Page Program
+pub const JEDEC_BYTE_PROGRAM: u8 = 0x02;
+/// Sector Erase (4KB typically)
+pub const JEDEC_SE: u8 = 0x20;
+/// Block Erase (32KB)
+pub const JEDEC_BE_52: u8 = 0x52;
+/// Block Erase (64KB)
+pub const JEDEC_BE_D8: u8 = 0xD8;
+/// Chip Erase (0x60)
+pub const JEDEC_CE_60: u8 = 0x60;
+/// Chip Erase (0xC7)
+pub const JEDEC_CE_C7: u8 = 0xC7;
+/// Read JEDEC ID
+pub const JEDEC_RDID: u8 = 0x9F;
+/// Read Electronic Manufacturer Signature
+pub const JEDEC_REMS: u8 = 0x90;
+/// Read Electronic Signature
+pub const JEDEC_RES: u8 = 0xAB;
+/// Read SFDP (Serial Flash Discoverable Parameters)
+pub const JEDEC_RDSFDP: u8 = 0x5A;
+
+// ============================================================================
+// Hardware Sequencing Constants
+// ============================================================================
+
+/// Maximum SPI data transfer size for hardware sequencing
+pub const HWSEQ_MAX_DATA: usize = 64;
+
+/// Hardware sequencing cycle types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HwSeqCycle {
+    /// Read cycle
+    Read = 0,
+    /// Reserved
+    Reserved = 1,
+    /// Write cycle
+    Write = 2,
+    /// Erase cycle (4KB)
+    Erase = 3,
+}
+
+// ============================================================================
+// TODO: Software Sequencing Data Structures
+// ============================================================================
+//
+// The following structures are needed for software sequencing support.
+// See rflasher/crates/rflasher-internal/src/ichspi.rs for reference.
+//
+// /// Opcode entry for software sequencing
+// #[derive(Debug, Clone, Copy, Default)]
+// pub struct Opcode {
+//     /// SPI opcode byte
+//     pub opcode: u8,
+//     /// Opcode type (SPI_OPCODE_TYPE_*)
+//     pub spi_type: u8,
+//     /// Atomic operation: 0 = none, 1 = preop0, 2 = preop1
+//     pub atomic: u8,
+// }
+//
+// /// Opcode table for software sequencing
+// #[derive(Debug, Clone)]
+// pub struct Opcodes {
+//     /// Pre-opcodes [WREN=0x06, EWSR=0x50]
+//     pub preop: [u8; 2],
+//     /// Main opcodes (8 slots in OPMENU register)
+//     pub opcode: [Opcode; 8],
+// }
+//
+// Default opcode configuration (like O_ST_M25P in flashprog):
+// preop: [JEDEC_WREN (0x06), JEDEC_EWSR (0x50)]
+// opcode[0]: JEDEC_BYTE_PROGRAM (0x02), WRITE_WITH_ADDRESS
+// opcode[1]: JEDEC_READ (0x03), READ_WITH_ADDRESS
+// opcode[2]: JEDEC_SE (0x20), WRITE_WITH_ADDRESS (4KB erase)
+// opcode[3]: JEDEC_RDSR (0x05), READ_NO_ADDRESS
+// opcode[4]: JEDEC_REMS (0x90), READ_WITH_ADDRESS
+// opcode[5]: JEDEC_WRSR (0x01), WRITE_NO_ADDRESS
+// opcode[6]: JEDEC_RDID (0x9F), READ_NO_ADDRESS
+// opcode[7]: JEDEC_CE_C7 (0xC7), WRITE_NO_ADDRESS (chip erase)
+//
+// /// ICH7 software sequencing register offsets
+// pub struct Ich7SwseqRegs {
+//     pub spis: u64,   // 0x00 - Status
+//     pub spic: u64,   // 0x02 - Control
+//     pub spia: u64,   // 0x04 - Address
+//     pub spid0: u64,  // 0x08 - Data (64 bytes)
+//     pub preop: u64,  // 0x54
+//     pub optype: u64, // 0x56
+//     pub opmenu: u64, // 0x58 (64-bit)
+// }
+//
+// /// ICH9+ software sequencing register offsets
+// pub struct SwseqRegs {
+//     pub ssfsc: u64,  // ICH9: 0x90 (SSFS+SSFC combined), PCH100: 0xA0
+//     pub preop: u64,  // ICH9: 0x94, PCH100: 0xA4
+//     pub optype: u64, // ICH9: 0x96, PCH100: 0xA6
+//     pub opmenu: u64, // ICH9: 0x98, PCH100: 0xA8 (64-bit)
+// }

--- a/crates/fstart-ffs/src/builder.rs
+++ b/crates/fstart-ffs/src/builder.rs
@@ -103,6 +103,28 @@ pub enum InputRegion {
         /// Fill byte (0xFF for erased flash).
         fill: u8,
     },
+    /// Raw reserved space that is physically present in this image and aligned.
+    RawAligned {
+        /// Region name (e.g., "mrc-cache").
+        name: String,
+        /// Size in bytes.
+        size: u32,
+        /// Fill byte (0xFF for erased flash).
+        fill: u8,
+        /// Required power-of-two alignment.
+        align: u32,
+    },
+    /// Raw reserved space physically present at an explicit image offset.
+    RawAt {
+        /// Region name (e.g., "mrc-cache").
+        name: String,
+        /// Offset from image base.
+        offset: u32,
+        /// Size in bytes.
+        size: u32,
+        /// Fill byte (0xFF for erased flash).
+        fill: u8,
+    },
     /// Raw flash region described in the manifest but not stored in this image.
     ///
     /// This is used for descriptor-based x86 platforms where a BIOS-region
@@ -285,6 +307,65 @@ where
                     .push(Region {
                         name: region_name,
                         offset,
+                        size: *size,
+                        content: RegionContent::Raw { fill: *fill },
+                    })
+                    .map_err(|_| "too many regions (max 6)".to_string())?;
+            }
+            InputRegion::RawAligned {
+                name,
+                size,
+                fill,
+                align,
+            } => {
+                if *align == 0 || !align.is_power_of_two() {
+                    return Err(format!(
+                        "raw region {name} has invalid alignment {align:#x}"
+                    ));
+                }
+                let align = *align as usize;
+                let pad = (align - (image.len() % align)) % align;
+                image.resize(image.len() + pad, *fill);
+                let offset = image.len() as u32;
+                image.resize(image.len() + *size as usize, *fill);
+
+                let region_name: HString<64> = HString::try_from(name.as_str())
+                    .map_err(|_| format!("region name too long: {name}"))?;
+
+                manifest_regions
+                    .push(Region {
+                        name: region_name,
+                        offset,
+                        size: *size,
+                        content: RegionContent::Raw { fill: *fill },
+                    })
+                    .map_err(|_| "too many regions (max 6)".to_string())?;
+            }
+            InputRegion::RawAt {
+                name,
+                offset,
+                size,
+                fill,
+            } => {
+                let start = *offset as usize;
+                let end = start
+                    .checked_add(*size as usize)
+                    .ok_or_else(|| format!("raw region {name} overflows image offsets"))?;
+                if start < image.len() {
+                    return Err(format!(
+                        "raw region {name} at {offset:#x} overlaps prior image data ending at {:#x}",
+                        image.len()
+                    ));
+                }
+                image.resize(end, *fill);
+
+                let region_name: HString<64> = HString::try_from(name.as_str())
+                    .map_err(|_| format!("region name too long: {name}"))?;
+
+                manifest_regions
+                    .push(Region {
+                        name: region_name,
+                        offset: *offset,
                         size: *size,
                         content: RegionContent::Raw { fill: *fill },
                     })

--- a/crates/fstart-ffs/tests/round_trip.rs
+++ b/crates/fstart-ffs/tests/round_trip.rs
@@ -1178,3 +1178,102 @@ fn test_lz4_incompressible_data() {
     assert_eq!(n, data.len());
     assert_eq!(&buf[..n], &data);
 }
+
+#[test]
+fn test_raw_at_region_manifest_offset() {
+    let (signing_key, vk) = dev_keypair();
+    let stage_data = stage_data_with_anchor(&[0xAA; 16]);
+    let config = FfsImageConfig {
+        keys: vec![vk],
+        regions: vec![
+            InputRegion::Container {
+                name: "ro".to_string(),
+                files: vec![InputFile {
+                    name: "bootblock".to_string(),
+                    file_type: FileType::StageCode,
+                    segments: vec![InputSegment {
+                        name: ".text".to_string(),
+                        kind: SegmentKind::Code,
+                        data: stage_data,
+                        mem_size: None,
+                        load_addr: 0x8000_0000,
+                        compression: Compression::None,
+                        flags: SegmentFlags::CODE,
+                    }],
+                }],
+            },
+            InputRegion::RawAt {
+                name: "mrc-cache".to_string(),
+                offset: 0x1000,
+                size: 0x100,
+                fill: 0xff,
+            },
+        ],
+    };
+
+    let ffs = build_image(&config, &make_signer(&signing_key)).expect("build should succeed");
+    assert!(ffs.image[0x1000..0x1100].iter().all(|byte| *byte == 0xff));
+
+    let reader = FfsReader::new(&ffs.image);
+    let anchor_offset = reader.scan_for_anchor().expect("should find anchor");
+    let anchor = reader
+        .read_anchor(anchor_offset)
+        .expect("anchor should parse");
+    let manifest = reader
+        .read_manifest(&anchor)
+        .expect("manifest should verify");
+    let region = FfsReader::find_region(&manifest, "mrc-cache").expect("mrc region");
+    assert_eq!(region.offset, 0x1000);
+    assert_eq!(region.size, 0x100);
+    assert!(matches!(region.content, RegionContent::Raw { fill: 0xff }));
+}
+
+#[test]
+fn test_raw_aligned_region_manifest_offset() {
+    let (signing_key, vk) = dev_keypair();
+    let stage_data = stage_data_with_anchor(&[0xBB; 17]);
+    let config = FfsImageConfig {
+        keys: vec![vk],
+        regions: vec![
+            InputRegion::Container {
+                name: "ro".to_string(),
+                files: vec![InputFile {
+                    name: "bootblock".to_string(),
+                    file_type: FileType::StageCode,
+                    segments: vec![InputSegment {
+                        name: ".text".to_string(),
+                        kind: SegmentKind::Code,
+                        data: stage_data,
+                        mem_size: None,
+                        load_addr: 0x8000_0000,
+                        compression: Compression::None,
+                        flags: SegmentFlags::CODE,
+                    }],
+                }],
+            },
+            InputRegion::RawAligned {
+                name: "mrc-cache".to_string(),
+                size: 0x100,
+                fill: 0xff,
+                align: 0x1000,
+            },
+        ],
+    };
+
+    let ffs = build_image(&config, &make_signer(&signing_key)).expect("build should succeed");
+    let reader = FfsReader::new(&ffs.image);
+    let anchor_offset = reader.scan_for_anchor().expect("should find anchor");
+    let anchor = reader
+        .read_anchor(anchor_offset)
+        .expect("anchor should parse");
+    let manifest = reader
+        .read_manifest(&anchor)
+        .expect("manifest should verify");
+    let region = FfsReader::find_region(&manifest, "mrc-cache").expect("mrc region");
+    assert_eq!(region.offset % 0x1000, 0);
+    assert_eq!(region.size, 0x100);
+    assert!(matches!(region.content, RegionContent::Raw { fill: 0xff }));
+    let start = region.offset as usize;
+    let end = start + region.size as usize;
+    assert!(ffs.image[start..end].iter().all(|byte| *byte == 0xff));
+}

--- a/crates/fstart-platform-x86_64/Cargo.toml
+++ b/crates/fstart-platform-x86_64/Cargo.toml
@@ -11,6 +11,7 @@ fstart-log = { workspace = true }
 fstart-pio = { workspace = true }
 fstart-services = { workspace = true }
 fstart-types = { workspace = true, optional = true }
+postcard = { workspace = true }
 ufmt = { workspace = true }
 
 [features]

--- a/crates/fstart-platform-x86_64/src/car_teardown.rs
+++ b/crates/fstart-platform-x86_64/src/car_teardown.rs
@@ -204,20 +204,37 @@ pub unsafe fn stage_load_mmio(
     anchor: &'static [u8],
     base: u64,
     size: u64,
+    cache_base: u64,
+    cache_size: u64,
 ) -> ! {
     let Some(stack_top) = config.stack_top() else {
         crate::halt();
+    };
+    let boot_path = match fstart_services::resume::boot_path() {
+        fstart_types::BootPath::Normal => 0u64,
+        fstart_types::BootPath::S3Resume => 1u64,
     };
 
     unsafe {
         asm!(
             "mov rsp, {stack}",
             "and rsp, -16",
-            "sub rsp, 8",
+            // Reserve a dummy return address plus four stack-passed
+            // arguments. With an aligned stack top, `sub rsp, 40` leaves
+            // `rsp % 16 == 8`, matching SysV function-entry alignment for
+            // the jmp into `stage_load_mmio_trampoline`.
+            "sub rsp, 40",
+            "mov qword ptr [rsp], 0",
             "mov qword ptr [rsp + 8], {image_size}",
+            "mov qword ptr [rsp + 16], {cache_base}",
+            "mov qword ptr [rsp + 24], {cache_size}",
+            "mov qword ptr [rsp + 32], {boot_path}",
             "jmp {tramp}",
             stack = in(reg) stack_top,
             image_size = in(reg) size,
+            cache_base = in(reg) cache_base,
+            cache_size = in(reg) cache_size,
+            boot_path = in(reg) boot_path,
             tramp = sym stage_load_mmio_trampoline,
             in("rdi") config as *const PostcarConfig,
             in("rsi") next_stage.as_ptr(),
@@ -239,6 +256,9 @@ extern "C" fn stage_load_mmio_trampoline(
     anchor_len: usize,
     base: u64,
     size: u64,
+    cache_base: u64,
+    cache_size: u64,
+    boot_path: u64,
 ) -> ! {
     // SAFETY: generated code passes pointers derived from ROM-resident strings
     // and anchor bytes with their original lengths.
@@ -248,6 +268,10 @@ extern "C" fn stage_load_mmio_trampoline(
     let anchor = unsafe { core::slice::from_raw_parts(anchor_ptr, anchor_len) };
     // SAFETY: `config` points at the ROM-resident generated config block.
     let config = unsafe { &*config };
+    let boot_path = match boot_path {
+        1 => fstart_types::BootPath::S3Resume,
+        _ => fstart_types::BootPath::Normal,
+    };
 
     // SAFETY: we are now on a DRAM stack and will never return to CAR-backed
     // state. MTRRs are installed before the large FFS/ramstage copy.
@@ -256,12 +280,42 @@ extern "C" fn stage_load_mmio_trampoline(
         postcar_mtrr_setup(config);
     }
 
-    let entry = quiet_stage_load(next_stage, anchor, base, size);
-    crate::jump_to(entry)
+    let entry = quiet_stage_load(
+        next_stage, anchor, base, size, cache_base, cache_size, boot_path,
+    );
+    let handoff_addr = entry.saturating_sub(0x1000) as usize;
+    write_stage_handoff(handoff_addr, boot_path);
+    crate::jump_to_with_handoff(entry, handoff_addr)
 }
 
 #[cfg(feature = "postcar-stage-load")]
-fn quiet_stage_load(next_stage: &str, anchor_data: &[u8], base: u64, size: u64) -> u64 {
+fn write_stage_handoff(handoff_addr: usize, boot_path: fstart_types::BootPath) {
+    let mut handoff = fstart_types::handoff::StageHandoff::new(0);
+    handoff.resume.boot_path = boot_path;
+    // SAFETY: generated stage layout reserves a handoff buffer immediately below
+    // the next stage load address. This mirrors non-x86 multi-stage handoff.
+    let buf = unsafe {
+        core::slice::from_raw_parts_mut(
+            handoff_addr as *mut u8,
+            fstart_types::handoff::HANDOFF_MAX_SIZE,
+        )
+    };
+    if postcard::to_slice(&handoff, buf).is_err() {
+        fstart_log::error!("post-CAR stage handoff serialization failed");
+        crate::halt();
+    }
+}
+
+#[cfg(feature = "postcar-stage-load")]
+fn quiet_stage_load(
+    next_stage: &str,
+    anchor_data: &[u8],
+    base: u64,
+    size: u64,
+    cache_base: u64,
+    cache_size: u64,
+    boot_path: fstart_types::BootPath,
+) -> u64 {
     use fstart_types::ffs::{Compression, EntryContent, SegmentKind};
 
     // SAFETY: generated code passes the memory-mapped FFS base/size from the
@@ -286,6 +340,17 @@ fn quiet_stage_load(next_stage: &str, anchor_data: &[u8], base: u64, size: u64) 
             continue;
         };
 
+        let cached_entry = if boot_path.is_s3_resume() {
+            cached_entry_bytes(
+                cache_base,
+                cache_size,
+                entry.size,
+                region.offset + entry.offset,
+            )
+        } else {
+            None
+        };
+
         let mut entry_addr = 0;
         for seg in segments {
             if entry_addr == 0 && seg.kind == SegmentKind::Code {
@@ -302,18 +367,23 @@ fn quiet_stage_load(next_stage: &str, anchor_data: &[u8], base: u64, size: u64) 
             }
 
             let src_off = (region.offset + entry.offset + seg.offset) as usize;
+            let entry_seg_off = seg.offset as usize;
             let stored = seg.stored_size as usize;
-            if src_off.saturating_add(stored) > image_size {
-                loop {}
-            }
+            let src = if let Some(cached) = cached_entry {
+                if entry_seg_off.saturating_add(stored) > cached.len() {
+                    loop {}
+                }
+                &cached[entry_seg_off..entry_seg_off + stored]
+            } else {
+                if src_off.saturating_add(stored) > image_size {
+                    loop {}
+                }
+                &image[src_off..src_off + stored]
+            };
 
             match seg.compression {
                 Compression::None => unsafe {
-                    core::ptr::copy(
-                        image.as_ptr().add(src_off),
-                        seg.load_addr as *mut u8,
-                        stored,
-                    );
+                    core::ptr::copy(src.as_ptr(), seg.load_addr as *mut u8, stored);
                 },
                 Compression::Lz4 => {
                     let buf_size = seg.in_place_size as usize;
@@ -326,11 +396,7 @@ fn quiet_stage_load(next_stage: &str, anchor_data: &[u8], base: u64, size: u64) 
                     let comp_offset = buf_size - stored;
                     unsafe {
                         let buf = core::slice::from_raw_parts_mut(dest, buf_size);
-                        core::ptr::copy(
-                            image.as_ptr().add(src_off),
-                            buf.as_mut_ptr().add(comp_offset),
-                            stored,
-                        );
+                        core::ptr::copy(src.as_ptr(), buf.as_mut_ptr().add(comp_offset), stored);
                         let src =
                             core::slice::from_raw_parts(buf.as_ptr().add(comp_offset), stored);
                         let dst = core::slice::from_raw_parts_mut(buf.as_mut_ptr(), loaded);
@@ -343,9 +409,92 @@ fn quiet_stage_load(next_stage: &str, anchor_data: &[u8], base: u64, size: u64) 
             }
         }
         if entry_addr != 0 {
+            save_compressed_entry_to_cache(
+                image,
+                image_size,
+                region.offset + entry.offset,
+                entry.size,
+                cache_base,
+                cache_size,
+            );
             return entry_addr;
         }
     }
 
     loop {}
+}
+
+#[cfg(feature = "postcar-stage-load")]
+fn cached_entry_bytes(
+    cache_base: u64,
+    cache_size: u64,
+    expected_size: u32,
+    expected_source_offset: u32,
+) -> Option<&'static [u8]> {
+    if cache_base == 0 || cache_size < 20 {
+        return None;
+    }
+    let header = unsafe { core::slice::from_raw_parts(cache_base as *const u8, 20) };
+    if &header[0..4] != b"FSC1" {
+        return None;
+    }
+    let version = u16::from_le_bytes([header[4], header[5]]);
+    let header_len = u16::from_le_bytes([header[6], header[7]]) as usize;
+    let size = u32::from_le_bytes([header[8], header[9], header[10], header[11]]) as usize;
+    let hash = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
+    let source_offset = u32::from_le_bytes([header[16], header[17], header[18], header[19]]);
+    if version != 1
+        || header_len != 20
+        || size != expected_size as usize
+        || source_offset != expected_source_offset
+    {
+        return None;
+    }
+    if header_len.saturating_add(size) > cache_size as usize {
+        return None;
+    }
+    let data = unsafe {
+        core::slice::from_raw_parts((cache_base as usize + header_len) as *const u8, size)
+    };
+    let actual = data.iter().fold(0x811c_9dc5u32, |mut h, b| {
+        h ^= u32::from(*b);
+        h.wrapping_mul(0x0100_0193)
+    });
+    if actual != hash {
+        return None;
+    }
+    Some(data)
+}
+
+#[cfg(feature = "postcar-stage-load")]
+fn save_compressed_entry_to_cache(
+    image: &[u8],
+    image_size: usize,
+    entry_offset: u32,
+    entry_size: u32,
+    cache_base: u64,
+    cache_size: u64,
+) {
+    if cache_base == 0 || cache_size == 0 {
+        return;
+    }
+    let entry_offset = entry_offset as usize;
+    let entry_size = entry_size as usize;
+    let total = 20usize.saturating_add(entry_size);
+    if total > cache_size as usize || entry_offset.saturating_add(entry_size) > image_size {
+        return;
+    }
+    let src = &image[entry_offset..entry_offset + entry_size];
+    let dst = unsafe { core::slice::from_raw_parts_mut(cache_base as *mut u8, total) };
+    let hash = src.iter().fold(0x811c_9dc5u32, |mut h, b| {
+        h ^= u32::from(*b);
+        h.wrapping_mul(0x0100_0193)
+    });
+    dst[0..4].copy_from_slice(b"FSC1");
+    dst[4..6].copy_from_slice(&1u16.to_le_bytes());
+    dst[6..8].copy_from_slice(&20u16.to_le_bytes());
+    dst[8..12].copy_from_slice(&(entry_size as u32).to_le_bytes());
+    dst[12..16].copy_from_slice(&hash.to_le_bytes());
+    dst[16..20].copy_from_slice(&(entry_offset as u32).to_le_bytes());
+    dst[20..total].copy_from_slice(src);
 }

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -60,6 +60,9 @@ pub fn disable_boot_media_rom_cache_for_handoff() {
 // - 0x08: 32-bit flat code (used for 16→32 bit transition)
 // - 0x10: flat data (used in both 32-bit mode and long mode)
 // - 0x18: 64-bit code (Long mode, Execute/Read)
+// - 0x20: reserved/TSS slot (keeps coreboot-compatible selector numbering)
+// - 0x28: 16-bit code (used by ACPI S3 wake trampoline)
+// - 0x30: 16-bit data (used by ACPI S3 wake trampoline)
 //
 // Page tables: identity-mapped 2 MiB pages covering 4 GiB.
 // PML4 → 1 PDPT → 4 PDTs → 512 × 2 MiB pages each.
@@ -169,6 +172,14 @@ core::arch::global_asm!(
     // Entry 0x18: 64-bit code (L=1, D=0, base=0, limit=4G)
     ".word 0xffff, 0x0000",
     ".byte 0x00, 0x9b, 0xaf, 0x00",
+    // Entry 0x20: reserved/TSS slot (zeroed, selector not used here)
+    ".quad 0x0000000000000000",
+    // Entry 0x28: 16-bit flat code (base=0, limit=64K, D=0)
+    ".word 0xffff, 0x0000",
+    ".byte 0x00, 0x9b, 0x00, 0x00",
+    // Entry 0x30: 16-bit flat data (base=0, limit=64K, B=0)
+    ".word 0xffff, 0x0000",
+    ".byte 0x00, 0x93, 0x00, 0x00",
     "_gdt_end:",
     "_gdt_desc:",
     ".word _gdt_end - _gdt - 1", // limit
@@ -963,6 +974,15 @@ pub fn jump_to(addr: u64) -> ! {
     }
 }
 
+/// Jump to a fstart stage entry while passing a serialized handoff pointer.
+pub fn jump_to_with_handoff(addr: u64, handoff_addr: usize) -> ! {
+    // SAFETY: caller guarantees `addr` is a fstart stage entry with the stable
+    // `extern "Rust" fn(usize) -> !` ABI and `handoff_addr` points to a valid
+    // serialized handoff buffer or zero.
+    let entry: extern "Rust" fn(usize) -> ! = unsafe { core::mem::transmute(addr as usize) };
+    entry(handoff_addr)
+}
+
 #[inline]
 fn read_cr0() -> u64 {
     // SAFETY: reading CR0 is side-effect free in firmware context.
@@ -1348,3 +1368,222 @@ fn log_x86_irq_handoff_state() {}
 
 #[cfg(not(target_arch = "x86_64"))]
 fn log_x86_irq_handoff_state() {}
+
+/// Resume the OS from ACPI S3 using the preserved FACS wake vector.
+///
+/// This path intentionally discovers the wake vector from the OS-owned ACPI
+/// tables left in memory; it must be called before regenerating ACPI/SMBIOS.
+pub fn acpi_s3_resume() -> ! {
+    fstart_log::info!("x86 S3: locating preserved ACPI wake vector");
+    let vector = unsafe { find_s3_wakeup_vector_legacy() };
+    let Some(vector) = vector else {
+        fstart_log::error!("x86 S3: no valid FACS firmware waking vector found");
+        halt();
+    };
+    if vector > 0x000f_ffff {
+        fstart_log::error!(
+            "x86 S3: real-mode wake vector {:#x} is above 1MiB; protected-mode wake is not implemented",
+            vector,
+        );
+        halt();
+    }
+    fstart_log::info!("x86 S3: jumping to wake vector {:#x}", vector);
+    unsafe { s3_copy_wakeup_trampoline() };
+    unsafe {
+        let wake: extern "C" fn(u64) -> ! = core::mem::transmute(S3_WAKEUP_BASE);
+        wake(vector);
+    }
+}
+
+// Keep this scanner local to the platform S3 wake path even though
+// `fstart-acpi::resume` has a shared equivalent: this code runs after DRAM
+// resume, before table regeneration, and deliberately depends only on simple
+// physical-memory reads plus the platform halt/log path. Keep fixes mirrored
+// with `fstart-acpi::resume`.
+const S3_RSDP_SCAN_START: usize = 0x000e_0000;
+const S3_RSDP_SCAN_END: usize = 0x0010_0000;
+
+unsafe fn find_s3_wakeup_vector_legacy() -> Option<u64> {
+    let mut addr = S3_RSDP_SCAN_START;
+    while addr < S3_RSDP_SCAN_END {
+        if let Some(vector) = unsafe { find_s3_wakeup_vector_from_rsdp(addr) } {
+            return Some(vector);
+        }
+        addr += 16;
+    }
+    None
+}
+
+unsafe fn find_s3_wakeup_vector_from_rsdp(rsdp_addr: usize) -> Option<u64> {
+    let rsdp = unsafe { core::slice::from_raw_parts(rsdp_addr as *const u8, 36) };
+    if &rsdp[0..8] != b"RSD PTR " || s3_checksum(&rsdp[..20]) != 0 {
+        return None;
+    }
+    let revision = rsdp[15];
+    if revision >= 2 && s3_checksum(rsdp) == 0 {
+        let xsdt = u64::from_le_bytes(rsdp[24..32].try_into().ok()?) as usize;
+        if xsdt != 0 {
+            if let Some(fadt) = unsafe { s3_find_table(xsdt, true, b"FACP") } {
+                return unsafe { s3_wake_vector_from_fadt(fadt) };
+            }
+        }
+    }
+    let rsdt = u32::from_le_bytes(rsdp[16..20].try_into().ok()?) as usize;
+    if rsdt != 0 {
+        if let Some(fadt) = unsafe { s3_find_table(rsdt, false, b"FACP") } {
+            return unsafe { s3_wake_vector_from_fadt(fadt) };
+        }
+    }
+    None
+}
+
+unsafe fn s3_find_table(root: usize, xsdt: bool, sig: &[u8; 4]) -> Option<usize> {
+    let header = unsafe { core::slice::from_raw_parts(root as *const u8, 36) };
+    let len = u32::from_le_bytes(header[4..8].try_into().ok()?) as usize;
+    if len < 36 {
+        return None;
+    }
+    let bytes = unsafe { core::slice::from_raw_parts(root as *const u8, len) };
+    if s3_checksum(bytes) != 0 {
+        return None;
+    }
+    let ent = if xsdt { 8 } else { 4 };
+    for off in (36..len).step_by(ent) {
+        if off + ent > len {
+            break;
+        }
+        let addr = if xsdt {
+            u64::from_le_bytes(bytes[off..off + 8].try_into().ok()?) as usize
+        } else {
+            u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize
+        };
+        if addr == 0 {
+            continue;
+        }
+        let tsig = unsafe { core::slice::from_raw_parts(addr as *const u8, 4) };
+        if tsig == sig {
+            return Some(addr);
+        }
+    }
+    None
+}
+
+unsafe fn s3_wake_vector_from_fadt(fadt: usize) -> Option<u64> {
+    let bytes = unsafe { core::slice::from_raw_parts(fadt as *const u8, 148) };
+    let len = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+    if len < 116 {
+        return None;
+    }
+    let facs32 = u32::from_le_bytes(bytes[36..40].try_into().ok()?) as u64;
+    let facs64 = if len >= 140 {
+        u64::from_le_bytes(bytes[132..140].try_into().ok()?)
+    } else {
+        0
+    };
+    let facs = if facs64 != 0 { facs64 } else { facs32 };
+    if facs == 0 {
+        return None;
+    }
+    let facs_bytes = unsafe { core::slice::from_raw_parts(facs as usize as *const u8, 32) };
+    if &facs_bytes[0..4] != b"FACS" {
+        return None;
+    }
+    let v32 = u32::from_le_bytes(facs_bytes[12..16].try_into().ok()?) as u64;
+    let v64 = u64::from_le_bytes(facs_bytes[24..32].try_into().ok()?);
+    if v64 != 0 {
+        Some(v64)
+    } else if v32 != 0 {
+        Some(v32)
+    } else {
+        None
+    }
+}
+
+fn s3_checksum(bytes: &[u8]) -> u8 {
+    bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte))
+}
+
+const S3_WAKEUP_BASE: usize = 0x600;
+
+unsafe fn s3_copy_wakeup_trampoline() {
+    unsafe extern "C" {
+        static __fstart_s3_wakeup: u8;
+        static __fstart_s3_wakeup_end: u8;
+    }
+    let src = unsafe { &__fstart_s3_wakeup as *const u8 };
+    let end = unsafe { &__fstart_s3_wakeup_end as *const u8 };
+    let size = (end as usize).saturating_sub(src as usize);
+    if size == 0 || size > 0x200 {
+        fstart_log::error!("x86 S3: invalid wake trampoline size {}", size);
+        halt();
+    }
+    unsafe { core::ptr::copy_nonoverlapping(src, S3_WAKEUP_BASE as *mut u8, size) };
+}
+
+core::arch::global_asm!(
+    ".section .text.s3_wakeup, \"ax\"",
+    ".code64",
+    ".global __fstart_s3_wakeup",
+    "__fstart_s3_wakeup:",
+    // Preserve the low 32 bits of the real-mode wake vector in EBX across
+    // the long-mode to protected-mode transition. The vector is constrained
+    // below 1MiB before entering this trampoline.
+    "movl %edi, %ebx",
+    "xor %rax, %rax",
+    "mov %ss, %ax",
+    "push %rax",
+    "mov %rsp, %rax",
+    "add $8, %rax",
+    "push %rax",
+    "pushfq",
+    "push $0x08",
+    "lea 3(%rip), %rax",
+    "push %rax",
+    "iretq",
+    ".code32",
+    // Disable paging, then long mode.
+    "mov %cr0, %eax",
+    "btc $31, %eax",
+    "mov %eax, %cr0",
+    "mov $0xC0000080, %ecx",
+    "rdmsr",
+    "btc $8, %eax",
+    "wrmsr",
+    // Convert the linear wake vector in EBX to real-mode segment:offset.
+    "mov %ebx, %eax",
+    "andw $0x0f, %ax",
+    "movw %ax, (s3_wakeup_offset - __fstart_s3_wakeup + 0x600)",
+    "mov %ebx, %eax",
+    "shr $4, %eax",
+    "movw %ax, (s3_wakeup_segment - __fstart_s3_wakeup + 0x600)",
+    // Enter a 16-bit protected-mode segment, then clear PE.
+    "ljmp $0x28, $(1f - __fstart_s3_wakeup + 0x600)",
+    "1:",
+    ".code16",
+    "mov $0x30, %ax",
+    "mov %ax, %ds",
+    "mov %ax, %es",
+    "mov %ax, %fs",
+    "mov %ax, %gs",
+    "mov %ax, %ss",
+    "movl %cr0, %eax",
+    "andl $0xfffffffe, %eax",
+    "movl %eax, %cr0",
+    "ljmp $0, $(1f - __fstart_s3_wakeup + 0x600)",
+    "1:",
+    "movw $0, %ax",
+    "movw %ax, %ds",
+    "movw %ax, %es",
+    "movw %ax, %ss",
+    "movw %ax, %fs",
+    "movw %ax, %gs",
+    ".byte 0xea",
+    "s3_wakeup_offset:",
+    ".word 0x0000",
+    "s3_wakeup_segment:",
+    ".word 0x0000",
+    ".code64",
+    ".global __fstart_s3_wakeup_end",
+    "__fstart_s3_wakeup_end:",
+    options(att_syntax),
+);

--- a/crates/fstart-services/Cargo.toml
+++ b/crates/fstart-services/Cargo.toml
@@ -11,3 +11,4 @@ pci = ["dep:fstart-pci"]
 [dependencies]
 embedded-hal = { workspace = true }
 fstart-pci = { workspace = true, optional = true }
+fstart-types = { workspace = true }

--- a/crates/fstart-services/src/lib.rs
+++ b/crates/fstart-services/src/lib.rs
@@ -31,10 +31,12 @@ pub mod network;
 #[cfg(feature = "pci")]
 pub mod pci;
 pub mod pci_host;
+pub mod resume;
 pub mod smbus;
 pub mod soc_boot;
 pub mod southbridge;
 pub mod spi;
+pub mod stage_cache;
 pub mod timer;
 
 pub use block::BlockDevice;
@@ -54,10 +56,12 @@ pub use network::Network;
 #[cfg(feature = "pci")]
 pub use pci::{PciBdf, PciRootBus, PciWindow, PciWindowKind};
 pub use pci_host::PciHost;
+pub use resume::ResumeDetector;
 pub use smbus::SmBus;
 pub use soc_boot::SocBootHeader;
 pub use southbridge::Southbridge;
 pub use spi::SpiBus;
+pub use stage_cache::StageCacheProvider;
 pub use timer::Timer;
 
 /// Common error type for service operations.

--- a/crates/fstart-services/src/memory_controller.rs
+++ b/crates/fstart-services/src/memory_controller.rs
@@ -5,6 +5,8 @@
 //! training, size detection).  This trait exposes detected parameters
 //! for use by later firmware stages.
 
+use fstart_types::BootPath;
+
 use crate::ServiceError;
 
 /// Memory controller — DRAM initialization and detection.
@@ -26,6 +28,14 @@ pub trait MemoryController: Send + Sync {
     /// chipset init are available. Real DRAM training is dispatched later by
     /// the `DramInit` capability, after SMBus/GPIO/BAR setup has completed.
     fn dram_init(&mut self) -> Result<(), ServiceError> {
+        self.dram_init_with_boot_path(BootPath::Normal)
+    }
+
+    /// Run DRAM initialization/training for a known boot path.
+    ///
+    /// Implementations that support ACPI S3 should use [`BootPath::S3Resume`]
+    /// to select their non-destructive resume path and cached training data.
+    fn dram_init_with_boot_path(&mut self, _boot_path: BootPath) -> Result<(), ServiceError> {
         Ok(())
     }
 

--- a/crates/fstart-services/src/resume.rs
+++ b/crates/fstart-services/src/resume.rs
@@ -1,0 +1,40 @@
+//! ACPI S3 resume service traits and global boot-path state.
+
+use core::sync::atomic::{AtomicU8, Ordering};
+
+use fstart_types::BootPath;
+
+use crate::ServiceError;
+
+const BOOT_PATH_NORMAL: u8 = 0;
+const BOOT_PATH_S3_RESUME: u8 = 1;
+
+static BOOT_PATH: AtomicU8 = AtomicU8::new(BOOT_PATH_NORMAL);
+
+/// Detects chipset sleep/resume state early in boot.
+pub trait ResumeDetector: Send + Sync {
+    /// Return the current firmware boot path.
+    fn detect_boot_path(&self) -> Result<BootPath, ServiceError>;
+}
+
+/// Publish the detected boot path for later stages/capabilities.
+pub fn set_boot_path(path: BootPath) {
+    let raw = match path {
+        BootPath::Normal => BOOT_PATH_NORMAL,
+        BootPath::S3Resume => BOOT_PATH_S3_RESUME,
+    };
+    BOOT_PATH.store(raw, Ordering::SeqCst);
+}
+
+/// Return the current globally published boot path.
+pub fn boot_path() -> BootPath {
+    match BOOT_PATH.load(Ordering::SeqCst) {
+        BOOT_PATH_S3_RESUME => BootPath::S3Resume,
+        _ => BootPath::Normal,
+    }
+}
+
+/// Return true when the active boot path is ACPI S3 resume.
+pub fn is_s3_resume() -> bool {
+    boot_path().is_s3_resume()
+}

--- a/crates/fstart-services/src/stage_cache.rs
+++ b/crates/fstart-services/src/stage_cache.rs
@@ -1,0 +1,19 @@
+//! Firmware stage-cache provider trait.
+
+use crate::ServiceError;
+
+/// Provides a firmware-owned region for compressed stage cache storage.
+pub trait StageCacheProvider: Send + Sync {
+    /// Return `(base, size)` for a cache region with at least `requested_size` bytes.
+    fn stage_cache_region(&self, requested_size: u64) -> Option<(u64, u64)>;
+
+    /// Make the cache region writable/readable by normal firmware.
+    fn stage_cache_open(&self) -> Result<(), ServiceError> {
+        Ok(())
+    }
+
+    /// Close the cache region after access.
+    fn stage_cache_close(&self) -> Result<(), ServiceError> {
+        Ok(())
+    }
+}

--- a/crates/fstart-stage-runtime/Cargo.toml
+++ b/crates/fstart-stage-runtime/Cargo.toml
@@ -17,4 +17,5 @@ std = ["fstart-types/std"]
 fstart-types = { workspace = true }
 fstart-services = { workspace = true }
 fstart-log = { workspace = true }
+postcard = { workspace = true }
 ufmt = { workspace = true }

--- a/crates/fstart-stage-runtime/src/lib.rs
+++ b/crates/fstart-stage-runtime/src/lib.rs
@@ -247,6 +247,11 @@ pub trait Board: Sized {
     /// `fstart_capabilities::late_driver_init_complete`.
     fn late_driver_init_complete(&mut self, count: usize);
 
+    /// Receive a deserialized previous-stage handoff, if any.
+    fn set_handoff(&mut self, handoff: Option<fstart_types::handoff::StageHandoff>) {
+        let _ = handoff;
+    }
+
     /// Stage operation for `SigVerify`.
     ///
     /// Generated adapter reads its anchor pointer and current boot
@@ -275,6 +280,9 @@ pub trait Board: Sized {
     /// and calls `fstart_capabilities::stage_load`.  Halts on failure.
     fn stage_load(&self, next_stage: &str) -> !;
 
+    /// Stage operation for `StageCacheSave`.
+    fn stage_cache_save(&self, stage: &str);
+
     /// Stage operation for `AcpiPrepare`.
     ///
     /// Generated adapter calls `fstart_capabilities::acpi_prepare`
@@ -286,6 +294,9 @@ pub trait Board: Sized {
     /// Generated adapter calls `fstart_capabilities::smbios_prepare`
     /// with its SmbiosConfig descriptor (held in `&self`).
     fn smbios_prepare(&self);
+
+    /// Stage operation for the ACPI S3 OS wake path. Diverges.
+    fn acpi_s3_resume(&self) -> !;
 
     /// Stage operation for `MpInit`.
     ///
@@ -336,6 +347,9 @@ pub trait Board: Sized {
     /// a `PreConsoleInit` phase, while DRAM training must happen later after
     /// chipset/SMBus setup.
     fn dram_init(&mut self, id: DeviceId) -> Result<(), DeviceError>;
+
+    /// Stage operation for `ResumeDetect`. `id` is the resolved device ID.
+    fn resume_detect(&mut self, id: DeviceId) -> Result<(), DeviceError>;
 
     /// Stage operation for `PciInit`.  `id` is the resolved device ID.
     ///

--- a/crates/fstart-stage/Cargo.toml
+++ b/crates/fstart-stage/Cargo.toml
@@ -57,6 +57,7 @@ intel-pineview = ["dep:fstart-driver-intel-pineview"]
 intel-ich7 = ["dep:fstart-driver-intel-ich7", "dep:fstart-gpio-ich"]
 intel-gm965 = ["dep:fstart-driver-intel-gm965"]
 intel-ich8 = ["dep:fstart-driver-intel-ich8", "dep:fstart-gpio-ich"]
+intel-spi = ["dep:fstart-driver-intel-spi"]
 lenovo-x61-mainboard = ["dep:fstart-mainboard-lenovo-x61"]
 i2c-ck505 = ["dep:fstart-driver-i2c-ck505"]
 # NS16550 with x86 port I/O support
@@ -179,6 +180,7 @@ fstart-driver-intel-pineview = { workspace = true, optional = true }
 fstart-driver-intel-ich7 = { workspace = true, optional = true }
 fstart-driver-intel-gm965 = { workspace = true, optional = true }
 fstart-driver-intel-ich8 = { workspace = true, optional = true }
+fstart-driver-intel-spi = { workspace = true, optional = true }
 fstart-mainboard-lenovo-x61 = { workspace = true, optional = true }
 fstart-driver-i2c-ck505 = { workspace = true, optional = true }
 fstart-mp = { workspace = true, optional = true }

--- a/crates/fstart-types/src/board.rs
+++ b/crates/fstart-types/src/board.rs
@@ -145,6 +145,14 @@ pub struct BoardConfig {
     #[serde(default)]
     pub smm: Option<crate::smm::SmmConfig>,
 
+    /// Optional compressed-stage cache configuration for S3 resume.
+    #[serde(default)]
+    pub stage_cache: Option<crate::resume::StageCacheConfig>,
+
+    /// Optional FFS raw region reserved for persistent MRC/training data.
+    #[serde(default)]
+    pub mrc_cache: Option<MrcCacheConfig>,
+
     /// Boot hart ID for multi-hart platforms.
     ///
     /// On multi-hart SoCs (e.g., SiFive FU740 with 5 harts), the boot ROM
@@ -158,6 +166,21 @@ pub struct BoardConfig {
     /// without S-mode; hart 1 is the first U74 application core).
     #[serde(default)]
     pub boot_hart_id: u32,
+}
+
+/// Persistent MRC/training-data cache region configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MrcCacheConfig {
+    /// FFS raw-region name.
+    #[serde(default = "default_mrc_cache_region_name")]
+    pub name: HString<64>,
+    /// Cache region size in bytes. xtask places this automatically.
+    pub size: u32,
+}
+
+fn default_mrc_cache_region_name() -> HString<64> {
+    HString::try_from("mrc-cache").unwrap_or_default()
 }
 
 /// CPU microcode packaging configuration.

--- a/crates/fstart-types/src/handoff.rs
+++ b/crates/fstart-types/src/handoff.rs
@@ -13,6 +13,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::resume::ResumeHandoff;
+
 /// Magic number for StageHandoff validation.
 ///
 /// ASCII "FSTH" (fstart handoff). If the incoming stage reads a buffer
@@ -24,7 +26,7 @@ pub const HANDOFF_MAGIC: u32 = 0x4653_5448;
 ///
 /// Increment when fields are added or the layout changes. The incoming
 /// stage should reject versions it doesn't understand.
-pub const HANDOFF_VERSION: u16 = 1;
+pub const HANDOFF_VERSION: u16 = 2;
 
 /// Maximum serialized size of a StageHandoff.
 ///
@@ -50,6 +52,9 @@ pub struct StageHandoff {
     /// 0 means DRAM size was not determined (e.g., QEMU, or DRAM init
     /// was not performed by the previous stage).
     pub dram_size: u64,
+    /// Resume-state handoff from early chipset initialization.
+    #[cfg_attr(not(target_arch = "x86_64"), serde(skip))]
+    pub resume: ResumeHandoff,
 }
 
 impl StageHandoff {
@@ -59,6 +64,7 @@ impl StageHandoff {
             magic: HANDOFF_MAGIC,
             version: HANDOFF_VERSION,
             dram_size,
+            resume: ResumeHandoff::default(),
         }
     }
 

--- a/crates/fstart-types/src/lib.rs
+++ b/crates/fstart-types/src/lib.rs
@@ -13,6 +13,7 @@ pub mod device;
 pub mod ffs;
 pub mod handoff;
 pub mod memory;
+pub mod resume;
 pub mod security;
 pub mod smbios;
 pub mod smm;
@@ -36,6 +37,7 @@ pub use memory::{
     CarConfig, FlashLayout, IntelIfdFlashLayout, IntelIfdRegion, IntelIfdRegionConfig, MemoryMap,
     MemoryRegion, RegionKind,
 };
+pub use resume::{BootPath, ResumeHandoff, StageCacheBackend, StageCacheConfig, StageCacheInfo};
 pub use security::{DigestAlgorithm, SecurityConfig, SignatureAlgorithm};
 pub use smbios::SmbiosConfig;
 pub use smm::{CorebootSmmCompat, SmmConfig, SmmPlatform};

--- a/crates/fstart-types/src/resume.rs
+++ b/crates/fstart-types/src/resume.rs
@@ -1,0 +1,64 @@
+//! S3 resume state shared by stages and chipset drivers.
+
+use serde::{Deserialize, Serialize};
+
+/// Firmware boot path selected by early chipset power-state detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum BootPath {
+    /// Cold/reset boot; firmware owns hardware initialization and table generation.
+    #[default]
+    Normal,
+    /// ACPI S3 resume; firmware must preserve OS memory and jump to the wake vector.
+    S3Resume,
+}
+
+impl BootPath {
+    /// Return true when this boot is an ACPI S3 resume.
+    pub const fn is_s3_resume(self) -> bool {
+        matches!(self, Self::S3Resume)
+    }
+}
+
+/// Stage-cache backend selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum StageCacheBackend {
+    /// Cache in normal RAM and reserve the range from the OS memory map.
+    Memory,
+    /// Cache in TSEG/SMRAM. The chipset/SMM provider chooses the final base.
+    Tseg,
+}
+
+/// Persistent compressed-stage cache configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StageCacheConfig {
+    /// Cache backend.
+    pub backend: StageCacheBackend,
+    /// Base address for [`StageCacheBackend::Memory`]. Ignored for TSEG.
+    #[serde(default)]
+    pub base: u64,
+    /// Cache capacity in bytes.
+    pub size: u64,
+}
+
+/// Persistent stage-cache location used by the resume path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct StageCacheInfo {
+    /// Physical base address of the cached compressed stage/FFS bytes.
+    pub base: u64,
+    /// Size in bytes of the cached region.
+    pub size: u64,
+}
+
+/// Resume-specific inter-stage data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ResumeHandoff {
+    /// Boot path detected by the earliest chipset stage.
+    pub boot_path: BootPath,
+    /// Whether persistent firmware memory/CBMEM-style state was recovered.
+    pub persistent_memory_recovered: bool,
+    /// Optional SMRAM/TSEG compressed stage cache.
+    pub stage_cache: StageCacheInfo,
+}

--- a/crates/fstart-types/src/stage.rs
+++ b/crates/fstart-types/src/stage.rs
@@ -248,6 +248,14 @@ pub enum Capability {
         /// Device name from the devices list (e.g., "dramc0")
         device: HString<32>,
     },
+    /// Detect ACPI S3 resume state via a chipset/southbridge device.
+    ///
+    /// Must run after the device has enough early PM I/O setup to read PM1_CNT
+    /// and before `DramInit` so memory controllers can select resume-safe init.
+    ResumeDetect {
+        /// Device name from the devices list (e.g., "southbridge")
+        device: HString<32>,
+    },
     /// Minimal platform/device setup before the console can be initialized.
     ///
     /// The referenced devices implement `PreConsoleInit`.  This is a portable
@@ -322,6 +330,11 @@ pub enum Capability {
     },
     /// Prepare a Flattened Device Tree for OS handoff.
     FdtPrepare,
+    /// Save a compressed stage FFS entry to a firmware-owned cache region.
+    StageCacheSave {
+        /// FFS stage entry name to cache (e.g., "ramstage").
+        stage: HString<32>,
+    },
     /// Load and jump to the payload (OS kernel, shell, etc.).
     PayloadLoad,
     /// Load the next stage from FFS into RAM and jump to it.
@@ -475,18 +488,6 @@ pub enum BootMedium {
         base: u64,
         /// Size of the mapped flash region in bytes.
         size: u64,
-        /// Optional RAM address to copy FFS data before accessing it.
-        ///
-        /// On x86_64 with code-model=large, FFS operations (postcard
-        /// deserialization, LZ4 decompression) are significantly faster
-        /// when operating on RAM rather than flash-mapped MMIO. When
-        /// set, generated code copies `size` bytes from `base` to this
-        /// address before constructing the `MemoryMapped` accessor.
-        ///
-        /// On platforms with true XIP (ARM, RISC-V), this should be
-        /// `None` — the flash is accessed directly.
-        #[serde(default)]
-        ram_copy_addr: Option<u64>,
     },
     /// A named device that implements `BlockDevice`.
     ///

--- a/docs/s3-resume.md
+++ b/docs/s3-resume.md
@@ -1,0 +1,52 @@
+# ACPI S3 resume implementation notes
+
+This document records the fstart S3 resume model based on the coreboot paths for
+Pineview/ICH7 and GM965/ICH8.
+
+## Coreboot references
+
+- `src/northbridge/intel/pineview/romstage.c`: detect S3, run resume DRAM init,
+  recover CBMEM, set romstage handoff.
+- `src/northbridge/intel/gm965/raminit.c`: load MRC cache before raminit,
+  validate CPU/SPD-specific data, and stash updated training data after raminit.
+- `src/drivers/mrc_cache/mrc_cache.c`: generic `MRCD` metadata, FMAP regions
+  `RW_MRC_CACHE`, `RW_VAR_MRC_CACHE`, `RECOVERY_MRC_CACHE`, and
+  `UNIFIED_MRC_CACHE`.
+- `src/lib/prog_loaders.c`: use stage cache on S3, populate it on normal boot.
+- `src/acpi/acpi.c` and `src/arch/x86/acpi_s3.c`: find FACS wake vector from
+  old OS tables, copy trampoline to low memory, and jump without regenerating
+  ACPI/SMBIOS.
+
+## fstart pieces now in tree
+
+- `fstart_types::BootPath`, `ResumeHandoff`, and `StageCacheInfo` model the
+  early resume handoff.
+- `fstart_services::resume` provides a global boot-path state and
+  `ResumeDetector` trait.
+- ICH7 and ICH8 implement `ResumeDetector` by checking PM1_CNT `SLP_TYP == S3`
+  and publishing `BootPath::S3Resume`.
+- `MemoryController::dram_init_with_boot_path()` lets northbridges select cold,
+  warm, or S3-safe DRAM init. Pineview now maps S3 to the existing
+  `BOOT_PATH_RESUME` value passed into native raminit. GM965 receives the boot
+  path and currently logs the pending MRC fast path before using existing native
+  training.
+- `fstart_capabilities::mrc_cache` provides the generic persistent record
+  format and helpers for SPI/FFS-backed MRC training data.
+- `fstart_acpi::resume` can discover the preserved OS S3 wake vector from old
+  RSDP/RSDT/XSDT/FADT/FACS tables.
+
+## Remaining integration work
+
+1. Add a generated `ResumeDetect` capability or call `ResumeDetector` from the
+   existing early-init plan before `DramInit`.
+2. Add board RON schema for SPI MRC regions and SMRAM/TSEG stage-cache ranges.
+3. Wire chipset SPI/flash backends to `mrc_cache::read_record()` and a future
+   write/stash path.
+4. Teach GM965 native raminit to serialize/deserialize its training `sysinfo`
+   equivalent and validate CPU/SPD checksums like coreboot.
+5. Add SMRAM/TSEG compressed-stage cache population on normal boot and use on
+   S3 before loading ramstage from SPI.
+6. Add the x86 low-memory wake trampoline/jump and branch before ACPI/SMBIOS
+   generation on `BootPath::S3Resume`.
+7. Ensure normal-boot E820 reserves SMRAM/TSEG, stage cache, firmware heap,
+   ACPI/SMBIOS tables, zero page, and any persistent handoff areas.

--- a/xtask/src/assemble.rs
+++ b/xtask/src/assemble.rs
@@ -440,7 +440,10 @@ fn compressed_anchor_slots(regions: &[InputRegion]) -> Result<Vec<CompressedAnch
         let files = match region {
             InputRegion::Container { files, .. }
             | InputRegion::ContainerWithExternal { files, .. } => files,
-            InputRegion::Raw { .. } | InputRegion::ExternalRaw { .. } => continue,
+            InputRegion::Raw { .. }
+            | InputRegion::RawAligned { .. }
+            | InputRegion::RawAt { .. }
+            | InputRegion::ExternalRaw { .. } => continue,
         };
 
         for (file_idx, file) in files.iter().enumerate() {
@@ -501,7 +504,10 @@ fn patch_compressed_anchor_slots(
         let files = match region {
             InputRegion::Container { files, .. }
             | InputRegion::ContainerWithExternal { files, .. } => files,
-            InputRegion::Raw { .. } | InputRegion::ExternalRaw { .. } => {
+            InputRegion::Raw { .. }
+            | InputRegion::RawAligned { .. }
+            | InputRegion::RawAt { .. }
+            | InputRegion::ExternalRaw { .. } => {
                 return Err("compressed anchor slot points at a raw region".to_string());
             }
         };
@@ -524,6 +530,8 @@ fn patch_compressed_anchor_slots(
     Ok(())
 }
 
+const MRC_CACHE_FLASH_ALIGN: u32 = 0x1000;
+
 fn ffs_input_regions(
     config: &BoardConfig,
     ro_files: Vec<InputFile>,
@@ -536,25 +544,31 @@ fn ffs_input_regions(
                 .ok_or_else(|| "full_flash_image requires memory.flash_size".to_string())?;
             let flash_size_u32 = u32::try_from(flash_size)
                 .map_err(|_| format!("flash size {flash_size:#x} exceeds FFS u32 limits"))?;
-            let (files, external_files) =
-                externalize_xip_bootblock(config, ro_files, flash_size_u32)?;
+            let ro_size = mrc_cache_offset_before(config, flash_size_u32)?;
+            let (files, external_files) = externalize_xip_bootblock(config, ro_files, ro_size)?;
+            let mut regions = Vec::new();
             if !external_files.is_empty() {
-                return Ok(vec![InputRegion::ContainerWithExternal {
+                regions.push(InputRegion::ContainerWithExternal {
                     name: "ro".to_string(),
                     files,
                     external_files,
-                    size: Some(flash_size_u32),
-                }]);
+                    size: Some(ro_size),
+                });
+            } else {
+                regions.push(InputRegion::Container {
+                    name: "ro".to_string(),
+                    files,
+                });
             }
-            return Ok(vec![InputRegion::Container {
-                name: "ro".to_string(),
-                files,
-            }]);
+            push_mrc_cache_region(config, &mut regions, Some(ro_size))?;
+            return Ok(regions);
         }
-        return Ok(vec![InputRegion::Container {
+        let mut regions = vec![InputRegion::Container {
             name: "ro".to_string(),
             files: ro_files,
-        }]);
+        }];
+        push_mrc_cache_region(config, &mut regions, None)?;
+        return Ok(regions);
     };
 
     let bios = layout
@@ -576,16 +590,61 @@ fn ffs_input_regions(
             fill: 0xff,
         });
     }
-    let (files, external_files) = externalize_xip_bootblock(config, ro_files, bios.size)?;
+    let ro_size = mrc_cache_offset_before(config, bios.size)?;
+    let (files, external_files) = externalize_xip_bootblock(config, ro_files, ro_size)?;
 
     regions.push(InputRegion::ContainerWithExternal {
         name: "ro".to_string(),
         files,
         external_files,
-        size: Some(bios.size),
+        size: Some(ro_size),
     });
+    push_mrc_cache_region(config, &mut regions, Some(ro_size))?;
 
     Ok(regions)
+}
+
+fn push_mrc_cache_region(
+    config: &BoardConfig,
+    regions: &mut Vec<InputRegion>,
+    offset: Option<u32>,
+) -> Result<(), String> {
+    let Some(cache) = &config.mrc_cache else {
+        return Ok(());
+    };
+    if cache.size == 0 {
+        return Err("mrc_cache.size must be non-zero".to_string());
+    }
+    let name = cache.name.as_str().to_string();
+    if let Some(offset) = offset {
+        regions.push(InputRegion::ExternalRaw {
+            name,
+            offset,
+            size: cache.size,
+            fill: 0xff,
+        });
+    } else {
+        regions.push(InputRegion::RawAligned {
+            name,
+            size: cache.size,
+            fill: 0xff,
+            align: MRC_CACHE_FLASH_ALIGN,
+        });
+    }
+    Ok(())
+}
+
+fn mrc_cache_offset_before(config: &BoardConfig, container_size: u32) -> Result<u32, String> {
+    let Some(cache) = &config.mrc_cache else {
+        return Ok(container_size);
+    };
+    let unaligned = container_size.checked_sub(cache.size).ok_or_else(|| {
+        format!(
+            "mrc_cache size {:#x} exceeds container size {container_size:#x}",
+            cache.size
+        )
+    })?;
+    Ok(unaligned & !(MRC_CACHE_FLASH_ALIGN - 1))
 }
 
 fn externalize_xip_bootblock(


### PR DESCRIPTION
## Summary
- add S3 resume state/handoff plumbing and ResumeDetect capability
- add x86 ACPI wake-vector discovery/trampoline and skip ACPI/SMBIOS regeneration on S3
- add stage-cache configuration, compressed stage cache support, and GM965 TSEG provider
- thread BootPath through Pineview/GM965 DRAM init and add GM965 S3-safe raminit path shape
- remove ram_copy_addr whole-image RAM copy path

## Validation
- cargo fmt --all -- --check
- cargo test --package fstart-codegen --lib
- cargo check --workspace --exclude fstart-stage --exclude fstart-platform-riscv64 --exclude fstart-platform-aarch64 --exclude fstart-platform-armv7 --exclude fstart-runtime
- cargo xtask build --board lenovo-x61 --release
- cargo xtask build --board foxconn-d41s --release

## Notes
- GM965 MRC cache payload serialization/restore remains follow-up work.
- Normal-RAM stage cache is E820-reserved but not a security boundary; TSEG is preferred for protected cache placement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ACPI S3 resume support with boot-path detection for sleep/wake cycles
  * Introduced stage-cache functionality for compressed firmware caching during resume
  * Added MRC-cache support for persistent memory training data
  * Added Intel SPI flash controller driver with hardware and software sequencing modes

* **Improvements**
  * Enhanced board configurations to support resume detection and cache operations
  * Updated memory controller initialization to handle S3 resume paths
  * Improved inter-stage handoff with resume state data

* **Documentation**
  * Added S3 resume implementation guide

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fstart-io/fstart/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->