### PR TITLE
Harden Pineview RAM initialization

### DIFF
--- a/crates/fstart-driver-intel-pineview/src/lib.rs
+++ b/crates/fstart-driver-intel-pineview/src/lib.rs
@@ -265,6 +265,23 @@ impl IntelPineview {
         mch.read32(mchbar::PMSTS) & (1 << 8) != 0
     }
 
+    fn detect_boot_path(&self) -> u8 {
+        let pm = fstart_pmio_ich::PmIo::new(ICH7_PMBASE);
+        if pm.is_s3_resume() {
+            let pm1_cnt = pm.read32(fstart_pmio_ich::PM1_CNT);
+            pm.write32(
+                fstart_pmio_ich::PM1_CNT,
+                pm1_cnt & !fstart_pmio_ich::SLP_TYP_MASK,
+            );
+            fstart_log::info!("pineview: S3 resume detected");
+            raminit::BOOT_PATH_RESUME
+        } else if self.detect_warm_reset() {
+            raminit::BOOT_PATH_RESET
+        } else {
+            raminit::BOOT_PATH_NORMAL
+        }
+    }
+
     fn platform_type(&self) -> u8 {
         const PINEVIEW_DID_MASK: u16 = 0xfff0;
         const PINEVIEW_MOBILE_DID: u16 = 0xa010;
@@ -661,7 +678,7 @@ impl MemoryController for IntelPineview {
         if self.config.ck505_pre_raminit {
             pineview_ck505_pre_raminit(&mut smbus);
         }
-        let boot_path = if self.detect_warm_reset() { 1 } else { 0 };
+        let boot_path = self.detect_boot_path();
         let platform_type = self.platform_type();
         let size = raminit::sdram_initialize(
             &self.mchbar(),

--- a/crates/fstart-driver-intel-pineview/src/raminit/jedec.rs
+++ b/crates/fstart-driver-intel-pineview/src/raminit/jedec.rs
@@ -10,9 +10,10 @@ use crate::regs::{mchbar, MchBar};
 const NOP_CMD: u8 = 1 << 1;
 const PRE_CHARGE_CMD: u8 = 1 << 2;
 const MRS_CMD: u8 = (1 << 2) | (1 << 1);
-const EMRS1_CMD: u8 = 1 << 3;
-const EMRS2_CMD: u8 = (1 << 3) | (1 << 2);
-const EMRS3_CMD: u8 = (1 << 3) | (1 << 2) | (1 << 1);
+const EMRS_CMD: u8 = 1 << 3;
+const EMRS1_CMD: u8 = EMRS_CMD | (1 << 4);
+const EMRS2_CMD: u8 = EMRS_CMD | (1 << 5);
+const EMRS3_CMD: u8 = EMRS_CMD | (1 << 5) | (1 << 4);
 const CBR_CMD: u8 = (1 << 3) | (1 << 2);
 const NORMAL_OP_CMD: u8 = (1 << 3) | (1 << 2) | (1 << 1);
 
@@ -36,10 +37,8 @@ fn send_jedec_cmd(mch: &MchBar, rank: u8, jmode: u8, jval: u16) {
     }
     core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
 
-    // 1 µs delay for command execution.
-    for _ in 0..200 {
-        core::hint::spin_loop();
-    }
+    // Current coreboot/MRC waits 2 µs between JEDEC commands.
+    super::udelay(2);
 }
 
 /// JEDEC DDR2 initialization sequence.
@@ -81,10 +80,7 @@ pub fn jedec_init(si: &SysInfo, mch: &MchBar) {
         rttnom |= 1 << 6;
     }
 
-    // 200 µs settling time.
-    for _ in 0..40_000 {
-        core::hint::spin_loop();
-    }
+    super::udelay(200);
 
     // Execute JEDEC sequence for each populated rank.  The controller's
     // JEDEC command rank field is packed over populated ranks, not physical

--- a/crates/fstart-driver-intel-pineview/src/raminit/mod.rs
+++ b/crates/fstart-driver-intel-pineview/src/raminit/mod.rs
@@ -23,7 +23,7 @@ mod rcomplut;
 mod spd;
 mod timing;
 
-use crate::regs::{mchbar, MchBar};
+use crate::regs::{ich7, mchbar, MchBar, Rcba};
 use fstart_ecam as ecam;
 use fstart_services::ServiceError;
 use fstart_spd::DimmInfo;
@@ -43,10 +43,40 @@ pub const DIMM_TYPE_SODIMM: u8 = 2;
 pub const PLATFORM_DESKTOP: u8 = 0;
 pub const PLATFORM_MOBILE: u8 = 1;
 
-#[allow(dead_code)]
-const BOOT_PATH_NORMAL: u8 = 0;
-const BOOT_PATH_RESET: u8 = 1;
-const BOOT_PATH_RESUME: u8 = 2;
+pub(crate) const BOOT_PATH_NORMAL: u8 = 0;
+pub(crate) const BOOT_PATH_RESET: u8 = 1;
+pub(crate) const BOOT_PATH_RESUME: u8 = 2;
+
+const PINEVIEW_TSC_HZ: u64 = 1_666_666_667;
+const RCBA_HPTC: u32 = 0x3404;
+
+/// Delay for Pineview raminit timing sequences.
+pub(super) fn udelay(us: u32) {
+    fstart_arch_x86::udelay_tsc(us, PINEVIEW_TSC_HZ);
+}
+
+fn enable_hpet() -> Result<(), ServiceError> {
+    let lpc = ecam::EcamDevice::new(0, ich7::LPC_DEV, ich7::LPC_FUNC);
+    let rcba_base = lpc.read32(ich7::RCBA_REG) & 0xffff_c000;
+    if rcba_base == 0 {
+        fstart_log::error!("raminit: RCBA is not enabled, cannot enable HPET");
+        return Err(ServiceError::HardwareError);
+    }
+
+    let rcba = Rcba::new(rcba_base as usize);
+    rcba.write32(RCBA_HPTC, (rcba.read32(RCBA_HPTC) & !0x83) | (1 << 7));
+    let _ = rcba.read32(RCBA_HPTC);
+
+    // SAFETY: HPET MMIO is enabled at the fixed ICH7 HPET base above. Setting
+    // bit 0 in the main configuration register starts the counter for raminit
+    // microsecond delays, matching coreboot `enable_hpet()`.
+    unsafe {
+        let cfg = fstart_mmio::read32((mchbar::HPET_BASE as usize + 0x10) as *const u32);
+        fstart_mmio::write32((mchbar::HPET_BASE as usize + 0x10) as *mut u32, cfg | 1);
+    }
+
+    Ok(())
+}
 
 // ===================================================================
 // Sysinfo — raminit state
@@ -182,13 +212,13 @@ pub fn sdram_initialize(
     spd::read_spds(&mut si, smbus)?;
 
     // 2. Detect RAM speed (common frequency).
-    timing::detect_ram_speed(&mut si, mch);
+    timing::detect_ram_speed(&mut si, mch)?;
 
     // 3. Detect smallest common timings.
-    timing::detect_smallest_params(&mut si);
+    timing::detect_smallest_params(&mut si)?;
 
     // 4. Enable HPET.
-    // (Handled by platform code, not raminit.)
+    enable_hpet()?;
 
     // 5. Clock crossing.
     mch.setbits32(mchbar::CPCTL, 1 << 15);
@@ -210,7 +240,7 @@ pub fn sdram_initialize(
 
     // 10. RCOMP (skip on reset path).
     if si.boot_path != BOOT_PATH_RESET {
-        phy::rcomp(&si, mch);
+        phy::rcomp(&si, mch)?;
     }
 
     // 11. ODT.
@@ -265,11 +295,11 @@ pub fn sdram_initialize(
     mmap::sdram_dradrb(&mut si, mch);
 
     // 21. Receive enable calibration.
-    phy::sdram_rcven(&mut si, mch);
+    phy::sdram_rcven(&mut si, mch)?;
 
-    // Coreboot now runs additional Vref margining here for desktop
-    // DDR2 UDIMMs. fstart intentionally skips it until the temporary
-    // cache/MTRR dance used by that routine is ported safely.
+    if si.spd_type == fstart_spd::DDR2 && !si.is_sodimm() && si.boot_path != BOOT_PATH_RESUME {
+        phy::sdram_vref_margining(mch)?;
+    }
 
     // 22. New tRD.
     phy::sdram_new_trd(&si, mch);

--- a/crates/fstart-driver-intel-pineview/src/raminit/phy.rs
+++ b/crates/fstart-driver-intel-pineview/src/raminit/phy.rs
@@ -10,18 +10,7 @@
 use super::{PllParam, SysInfo};
 use crate::regs::{mchbar, MchBar};
 use fstart_ecam as ecam;
-
-const PINEVIEW_TSC_HZ: u64 = 1_666_666_667;
-
-/// Microsecond delay for raminit sequences.
-///
-/// Pineview boards supported here use Atom D410/D510-class parts with a
-/// constant 1.66 GHz TSC.  Use TSC-based delays instead of raw spin-loop
-/// guesses so the JEDEC/RCVEN waits match coreboot's `udelay()` much more
-/// closely once HPET is enabled.
-fn hpet_udelay(us: u32) {
-    fstart_arch_x86::udelay_tsc(us, PINEVIEW_TSC_HZ);
-}
+use fstart_services::ServiceError;
 
 // ===================================================================
 // PLL calibration tables (from coreboot sdram_calibratepll)
@@ -451,7 +440,7 @@ const RCOMPCTL: [u32; 7] = [
 /// Full RCOMP calibration.
 ///
 /// Ported from coreboot `sdram_rcomp()`.
-pub fn rcomp(si: &SysInfo, mch: &MchBar) {
+pub fn rcomp(si: &SysInfo, mch: &MchBar) -> Result<(), ServiceError> {
     let rcompslew: u8 = 0x0A;
 
     static RCOMPUPDATE: [u8; 7] = [0, 0, 0, 1, 1, 0, 0];
@@ -508,10 +497,14 @@ pub fn rcomp(si: &SysInfo, mch: &MchBar) {
         // Clear slew base / LUTs.
         let v = mch.read16(base + 0x16);
         mch.write16(base + 0x16, v & !0x7F7F);
-        mch.write16(base + 0x18, 0);
-        mch.write16(base + 0x18 + 2, 0);
-        mch.write16(base + 0x1C, 0);
-        mch.write16(base + 0x1C + 2, 0);
+        let v = mch.read16(base + 0x18);
+        mch.write16(base + 0x18, v & !0x3F3F);
+        let v = mch.read16(base + 0x18 + 2);
+        mch.write16(base + 0x18 + 2, v & !0x3F3F);
+        let v = mch.read16(base + 0x1C);
+        mch.write16(base + 0x1C, v & !0x3F3F);
+        let v = mch.read16(base + 0x1C + 2);
+        mch.write16(base + 0x1C + 2, v & !0x3F3F);
     }
 
     // ODT record.
@@ -527,8 +520,8 @@ pub fn rcomp(si: &SysInfo, mch: &MchBar) {
             continue;
         }
         let base = RCOMPCTL[i];
-        let v = mch.read8(base + 2);
-        mch.write8(base + 2, v & !0x71);
+        let v = mch.read8(base);
+        mch.write8(base, v & !(3 << 5));
         let v = mch.read16(base + 2);
         mch.write16(base + 2, v & !0x0706);
         let v = mch.read16(base + 0x0A);
@@ -615,9 +608,23 @@ pub fn rcomp(si: &SysInfo, mch: &MchBar) {
 
             let p_step = 1u8 << (srup + 1);
             let n_step = 1u8 << (srun + 1);
-            if rcompp < p_step || rcompn < n_step {
-                fstart_log::error!("raminit: RCOMP base underflow for group {}", i);
-                continue;
+            if rcompp < p_step {
+                fstart_log::error!(
+                    "raminit: RCOMP group {} P base underflow: raw={} granularity={}",
+                    i,
+                    rcompp as u32,
+                    srup as u32,
+                );
+                return Err(ServiceError::HardwareError);
+            }
+            if rcompn < n_step {
+                fstart_log::error!(
+                    "raminit: RCOMP group {} N base underflow: raw={} granularity={}",
+                    i,
+                    rcompn as u32,
+                    srun as u32,
+                );
+                return Err(ServiceError::HardwareError);
             }
             let base_p = rcompp - p_step;
             let base_n = rcompn - n_step;
@@ -629,15 +636,16 @@ pub fn rcomp(si: &SysInfo, mch: &MchBar) {
             );
         }
 
-        let lutpbase = rcompp.saturating_sub(1 << (last_srup + 1));
-        let lutnbase = rcompn.saturating_sub(1 << (last_srun + 1));
-        program_rcomp_luts(si, mch, lutpbase, last_srup, lutnbase, last_srun);
+        let lutpbase = rcompp - (1 << (last_srup + 1));
+        let lutnbase = rcompn - (1 << (last_srun + 1));
+        program_rcomp_luts(si, mch, lutpbase, last_srup, lutnbase, last_srun)?;
     }
 
     // Start final RCOMP.
     mch.setbits32(mchbar::COMPCTRL1, 1 << 0);
 
     fstart_log::info!("raminit: RCOMP calibration done");
+    Ok(())
 }
 
 fn program_lut_byte(mch: &MchBar, off: u32, value: u8) {
@@ -645,14 +653,21 @@ fn program_lut_byte(mch: &MchBar, off: u32, value: u8) {
     mch.write8(off, (v & !0x3f) | (value & 0x3f));
 }
 
-fn program_rcomp_luts(si: &SysInfo, mch: &MchBar, lutpbase: u8, srup: u8, lutnbase: u8, srun: u8) {
+fn program_rcomp_luts(
+    si: &SysInfo,
+    mch: &MchBar,
+    lutpbase: u8,
+    srup: u8,
+    lutnbase: u8,
+    srun: u8,
+) -> Result<(), ServiceError> {
     use super::rcomplut::RCOMPLUT;
 
     for i in 0..4u32 {
         let j = lutpbase as usize + ((i as usize) << srup);
         if j >= RCOMPLUT.len() {
-            fstart_log::error!("raminit: RCOMP P LUT index out of range");
-            return;
+            fstart_log::error!("raminit: RCOMP P LUT index out of range: {}", j as u32);
+            return Err(ServiceError::HardwareError);
         }
         program_lut_byte(mch, RCOMPCTL[0] + 0x18 + i, RCOMPLUT[j][0]);
         if !si.is_sodimm() {
@@ -669,8 +684,8 @@ fn program_rcomp_luts(si: &SysInfo, mch: &MchBar, lutpbase: u8, srup: u8, lutnba
     for i in 0..4u32 {
         let j = lutnbase as usize + ((i as usize) << srun);
         if j >= RCOMPLUT.len() {
-            fstart_log::error!("raminit: RCOMP N LUT index out of range");
-            return;
+            fstart_log::error!("raminit: RCOMP N LUT index out of range: {}", j as u32);
+            return Err(ServiceError::HardwareError);
         }
         program_lut_byte(mch, RCOMPCTL[0] + 0x1c + i, RCOMPLUT[j][1]);
         if !si.is_sodimm() {
@@ -683,6 +698,7 @@ fn program_rcomp_luts(si: &SysInfo, mch: &MchBar, lutpbase: u8, srup: u8, lutnba
         program_lut_byte(mch, RCOMPCTL[5] + 0x1c + i, RCOMPLUT[j][9]);
         program_lut_byte(mch, RCOMPCTL[6] + 0x1c + i, RCOMPLUT[j][9]);
     }
+    Ok(())
 }
 
 // ===================================================================
@@ -793,7 +809,7 @@ pub fn rcomp_update(_si: &SysInfo, mch: &MchBar) {
 
     for _ in 0..3 {
         mch.setbits32(mchbar::COMPCTRL1, 1 << 0);
-        hpet_udelay(1000);
+        super::udelay(1000);
         while mch.read8(mchbar::COMPCTRL1) & 1 != 0 {
             core::hint::spin_loop();
         }
@@ -807,7 +823,7 @@ pub fn rcomp_update(_si: &SysInfo, mch: &MchBar) {
     }
 
     mch.setbits32(mchbar::COMPCTRL1, 1 << 0);
-    hpet_udelay(1000);
+    super::udelay(1000);
     while mch.read8(mchbar::COMPCTRL1) & 1 != 0 {
         core::hint::spin_loop();
     }
@@ -823,7 +839,19 @@ pub fn rcomp_update(_si: &SysInfo, mch: &MchBar) {
 ///
 /// Ported from coreboot `sdram_rcven()`. Trains the DQS receive enable
 /// timing for each byte lane by sweeping coarse + medium + PI delay.
-pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
+fn rcven_fail(step: &str, lane: u8, coarse: u8, medium: u8, pi: u8) -> Result<(), ServiceError> {
+    fstart_log::error!(
+        "raminit: RCVEN lane {} failed {}: coarse={} medium={} pi={}",
+        lane,
+        step,
+        coarse,
+        medium,
+        pi,
+    );
+    Err(ServiceError::HardwareError)
+}
+
+pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) -> Result<(), ServiceError> {
     let v = mch.read8(mchbar::C0RSTCTL);
     mch.write8(mchbar::C0RSTCTL, v & !(3 << 2));
     let v = mch.read8(mchbar::CMNDQFIFORST);
@@ -861,15 +889,14 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
         // Phase 1: sweep until DQS goes high.
         while !sample_dqs(mch, dqshighaddr, 0, 3) {
             if !rcven_clock(mch, &mut coarse, &mut medium, lane) {
-                fstart_log::error!("raminit: RCVEN lane {} failed before DQS-low search", lane);
-                break;
+                return rcven_fail("before DQS-low search", lane, coarse, medium, pi);
             }
         }
 
         savecoarse = coarse;
         savemedium = medium;
         if !rcven_clock(mch, &mut coarse, &mut medium, lane) {
-            fstart_log::error!("raminit: RCVEN lane {} failed before DQS-high search", lane);
+            return rcven_fail("before DQS-high search", lane, coarse, medium, pi);
         }
 
         // Phase 2: continue until DQS stays high.
@@ -877,8 +904,7 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
             savecoarse = coarse;
             savemedium = medium;
             if !rcven_clock(mch, &mut coarse, &mut medium, lane) {
-                fstart_log::error!("raminit: RCVEN lane {} failed before PI search", lane);
-                break;
+                return rcven_fail("before PI search", lane, coarse, medium, pi);
             }
         }
 
@@ -904,9 +930,7 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
                     savepi = si.maxpi;
                     break;
                 }
-                fstart_log::error!("raminit: RCVEN lane {} PI search failed", lane);
-                savepi = si.maxpi;
-                break;
+                return rcven_fail("during PI search", lane, coarse, medium, savepi);
             }
             let v = mch.read8(mchbar::ly(0x560, lane as u32));
             mch.write8(
@@ -922,13 +946,16 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
             (v & !0x3F) | (pi << si.pioffset),
         );
         if !rcven_clock(mch, &mut coarse, &mut medium, lane) {
-            fstart_log::error!("raminit: RCVEN lane {} failed after PI search", lane);
+            return rcven_fail("after PI search", lane, coarse, medium, pi);
+        }
+        if !sample_dqs(mch, dqshighaddr, 1, 3) {
+            return rcven_fail("after centering", lane, coarse, medium, pi);
         }
 
         // Phase 4: back off until DQS goes low.
         while !sample_dqs(mch, dqshighaddr, 0, 3) {
             if coarse == 0 {
-                break;
+                return rcven_fail("finding final DQS-low edge", lane, coarse, medium, pi);
             }
             coarse -= 1;
             let v = mch.read32(mchbar::C0STATRDCTRL);
@@ -939,7 +966,7 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
         }
 
         if !rcven_clock(mch, &mut coarse, &mut medium, lane) {
-            fstart_log::error!("raminit: RCVEN lane {} failed at final clock step", lane);
+            return rcven_fail("at final clock step", lane, coarse, medium, pi);
         }
         si.pi[lane as usize] = pi;
         lanecoarse[lane as usize] = coarse;
@@ -954,7 +981,14 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
     for lane in (0..maxlane as usize).rev() {
         let offset = lanecoarse[lane].saturating_sub(minlanecoarse);
         if offset > 3 {
-            fstart_log::error!("raminit: RCVEN lane {} coarse offset too large", lane);
+            fstart_log::error!(
+                "raminit: RCVEN lane {} coarse offset too large: offset={} coarse={} min={}",
+                lane as u32,
+                offset as u32,
+                lanecoarse[lane] as u32,
+                minlanecoarse as u32,
+            );
+            return Err(ServiceError::HardwareError);
         }
         let v = mch.read16(mchbar::C0COARSEDLY0);
         mch.write16(
@@ -985,6 +1019,7 @@ pub fn sdram_rcven(si: &mut SysInfo, mch: &MchBar) {
     mch.setbits32(mchbar::CMNDQFIFORST, 1 << 7);
 
     fstart_log::info!("raminit: receive enable calibration done");
+    Ok(())
 }
 
 /// Sample DQS for the given lane.
@@ -992,9 +1027,9 @@ fn sample_dqs(mch: &MchBar, dqshighaddr: u32, highlow: u8, count: u8) -> bool {
     let mut matches = true;
     for _ in 0..count {
         mch.clrbits32(mchbar::C0RSTCTL, 1 << 1);
-        hpet_udelay(1);
+        super::udelay(1);
         mch.setbits32(mchbar::C0RSTCTL, 1 << 1);
-        hpet_udelay(1);
+        super::udelay(1);
 
         // SAFETY: Intentionally reads from physical address 0 to trigger
         // a DRAM read cycle for DQS sampling during receive-enable
@@ -1004,13 +1039,177 @@ fn sample_dqs(mch: &MchBar, dqshighaddr: u32, highlow: u8, count: u8) -> bool {
         unsafe {
             core::ptr::read_volatile(core::ptr::null::<u32>());
         }
-        hpet_udelay(1);
+        super::udelay(1);
 
         if ((mch.read8(dqshighaddr) & (1 << 6)) >> 6) != highlow {
             matches = false;
         }
     }
     matches
+}
+
+fn vref_pattern(addr: u32, inverse: bool) -> u8 {
+    let mut pattern_a = 0xffu8;
+    pattern_a &= !(((1u16 << ((addr >> 13) & 0x0f)) >> 1) as u8);
+    let mut pattern_b = !pattern_a;
+
+    if addr & 0x100 != 0 {
+        core::mem::swap(&mut pattern_a, &mut pattern_b);
+    }
+
+    let isi_left = ((addr >> 11) & 0x03) + 1;
+    let isi_total = isi_left + ((addr >> 9) & 0x03) + 1;
+
+    let mut pattern = pattern_a;
+    if (((addr & 0xff) >> 3) % isi_total) >= isi_left {
+        pattern = pattern_b;
+    }
+
+    if inverse {
+        !pattern
+    } else {
+        pattern
+    }
+}
+
+fn vref_write_pattern(addr: u32) {
+    for i in 0..1024u32 {
+        // SAFETY: Vref margining intentionally writes the already-initialized
+        // low DRAM test window, matching coreboot's raminit sequence.
+        unsafe {
+            core::ptr::write_volatile((addr + i) as usize as *mut u8, vref_pattern(addr + i, true));
+        }
+    }
+}
+
+fn vref_flush(addr: u32) {
+    for offset in (0..0x2000u32).step_by(64) {
+        let ptr = (addr + offset) as usize as *const u8;
+        // SAFETY: CLFLUSH is used on the temporary DRAM test window to force
+        // refills while sweeping Vref, exactly as required by the training
+        // algorithm.  The address range is covered by a temporary MTRR below.
+        unsafe {
+            core::arch::asm!("clflush [{}]", in(reg) ptr, options(nostack, preserves_flags));
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct VrefMtrrSave {
+    base: u64,
+    mask: u64,
+}
+
+fn vref_temp_cache_enable(addr: u32) -> VrefMtrrSave {
+    const VREF_MTRR_INDEX: u32 = 3;
+    // SAFETY: Pineview exposes at least the vendor-MRC variable MTRR slot 3.
+    // The saved values are restored after each short probe.
+    let save = unsafe {
+        let (base, mask) = fstart_arch_x86::mtrr::read_variable(VREF_MTRR_INDEX);
+        VrefMtrrSave { base, mask }
+    };
+    // SAFETY: Programs a temporary 8KiB write-protected MTRR over low DRAM for
+    // the Vref readback window.  The caller restores the original slot.
+    unsafe {
+        fstart_arch_x86::mtrr::set_variable(
+            VREF_MTRR_INDEX,
+            addr as u64,
+            0x2000,
+            fstart_arch_x86::mtrr::MTRR_TYPE_WRITE_PROTECT,
+        );
+    }
+    save
+}
+
+fn vref_temp_cache_disable(save: VrefMtrrSave) {
+    const VREF_MTRR_INDEX: u32 = 3;
+    let base_msr = fstart_arch_x86::mtrr::IA32_MTRR_PHYSBASE0 + VREF_MTRR_INDEX * 2;
+    let mask_msr = fstart_arch_x86::mtrr::IA32_MTRR_PHYSMASK0 + VREF_MTRR_INDEX * 2;
+    // SAFETY: Restores the exact variable MTRR pair saved by
+    // `vref_temp_cache_enable`.
+    unsafe {
+        fstart_arch_x86::x86::msr::wrmsr(base_msr, save.base);
+        fstart_arch_x86::x86::msr::wrmsr(mask_msr, save.mask);
+    }
+}
+
+fn vref_read_aligned(mch: &MchBar, addr: u32, vref: u8) -> bool {
+    let v = mch.read8(mchbar::CSHRMISCCTL1);
+    mch.write8(mchbar::CSHRMISCCTL1, (v & !0x3f) | vref);
+
+    for _ in 0..3 {
+        let save = vref_temp_cache_enable(addr);
+        vref_flush(addr);
+        for i in 0..1024u32 {
+            // SAFETY: Reads the low DRAM Vref pattern window after raminit has
+            // mapped DRAM at address 0.
+            let data = unsafe { core::ptr::read_volatile((addr + i) as usize as *const u8) };
+            let expected = vref_pattern(addr + i, true);
+            if data != expected {
+                vref_temp_cache_disable(save);
+                fstart_log::info!(
+                    "raminit: Vref {:#x} failed at {:#x}: wr={:#x} rd={:#x}",
+                    vref as u32,
+                    addr + i,
+                    expected as u32,
+                    data as u32,
+                );
+                return false;
+            }
+        }
+        vref_temp_cache_disable(save);
+    }
+
+    true
+}
+
+/// Run DDR2 UDIMM Vref margining.
+pub fn sdram_vref_margining(mch: &MchBar) -> Result<(), ServiceError> {
+    static POSITIVE: [u8; 4] = [0x07, 0x0e, 0x15, 0x1c];
+    static NEGATIVE: [u8; 4] = [0x27, 0x2e, 0x35, 0x3c];
+    static LOOKUP: [[u8; 5]; 5] = [
+        [0x00, 0x03, 0x04, 0x05, 0x05],
+        [0x23, 0x00, 0x03, 0x04, 0x05],
+        [0x24, 0x23, 0x00, 0x03, 0x04],
+        [0x25, 0x24, 0x23, 0x00, 0x03],
+        [0x25, 0x25, 0x24, 0x23, 0x00],
+    ];
+    let addr = 0u32;
+    let mut pos_pass = 0usize;
+    let mut neg_pass = 0usize;
+
+    let v = mch.read16(mchbar::CSHRMISCCTL1);
+    mch.write16(mchbar::CSHRMISCCTL1, v & !(1 << 8));
+    vref_write_pattern(addr);
+
+    for &vref in &POSITIVE {
+        if !vref_read_aligned(mch, addr, vref) {
+            break;
+        }
+        pos_pass += 1;
+    }
+    for &vref in &NEGATIVE {
+        if !vref_read_aligned(mch, addr, vref) {
+            break;
+        }
+        neg_pass += 1;
+    }
+
+    if pos_pass == 0 && neg_pass == 0 {
+        fstart_log::error!("raminit: Vref margining failed");
+        return Err(ServiceError::HardwareError);
+    }
+
+    let vref = LOOKUP[neg_pass][pos_pass];
+    let v = mch.read8(mchbar::CSHRMISCCTL1);
+    mch.write8(mchbar::CSHRMISCCTL1, (v & !0x3f) | vref);
+    fstart_log::info!(
+        "raminit: Vref margining pos={} neg={} value={:#x}",
+        pos_pass as u32,
+        neg_pass as u32,
+        vref as u32,
+    );
+    Ok(())
 }
 
 /// Advance receive enable clock (medium, then coarse).
@@ -1045,18 +1244,19 @@ fn rcven_clock(mch: &MchBar, coarse: &mut u8, medium: &mut u8, lane: u8) -> bool
 ///
 /// Ported from coreboot `sdram_new_trd()`.
 pub fn sdram_new_trd(si: &SysInfo, mch: &MchBar) {
-    let tmclk: u32 = if si.selected_timings.mem_clock == 0 {
+    let raw_tmclk: u32 = if si.selected_timings.mem_clock == 0 {
         3000
     } else {
         2500
     };
-    let thclk: u32 = if si.selected_timings.fsb_clock == 0 {
+    let raw_thclk: u32 = if si.selected_timings.fsb_clock == 0 {
         6000
     } else {
         5000
     };
     let freqgb: u32 = 110;
-    let tmclk_adj = tmclk * 100 / freqgb;
+    let tmclk_adj = raw_tmclk * 100 / freqgb;
+    let thclk = raw_thclk * 100 / freqgb;
     let buffertocore: u32 = if si.platform_type == super::PLATFORM_MOBILE {
         5500
     } else {
@@ -1108,11 +1308,11 @@ pub fn sdram_new_trd(si: &SysInfo, mch: &MchBar) {
         + buffertocore as i64
         + postcalib as i64
         + if si.r#async != 0 {
-            (tmclk_adj / 2) as i64
+            (raw_tmclk / 2) as i64
         } else {
             0
         };
-    let datadelay = datadelay_signed.max(0) as u32;
+    let mut datadelay = datadelay_signed.max(0) as u32;
 
     let j = si.selected_timings.mem_clock as usize;
     let k = si.selected_timings.fsb_clock as usize;
@@ -1129,6 +1329,18 @@ pub fn sdram_new_trd(si: &SysInfo, mch: &MchBar) {
         _ => 2,
     };
 
+    if si.selected_timings.cas == 5 {
+        if si.platform_type == super::PLATFORM_MOBILE {
+            if j == 0 && k == 0 {
+                datadelay = datadelay.saturating_sub(3084);
+            }
+        } else if j == 0 && k == 0 {
+            datadelay = datadelay.saturating_sub(1848);
+        } else if j == 1 && k == 1 {
+            datadelay = datadelay.saturating_sub(2750);
+        }
+    }
+
     let mut trd: u8 = 0;
     for i in 0..cc {
         let adj = TRD_ADJUST[k][j][i] * 100 / freqgb;
@@ -1139,15 +1351,6 @@ pub fn sdram_new_trd(si: &SysInfo, mch: &MchBar) {
         }
         phase_trd += 1;
         trd = trd.max(phase_trd);
-    }
-
-    if j == 0 && k == 0 {
-        let corrected = datadelay.saturating_sub(3084);
-        let mut phase_trd = (corrected / thclk) as u8;
-        if phase_trd >= 2 {
-            phase_trd -= 2;
-        }
-        trd = trd.max(phase_trd + 1);
     }
 
     let v = mch.read16(mchbar::C0STATRDCTRL);

--- a/crates/fstart-driver-intel-pineview/src/raminit/spd.rs
+++ b/crates/fstart-driver-intel-pineview/src/raminit/spd.rs
@@ -63,6 +63,8 @@ pub fn read_spds(
             info.cas_latencies = 7;
         }
 
+        validate_pineview_spd(&info, i)?;
+
         si.dt0mode |= (info.spd_data[49] & 0x2) >> 1;
 
         let dimm_type = match info.spd_data[20] {
@@ -111,7 +113,7 @@ pub fn read_spds(
 
     // Determine DIMM configuration per channel (coreboot find_ramconfig).
     for chan in 0..super::TOTAL_CHANNELS {
-        si.dimm_config[chan] = find_ramconfig(si, chan);
+        si.dimm_config[chan] = find_ramconfig(si, chan)?;
         fstart_log::info!("raminit: config[CH{}] = {}", chan, si.dimm_config[chan]);
     }
 
@@ -127,71 +129,101 @@ fn chip_width_bits(width: ChipWidth) -> u8 {
     }
 }
 
+fn validate_pineview_spd(info: &fstart_spd::DimmInfo, idx: usize) -> Result<(), ServiceError> {
+    if info.spd_data[11] & 0x02 != 0 {
+        fstart_log::error!(
+            "raminit: DIMM {} uses unsupported DDR2 module configuration bits",
+            idx
+        );
+        return Err(ServiceError::HardwareError);
+    }
+    if !matches!(info.banks, 4 | 8)
+        || !matches!(info.width, ChipWidth::X8 | ChipWidth::X16)
+        || info.ranks > 2
+        || info.sides > 2
+        || !(12..=15).contains(&info.rows)
+        || !(9..=10).contains(&info.cols)
+    {
+        fstart_log::error!(
+            "raminit: DIMM {} unsupported geometry banks={} width=x{} ranks={} sides={} rows={} cols={}",
+            idx,
+            info.banks as u32,
+            chip_width_bits(info.width) as u32,
+            info.ranks as u32,
+            info.sides as u32,
+            info.rows as u32,
+            info.cols as u32,
+        );
+        return Err(ServiceError::HardwareError);
+    }
+    Ok(())
+}
+
 /// Determine the DIMM configuration code for a channel.
 ///
 /// Pineview has two incompatible encodings.  Desktop/UDIMM uses the
 /// vendor-MRC 4-bit DIMMA/DIMMB matrix.  Mobile/SO-DIMM keeps the older
 /// 0..6 encoding used by coreboot for DDR2 SO-DIMMs.
-fn find_ramconfig(si: &SysInfo, chan: usize) -> u8 {
+fn find_ramconfig(si: &SysInfo, chan: usize) -> Result<u8, ServiceError> {
     let dimma = chan * 2;
     let dimmb = dimma + 1;
     let a = &si.dimms[dimma];
     let b = &si.dimms[dimmb];
 
     if !si.is_sodimm() {
-        let a_cfg = a.as_ref().map_or(0, dimm_config_desktop);
-        let b_cfg = b.as_ref().map_or(0, dimm_config_desktop);
-        return a_cfg | (b_cfg << 2);
+        let a_cfg = a.as_ref().map_or(Ok(0), dimm_config_desktop)?;
+        let b_cfg = b.as_ref().map_or(Ok(0), dimm_config_desktop)?;
+        return Ok(a_cfg | (b_cfg << 2));
     }
 
-    let a_sides = a.as_ref().map_or(0, |d| d.sides);
-    let b_sides = b.as_ref().map_or(0, |d| d.sides);
-    let a_x8 = a.as_ref().is_some_and(|d| d.width == ChipWidth::X8);
-    let b_x8 = b.as_ref().is_some_and(|d| d.width == ChipWidth::X8);
+    let a_pop = a.as_ref().is_some_and(|d| d.card_type != 0);
+    let b_pop = b.as_ref().is_some_and(|d| d.card_type != 0);
 
-    match (a_sides, b_sides) {
-        (0, 0) => 0,
-        (0, 1) => 1,
-        (0, s) if s > 1 => {
-            if b_x8 {
-                5
-            } else {
-                2
-            }
+    if a_pop && b_pop {
+        let Some(dimma) = a.as_ref() else {
+            return Ok(0);
+        };
+        let mut config = 3;
+        if dimma.sides > 1 {
+            config += 1;
         }
-        (1, 0) => 1,
-        (1, 1) => 3,
-        (s, 0) if s > 1 => {
-            if a_x8 {
-                5
-            } else {
-                4
-            }
+        if dimma.width == ChipWidth::X8 && dimma.sides > 1 {
+            config = 6;
         }
-        (s1, s2) if s1 > 1 && s2 > 1 => {
-            if a_x8 && b_x8 {
-                6
-            } else {
-                4
-            }
-        }
-        _ => 0,
+        return Ok(config);
     }
+
+    if a_pop || b_pop {
+        let a_sides = a.as_ref().map_or(0, |d| d.sides);
+        let b_sides = b.as_ref().map_or(0, |d| d.sides);
+        let a_x8 = a.as_ref().is_none_or(|d| d.width == ChipWidth::X8);
+        let b_x8 = b.as_ref().is_none_or(|d| d.width == ChipWidth::X8);
+        let mut config = 1;
+        if a_sides > 1 || b_sides > 1 {
+            config += 1;
+            if a_x8 || b_x8 {
+                config = 5;
+            }
+        }
+        return Ok(config);
+    }
+
+    Ok(0)
 }
 
-fn dimm_config_desktop(d: &fstart_spd::DimmInfo) -> u8 {
+fn dimm_config_desktop(d: &fstart_spd::DimmInfo) -> Result<u8, ServiceError> {
     if d.card_type == 0 {
-        return 0;
+        return Ok(0);
     }
     let x8 = d.width == ChipWidth::X8;
     let x16 = matches!(d.width, ChipWidth::X16 | ChipWidth::X32);
     match (d.ranks, x8, x16) {
-        (1, true, _) => 1,
-        (2, true, _) => 2,
-        (1, _, true) => 3,
+        (1, true, _) => Ok(1),
+        (2, true, _) => Ok(2),
+        (1, _, true) => Ok(3),
         _ => {
             fstart_log::error!("raminit: unsupported UDIMM rank/width config");
-            0
+            Err(ServiceError::HardwareError)
         }
     }
 }

--- a/crates/fstart-driver-intel-pineview/src/raminit/timing.rs
+++ b/crates/fstart-driver-intel-pineview/src/raminit/timing.rs
@@ -7,6 +7,8 @@
 use super::SysInfo;
 use crate::regs::{ich7, mchbar, MchBar};
 use fstart_ecam as ecam;
+use fstart_services::ServiceError;
+use fstart_spd::ChipWidth;
 
 // ===================================================================
 // Helpers
@@ -34,6 +36,14 @@ fn div_round_up(a: u32, b: u32) -> u32 {
     a.div_ceil(b)
 }
 
+fn chip_width_code(width: ChipWidth) -> u8 {
+    match width {
+        ChipWidth::X8 => 0,
+        ChipWidth::X16 | ChipWidth::X32 => 1,
+        ChipWidth::X4 => 0,
+    }
+}
+
 // ===================================================================
 // RAM speed detection
 // ===================================================================
@@ -42,27 +52,49 @@ fn div_round_up(a: u32, b: u32) -> u32 {
 /// then find the common CAS latency across all populated DIMMs.
 ///
 /// Ported from coreboot `sdram_detect_ram_speed()`.
-pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) {
-    // --- Read FSB frequency from host bridge register 0xE3 ---
+pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) -> Result<(), ServiceError> {
     let hb = ecam::EcamDevice::new(0, 0, 0);
-    let e3 = hb.read8(0xE3);
-    let fsb_raw = (e3 & 0x70) >> 4;
-    let fsb: u8 = if fsb_raw != 0 {
-        // 5 - fsb_raw: 4→1(800), 3→2(invalid), 2→3(invalid), 1→4(invalid)
-        // In practice only 4 (=800MHz) and 0 (=800MHz default) appear on Pineview.
-        (5u8.saturating_sub(fsb_raw)).min(1)
-    } else {
-        1 // FSB_CLOCK_800MHz
+
+    // Core frequency comes from MCHBAR CLKCFG on Pineview.
+    let fsb: u8 = match mch.read8(mchbar::CLKCFG) & 0x07 {
+        0x02 => 1, // FSB_CLOCK_800MHz
+        0x03 => 0, // FSB_CLOCK_667MHz
+        raw => {
+            fstart_log::error!(
+                "raminit: unsupported core frequency strap {:#x}",
+                raw as u32
+            );
+            return Err(ServiceError::HardwareError);
+        }
     };
 
     // --- Read DDR frequency from host bridge registers 0xE3/0xE4 ---
+    let e3 = hb.read8(0xE3);
     let freq_raw = ((e3 & 0x80) >> 7) | ((hb.read8(0xE4) & 0x03) << 1);
     let mut freq: u8 = if freq_raw != 0 {
-        // 6 - freq_raw: 5→1(800), 4→2(invalid), ... Only 5 (=800) and 0 used.
-        (6u8.saturating_sub(freq_raw)).min(1)
+        if freq_raw > 6 {
+            fstart_log::error!(
+                "raminit: unsupported DDR frequency strap {:#x}",
+                freq_raw as u32
+            );
+            return Err(ServiceError::HardwareError);
+        }
+        let converted = 6 - freq_raw;
+        if converted > 1 {
+            fstart_log::error!(
+                "raminit: DDR frequency strap {:#x} converts to unsupported index {}",
+                freq_raw as u32,
+                converted as u32,
+            );
+            return Err(ServiceError::HardwareError);
+        }
+        converted
     } else {
         1 // MEM_CLOCK_800MHz
     };
+    if si.is_sodimm() {
+        freq = 0; // Mobile/SO-DIMM MRC path is DDR667-only.
+    }
 
     si.selected_timings.fsb_clock = fsb;
     fstart_log::info!(
@@ -76,47 +108,51 @@ pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) {
     for i in 0..super::TOTAL_DIMMS {
         if si.dimm_populated(i) {
             let d = si.dimms[i].as_ref().expect("populated");
-            common_cas &= d.cas_latencies;
+            common_cas &= d.spd_data[18];
         }
     }
     if common_cas == 0 {
         fstart_log::error!("raminit: no common CAS latency among DIMMs");
-        common_cas = 7; // fallback
+        return Err(ServiceError::HardwareError);
     }
 
     let msb = msbpos(common_cas);
     let lsb = lsbpos(common_cas);
     let mut highcas = msb as u8;
-    let lowcas = (lsb.max(5)) as u8;
+    let mut lowcas = (lsb.max(5)) as u8;
     let mut cas: u8 = 0;
 
     // --- CAS / frequency negotiation loop ---
-    // For each populated DIMM, check if its tCK (SPD[9]) and
-    // tAA (SPD[10]) meet the current frequency's requirements.
+    // Match coreboot's per-DIMM loop: each DIMM can lower `highcas`, while
+    // an acceptable DIMM sets the selected CAS for the current pass.
     while cas == 0 && highcas >= lowcas {
-        let mut all_ok = true;
         for i in 0..super::TOTAL_DIMMS {
             if !si.dimm_populated(i) {
                 continue;
             }
             let d = si.dimms[i].as_ref().expect("populated");
-            let (max_tck, max_taa) = if freq == 1 {
-                (0x25u8, 0x40u8) // 800 MHz: tCK ≤ 2.5 ns, tAA ≤ 10 ns
-            } else {
-                (0x30u8, 0x45u8) // 667 MHz: tCK ≤ 3.0 ns, tAA ≤ ~11 ns
+            let ok = match freq {
+                1 => d.spd_data[9] <= 0x25 && d.spd_data[10] <= 0x40,
+                0 => d.spd_data[9] <= 0x30 && d.spd_data[10] <= 0x45,
+                _ => {
+                    fstart_log::error!(
+                        "raminit: unsupported DDR frequency index {} during CAS selection",
+                        freq as u32,
+                    );
+                    return Err(ServiceError::HardwareError);
+                }
             };
-            if d.spd_data[9] > max_tck || d.spd_data[10] > max_taa {
-                all_ok = false;
-                break;
+            if ok {
+                cas = highcas;
+            } else if highcas == 0 {
+                fstart_log::error!(
+                    "raminit: CAS search underflow at DDR frequency {}",
+                    freq as u32
+                );
+                return Err(ServiceError::HardwareError);
+            } else {
+                highcas -= 1;
             }
-        }
-        if all_ok {
-            cas = highcas;
-        } else {
-            if highcas == 0 {
-                break;
-            }
-            highcas -= 1;
         }
     }
 
@@ -125,37 +161,35 @@ pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) {
         freq = 0;
         fstart_log::warn!("raminit: dropping to 667 MHz due to timing constraints");
         highcas = msb as u8;
+        lowcas = lsb as u8;
         while cas == 0 && highcas >= lowcas {
-            let mut all_ok = true;
             for i in 0..super::TOTAL_DIMMS {
                 if !si.dimm_populated(i) {
                     continue;
                 }
                 let d = si.dimms[i].as_ref().expect("populated");
                 if d.spd_data[9] > 0x30 || d.spd_data[10] > 0x45 {
-                    all_ok = false;
-                    break;
+                    if highcas == 0 {
+                        fstart_log::error!("raminit: CAS retry underflow at DDR667");
+                        return Err(ServiceError::HardwareError);
+                    }
+                    highcas -= 1;
+                } else {
+                    cas = highcas;
                 }
-            }
-            if all_ok {
-                cas = highcas;
-            } else {
-                if highcas == 0 {
-                    break;
-                }
-                highcas -= 1;
             }
         }
     }
 
     if cas == 0 {
-        fstart_log::error!("raminit: no valid CAS latency found, defaulting to 5");
-        cas = 5;
+        fstart_log::error!("raminit: no valid CAS latency found");
+        return Err(ServiceError::HardwareError);
     }
 
     si.selected_timings.cas = cas;
     si.selected_timings.mem_clock = freq;
     si.selected_timings.fsb_clock = fsb;
+    update_clock_dependent_vars(si);
 
     // --- Program the selected frequency into MCHBAR CLKCFG ---
     if si.boot_path != super::BOOT_PATH_RESET {
@@ -167,18 +201,20 @@ pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) {
 
         // Read back the MCH-validated frequency.
         let validated = ((mch.read32(mchbar::CLKCFG) >> 4) & 0x07).wrapping_sub(2) as u8;
-        si.selected_timings.mem_clock = validated.min(1);
+        si.selected_timings.mem_clock = validated;
 
         if si.selected_timings.mem_clock == 1 {
             fstart_log::info!("raminit: MCH validated at 800MHz");
-            si.nodll = 0;
-            si.maxpi = 63;
-            si.pioffset = 0;
-        } else {
+            update_clock_dependent_vars(si);
+        } else if si.selected_timings.mem_clock == 0 {
             fstart_log::info!("raminit: MCH validated at 667MHz");
-            si.nodll = 1;
-            si.maxpi = 15;
-            si.pioffset = 1;
+            update_clock_dependent_vars(si);
+        } else {
+            fstart_log::error!(
+                "raminit: MCH validated unknown DDR frequency {:#x}",
+                si.selected_timings.mem_clock as u32,
+            );
+            return Err(ServiceError::HardwareError);
         }
     }
 
@@ -196,12 +232,25 @@ pub fn detect_ram_speed(si: &mut SysInfo, mch: &MchBar) {
             667
         }
     );
+    Ok(())
+}
+
+fn update_clock_dependent_vars(si: &mut SysInfo) {
+    if si.selected_timings.mem_clock == 1 {
+        si.nodll = 0;
+        si.maxpi = 63;
+        si.pioffset = 0;
+    } else {
+        si.nodll = 1;
+        si.maxpi = 15;
+        si.pioffset = 1;
+    }
 }
 
 /// Detect the smallest common timing parameters across all DIMMs.
 ///
 /// Ported from coreboot `sdram_detect_smallest_params()`.
-pub fn detect_smallest_params(si: &mut SysInfo) {
+pub fn detect_smallest_params(si: &mut SysInfo) -> Result<(), ServiceError> {
     // Cycle time in ps for DDR667 and DDR800.
     let mult: [u32; 2] = [3000, 2500];
     let m = mult[si.selected_timings.mem_clock as usize];
@@ -215,6 +264,10 @@ pub fn detect_smallest_params(si: &mut SysInfo) {
     let mut max_trrd: u32 = 0;
     let mut max_trtp: u32 = 0;
 
+    static TRFC_EXTENSION: [u32; 12] = [
+        0, 256_000, 250, 256_250, 333, 256_333, 500, 256_500, 667, 256_667, 750, 256_750,
+    ];
+
     for i in 0..super::TOTAL_DIMMS {
         if !si.dimm_populated(i) {
             continue;
@@ -225,7 +278,12 @@ pub fn detect_smallest_params(si: &mut SysInfo) {
         max_trp = max_trp.max(((spd[27] as u32) * 1000) >> 2);
         max_trcd = max_trcd.max(((spd[29] as u32) * 1000) >> 2);
         max_twr = max_twr.max(((spd[36] as u32) * 1000) >> 2);
-        max_trfc = max_trfc.max((spd[42] as u32) * 1000 + (spd[40] as u32 & 0xF));
+        let trfc_ext = (spd[40] & 0x0f) as usize;
+        let Some(extension) = TRFC_EXTENSION.get(trfc_ext) else {
+            fstart_log::error!("raminit: unsupported DDR2 tRFC extension");
+            return Err(ServiceError::HardwareError);
+        };
+        max_trfc = max_trfc.max((spd[42] as u32) * 1000 + *extension);
         max_twtr = max_twtr.max(((spd[37] as u32) * 1000) >> 2);
         max_trrd = max_trrd.max(((spd[28] as u32) * 1000) >> 2);
         max_trtp = max_trtp.max(((spd[38] as u32) * 1000) >> 2);
@@ -253,6 +311,7 @@ pub fn detect_smallest_params(si: &mut SysInfo) {
         si.selected_timings.trrd,
         si.selected_timings.trtp
     );
+    Ok(())
 }
 
 // ===================================================================
@@ -523,7 +582,7 @@ pub fn sdram_timings(si: &SysInfo, mch: &MchBar) {
                     trp_adj = 1;
                     bank = 0;
                 }
-                if d.page_size == 2048 {
+                if chip_width_code(d.width) + d.cols.saturating_sub(9) > 1 {
                     page = 1;
                 }
             }

--- a/crates/fstart-platform-x86_64/src/lib.rs
+++ b/crates/fstart-platform-x86_64/src/lib.rs
@@ -63,6 +63,7 @@ pub fn disable_boot_media_rom_cache_for_handoff() {
 //
 // Page tables: identity-mapped 2 MiB pages covering 4 GiB.
 // PML4 → 1 PDPT → 4 PDTs → 512 × 2 MiB pages each.
+#[cfg(not(test))]
 core::arch::global_asm!(
     // Use AT&T syntax throughout — matches coreboot convention and is
     // the natural syntax for 16-bit / mixed-mode x86 assembly.
@@ -250,6 +251,7 @@ core::arch::global_asm!(
 // Entry/return convention matches coreboot's no-stack helpers: `%esp` contains
 // the absolute return address. The routine may clobber all general registers.
 #[cfg(feature = "early-ffs-anchor")]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -327,6 +329,7 @@ core::arch::global_asm!(
 );
 
 #[cfg(not(feature = "early-ffs-anchor"))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -340,6 +343,7 @@ core::arch::global_asm!(
 // 1 GiB pages: PDPT[0..511] = 512 x 1 GiB identity-mapped pages.
 // Requires PDPE1GB. Covers 512 GiB. Compact: only 2 pages total.
 #[cfg(all(feature = "x86-writable-page-tables", feature = "x86-1g-pages"))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -376,6 +380,7 @@ core::arch::global_asm!(
 // Writable page-table setup for QEMU-style low-RAM page tables.
 // 2 MiB pages (default): PDPT[0..3] -> PD0..PD3, each PD 512 x 2 MiB.
 #[cfg(all(feature = "x86-writable-page-tables", not(feature = "x86-1g-pages")))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -428,6 +433,7 @@ core::arch::global_asm!(
 // - QEMU/writable-PT boards reserve BSS storage here; `_setup_page_tables`
 //   fills it at runtime.
 #[cfg(not(feature = "x86-writable-page-tables"))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -438,6 +444,7 @@ core::arch::global_asm!(
 );
 
 #[cfg(all(feature = "x86-static-page-tables", feature = "x86-1g-pages"))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .rodata, \"a\"",
     ".balign 4096",
@@ -459,6 +466,7 @@ core::arch::global_asm!(
 );
 
 #[cfg(all(feature = "x86-writable-page-tables", feature = "x86-1g-pages"))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .bss, \"aw\", @nobits",
     ".balign 4096",
@@ -473,6 +481,7 @@ core::arch::global_asm!(
 );
 
 #[cfg(all(feature = "x86-writable-page-tables", not(feature = "x86-1g-pages")))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .bss, \"aw\", @nobits",
     ".balign 4096",
@@ -490,6 +499,7 @@ core::arch::global_asm!(
     feature = "x86-static-page-tables",
     feature = "x86-writable-page-tables"
 )))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .bss, \"aw\", @nobits",
     ".balign 4096",
@@ -503,6 +513,7 @@ core::arch::global_asm!(
 );
 
 #[cfg(all(feature = "x86-static-page-tables", not(feature = "x86-1g-pages")))]
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .rodata, \"a\"",
     ".balign 4096",
@@ -532,6 +543,7 @@ core::arch::global_asm!(
 );
 
 // Continue the entry sequence after page table setup.
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text, \"ax\"",
     ".code32",
@@ -772,6 +784,7 @@ core::arch::global_asm!(
 // place it in CAR-backed BSS, and RAM stages place it in DRAM-backed BSS.
 // The assembly labels are sufficient; the linker script does not need a
 // dedicated IDT output section or linker-provided IDT symbols.
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .bss, \"aw\", @nobits",
     ".align 4096",
@@ -794,6 +807,7 @@ core::arch::global_asm!(
 // Placed in `.text.entry` so `KEEP(*(.text.entry))` in the linker script
 // ensures it's at the start of the binary (= the load address that the
 // bootblock's `jump_to()` targets).
+#[cfg(not(test))]
 core::arch::global_asm!(
     ".section .text.entry, \"ax\"",
     ".code64",


### PR DESCRIPTION
Detect S3 resume boot paths, enable HPET-backed delays, validate
SPD/timing inputs, and fail calibration errors explicitly. Add DDR2
UDIMM Vref margining and refine RCOMP, RCVEN, and tRD programming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot and memory initialization to better handle normal boot, warm reset, and sleep resume cases.
  * Added stricter DDR2 memory validation and calibration, reducing the chance of failed or unstable startup on unsupported modules.
  * Updated timing and delay handling for more reliable memory setup.

* **Tests**
  * Adjusted low-level assembly handling so test builds complete more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->